### PR TITLE
MADLIB-1142. Allow passing REPONAME into Jenkins build/rat scripts.

### DIFF
--- a/tool/jenkins/jenkins_build.sh
+++ b/tool/jenkins/jenkins_build.sh
@@ -19,7 +19,7 @@
 #####################################################################################
 workdir=`pwd`
 user_name=`whoami`
-reponame=incubator-madlib
+reponame=${REPONAME:=madlib}
 
 echo "======================================================================"
 echo "Build user: $user_name"

--- a/tool/jenkins/rat_check.sh
+++ b/tool/jenkins/rat_check.sh
@@ -22,7 +22,7 @@
 set -exu
 
 workdir=`pwd`
-reponame=incubator-madlib
+reponame=${REPONAME:=madlib}
 
 # Check if NOTICE file year is current
 grep "Copyright 2016-$(date +"%Y") The Apache Software Foundation" "${workdir}/${reponame}/NOTICE"


### PR DESCRIPTION
The variable REPONAME will be passed in via the Jenkins project configuration. If not set, it will default to a reponame of "madlib".

This task could not happen until the git repositories have been renamed. Nandish has informed the dev team this has happened.