### PR TITLE
Add a script to start docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ Development with Docker
 =======================
 We provide a Docker image with necessary dependencies required to compile and test MADlib on PostgreSQL 9.6. You can view the dependency Docker file at ./tool/docker/base/Dockerfile_postgres_9_6. The image is hosted on Docker Hub at madlib/postgres_9.6:latest. Later we will provide a similar Docker image for Greenplum Database.
 
-We have a script to quickly run this docker image at ./tool/docker_start.sh, which will mount your local madlib directory, build MADlib and run install check on this Docker image. At the end, it will `docker exec` as postgres user. Note that you have to run this script from one level up from your madlib directory, for example, ~/workspace which has madlib source directory there. 
+We provide a script to quickly run this docker image at ./tool/docker_start.sh, which will mount your local madlib directory, build MADlib and run install check on this Docker image. At the end, it will `docker exec` as postgres user. Note that you have to run this script from inside your madlib directory, and you can specify your docker CONTAINER_NAME (default is madlib) and IMAGE_TAG (default is latest). Here is an example:
 
-To kill this docker container, run `docker kill madlib` and `docker rm madlib`.
+```
+CONTAINER_NAME=my_madlib IMAGE_TAG=LaTex ./tool/docker_start.sh
+```
+
+To kill this docker container, run `docker kill YOUR_CONTAINER_NAME` and `docker rm YOUR_CONTAINER_NAME`.
 
 You can also manually run those commands to do the same thing:
 
@@ -28,8 +32,8 @@ You can also manually run those commands to do the same thing:
 ## 1) Pull down the `madlib/postgres_9.6:latest` image from docker hub:
 docker pull madlib/postgres_9.6:latest
 
-## 2) Launch a container corresponding to the MADlib image, mounting the
-##    source code folder to the container:
+## 2) Launch a container corresponding to the MADlib image, name it
+##    madlib, mounting the source code folder to the container:
 docker run -d -it --name madlib \
     -v (path to madlib directory):/madlib/ madlib/postgres_9.6
 # where madlib is the directory where the MADlib source code resides.
@@ -44,8 +48,8 @@ docker run -d -it --name madlib \
 
 ## 3) When the container is up, connect to it and build MADlib:
 docker exec -it madlib bash
-mkdir /madlib/build-docker
-cd /madlib/build-docker
+mkdir /madlib/build_docker
+cd /madlib/build_docker
 cmake ..
 make
 make doc

--- a/README.md
+++ b/README.md
@@ -23,8 +23,18 @@ We provide a script to quickly run this docker image at ./tool/docker_start.sh, 
 ```
 CONTAINER_NAME=my_madlib IMAGE_TAG=LaTex ./tool/docker_start.sh
 ```
+Notice that this script only needs to be run once. After that, you will have a local docker container with CONTAINER_NAME running. To get access to the container, run the following command and you can keep working on it.
 
-To kill this docker container, run `docker kill YOUR_CONTAINER_NAME` and `docker rm YOUR_CONTAINER_NAME`.
+```
+docker exec -it CONTAINER_NAME bash
+```
+
+To kill this docker container, run:
+
+```
+docker kill CONTAINER_NAME
+docker rm CONTAINER_NAME
+```
 
 You can also manually run those commands to do the same thing:
 
@@ -69,6 +79,16 @@ src/bin/madpack -p postgres -c postgres/postgres@localhost:5432/postgres reinsta
 ## 6) Kill and remove containers (after exiting the container):
 docker kill madlib
 docker rm madlib
+```
+
+Instruction for building design pdf on Docker:
+
+For users who wants to build design pdf, make sure you use the `IMAGE_TAG=LaTex` parameter when running the script. After launching your docker container, run the following to get `design.pdf`:
+
+```
+cd /madlib/build_docker
+make design_pdf
+cd doc/design
 ```
 
 Detailed build instructions are available in [`ReadMe_Build.txt`](ReadMe_Build.txt)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ Development with Docker
 =======================
 We provide a Docker image with necessary dependencies required to compile and test MADlib on PostgreSQL 9.6. You can view the dependency Docker file at ./tool/docker/base/Dockerfile_postgres_9_6. The image is hosted on Docker Hub at madlib/postgres_9.6:latest. Later we will provide a similar Docker image for Greenplum Database.
 
-Some useful commands to use the docker file:
+We have a script to quickly run this docker image at ./tool/docker_start.sh, which will mount your local madlib directory, build MADlib and run install check on this Docker image. At the end, it will `docker exec` as postgres user. Note that you have to run this script from one level up from your madlib directory, for example, ~/workspace which has madlib source directory there. 
+
+To kill this docker container, run `docker kill madlib` and `docker rm madlib`.
+
+You can also manually run those commands to do the same thing:
 
 ```
 ## 1) Pull down the `madlib/postgres_9.6:latest` image from docker hub:

--- a/tool/docker_start.sh
+++ b/tool/docker_start.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#####################################################################################
+#  This is a script that does the following:
+#  * Pull madlib/postgres_9.6:latest from docker;
+#  * Mount your local madlib directory to docker container;
+#  * Build madlib from source;
+#  * Install madlib and run install check;
+#  * Log in to docker container from shell as postgres user, so that you
+#    can run psql and start using madlib from here
+#
+# Note: you have to run this script from one level up from your madlib directory, for
+# example, ~/workspace which has madlib src directory there
+#####################################################################################
+set -o pipefail
+
+workdir=`pwd`
+user_name=`whoami`
+reponame=madlib
+
+echo "======================================================================"
+echo "Build user: $user_name"
+echo "Work directory: $workdir"
+echo "Git reponame: $reponame"
+echo "======================================================================"
+echo "ls -la"
+ls -la
+echo "rm -rf logs"
+rm -rf logs
+echo "mkdir logs"
+mkdir logs
+
+echo "-----------creating docker container madlib--------------------"
+echo "docker kill madlib"
+docker kill madlib-test
+echo "docker rm madlib"
+docker rm madlib-test
+
+# Pull down the base docker images
+echo "Creating docker container"
+docker pull madlib/postgres_9.6:latest
+
+# Launch docker container with volume mounted from workdir
+echo "-------------------------------"
+cat <<EOF
+docker run -d --name madlib-test -v "${workdir}/${reponame}":/madlib madlib/postgres_9.6 | tee logs/docker_setup.log
+EOF
+docker run -d --name madlib-test -v "${workdir}/${reponame}":/madlib madlib/postgres_9.6 | tee logs/docker_setup.log
+echo "-------------------------------"
+
+
+## This sleep is required since it takes a couple of seconds for the docker
+## container to come up, which is required by the docker exec command that follows.
+sleep 5
+
+echo "---------- Building MADlib -----------"
+# cmake, make, make install
+cat <<EOF
+docker exec madlib bash -c 'rm -rf /build; mkdir /build; cd /build; cmake ../madlib; make clean; make; make install' | tee $workdir/logs/madlib_compile.log
+EOF
+docker exec madlib-test bash -c 'rm -rf /build; mkdir /build; cd /build; cmake ../madlib; make clean; make; make install' | tee $workdir/logs/madlib_compile.log
+
+echo "---------- Installing and running install-check --------------------"
+# Install MADlib and run install check
+cat <<EOF
+docker exec madlib bash -c '/build/src/bin/madpack -p postgres -c postgres/postgres@localhost:5432/postgres install' | tee $workdir/logs/madlib_install.log
+EOF
+docker exec madlib-test bash -c '/build/src/bin/madpack -p postgres -c postgres/postgres@localhost:5432/postgres install' | tee $workdir/logs/madlib_install.log
+
+cat <<EOF
+docker exec madlib bash -c 'mkdir -p /tmp'
+docker exec madlib bash -c '/build/src/bin/madpack -p postgres  -c postgres/postgres@localhost:5432/postgres -d /tmp install-check' | tee $workdir/logs/madlib_install_check.log
+EOF
+
+docker exec madlib-test bash -c 'mkdir -p /tmp'
+docker exec madlib-test bash -c '/build/src/bin/madpack -p postgres  -c postgres/postgres@localhost:5432/postgres -d /tmp install-check' | tee $workdir/logs/madlib_install_check.log
+
+# To run psql, you have to login as postgres, not root
+echo "---------- docker exec image as user postgres-----------"
+cat <<EOF
+docker exec -it --user=postgres madlib bash | tee $workdir/logs/docker_exec.log
+EOF
+docker exec --user=postgres -it madlib-test bash | tee $workdir/logs/docker_exec.log

--- a/tool/docker_start.sh
+++ b/tool/docker_start.sh
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-#####################################################################################
+###############################################################################
 #  This is a script that does the following:
 #  * Pull madlib/postgres_9.6:latest from docker;
 #  * Mount your local madlib directory to docker container;
@@ -25,9 +25,9 @@
 #  * Log in to docker container from shell as postgres user, so that you
 #    can run psql and start using madlib from here
 #
-# Note: you have to run this script from one level up from your madlib directory, for
-# example, ~/workspace which has madlib src directory there
-#####################################################################################
+# Note: you have to run this script from one level up from your madlib 
+# directory, for example, ~/workspace which has madlib src directory there
+###############################################################################
 set -o pipefail
 
 workdir=$(pwd)
@@ -35,10 +35,18 @@ user_name=$(whoami)
 reponame=madlib
 
 echo "======================================================================"
-echo "Build user: $user_name"
-echo "Work directory: $workdir"
-echo "Git reponame: $reponame"
+echo "Build user: ${user_name}"
+echo "Work directory: ${workdir}"
+echo "Git reponame: ${reponame}"
 echo "======================================================================"
+
+if [[ ! -d "${workdir}/${reponame}" ]]; then
+  echo "Error: you have to run this script from one level up from your madlib \
+        directory, for example, ~/workspace which has madlib src directory \
+        there"
+  exit
+fi
+
 rm -rf logs
 mkdir logs
 
@@ -51,25 +59,35 @@ echo "Creating docker container"
 docker pull madlib/postgres_9.6:latest
 
 # Launch docker container with volume mounted from workdir
-docker run -d --name madlib -v "${workdir}/${reponame}":/madlib madlib/postgres_9.6 | tee logs/docker_setup.log
+docker run -d --name madlib -v "${workdir}/${reponame}":/madlib \
+ 					madlib/postgres_9.6 | tee logs/docker_setup.log
 
 ## This sleep is required since it takes a couple of seconds for the docker
-## container to come up, which is required by the docker exec command that follows.
+## container to come up, which is required by the docker exec command that 
+## follows.
 sleep 5
 
 echo "---------- Building MADlib -----------"
 # cmake, make, make install
-docker exec madlib bash -c 'rm -rf /build; mkdir /build; cd /build; cmake ../madlib; make; make install' | tee $workdir/logs/madlib_compile.log
+docker exec madlib bash -c "rm -rf /build; mkdir /build; cd /build; cmake \
+							../madlib; make; make install" \
+			| tee "${workdir}/logs/madlib_compile.log"
 
 echo "---------- Installing and running install-check --------------------"
 # Install MADlib and run install check
-docker exec madlib bash -c '/build/src/bin/madpack -p postgres -c postgres/postgres@localhost:5432/postgres install' | tee $workdir/logs/madlib_install.log
+docker exec madlib bash -c "/build/src/bin/madpack -p postgres -c \
+							postgres/postgres@localhost:5432/postgres install" \
+			| tee "${workdir}/logs/madlib_install.log"
 
 docker exec madlib bash -c 'mkdir -p /tmp'
-docker exec madlib bash -c '/build/src/bin/madpack -p postgres  -c postgres/postgres@localhost:5432/postgres -d /tmp install-check' | tee $workdir/logs/madlib_install_check.log
+docker exec madlib bash -c "/build/src/bin/madpack -p postgres  -c \
+							postgres/postgres@localhost:5432/postgres -d \
+							/tmp install-check" \
+			| tee "${workdir}/logs/madlib_install_check.log"
 
 # To run psql, you have to login as postgres, not root
 echo "---------- docker exec image as user postgres-----------"
 docker exec madlib bash -c 'chown -R postgres:postgres /build'
 docker exec madlib bash -c 'chown -R postgres:postgres /madlib'
-docker exec --user=postgres -it madlib bash | tee $workdir/logs/docker_exec.log
+docker exec --user=postgres -it madlib bash \
+		| tee "${workdir}/logs/docker_exec.log"

--- a/tool/docker_start.sh
+++ b/tool/docker_start.sh
@@ -30,8 +30,8 @@
 #####################################################################################
 set -o pipefail
 
-workdir=`pwd`
-user_name=`whoami`
+workdir=$(pwd)
+user_name=$(whoami)
 reponame=madlib
 
 echo "======================================================================"
@@ -39,31 +39,19 @@ echo "Build user: $user_name"
 echo "Work directory: $workdir"
 echo "Git reponame: $reponame"
 echo "======================================================================"
-echo "ls -la"
-ls -la
-echo "rm -rf logs"
 rm -rf logs
-echo "mkdir logs"
 mkdir logs
 
 echo "-----------creating docker container madlib--------------------"
-echo "docker kill madlib"
-docker kill madlib-test
-echo "docker rm madlib"
-docker rm madlib-test
+docker kill madlib
+docker rm madlib
 
 # Pull down the base docker images
 echo "Creating docker container"
 docker pull madlib/postgres_9.6:latest
 
 # Launch docker container with volume mounted from workdir
-echo "-------------------------------"
-cat <<EOF
-docker run -d --name madlib-test -v "${workdir}/${reponame}":/madlib madlib/postgres_9.6 | tee logs/docker_setup.log
-EOF
-docker run -d --name madlib-test -v "${workdir}/${reponame}":/madlib madlib/postgres_9.6 | tee logs/docker_setup.log
-echo "-------------------------------"
-
+docker run -d --name madlib -v "${workdir}/${reponame}":/madlib madlib/postgres_9.6 | tee logs/docker_setup.log
 
 ## This sleep is required since it takes a couple of seconds for the docker
 ## container to come up, which is required by the docker exec command that follows.
@@ -71,29 +59,17 @@ sleep 5
 
 echo "---------- Building MADlib -----------"
 # cmake, make, make install
-cat <<EOF
-docker exec madlib bash -c 'rm -rf /build; mkdir /build; cd /build; cmake ../madlib; make clean; make; make install' | tee $workdir/logs/madlib_compile.log
-EOF
-docker exec madlib-test bash -c 'rm -rf /build; mkdir /build; cd /build; cmake ../madlib; make clean; make; make install' | tee $workdir/logs/madlib_compile.log
+docker exec madlib bash -c 'rm -rf /build; mkdir /build; cd /build; cmake ../madlib; make; make install' | tee $workdir/logs/madlib_compile.log
 
 echo "---------- Installing and running install-check --------------------"
 # Install MADlib and run install check
-cat <<EOF
 docker exec madlib bash -c '/build/src/bin/madpack -p postgres -c postgres/postgres@localhost:5432/postgres install' | tee $workdir/logs/madlib_install.log
-EOF
-docker exec madlib-test bash -c '/build/src/bin/madpack -p postgres -c postgres/postgres@localhost:5432/postgres install' | tee $workdir/logs/madlib_install.log
 
-cat <<EOF
 docker exec madlib bash -c 'mkdir -p /tmp'
 docker exec madlib bash -c '/build/src/bin/madpack -p postgres  -c postgres/postgres@localhost:5432/postgres -d /tmp install-check' | tee $workdir/logs/madlib_install_check.log
-EOF
-
-docker exec madlib-test bash -c 'mkdir -p /tmp'
-docker exec madlib-test bash -c '/build/src/bin/madpack -p postgres  -c postgres/postgres@localhost:5432/postgres -d /tmp install-check' | tee $workdir/logs/madlib_install_check.log
 
 # To run psql, you have to login as postgres, not root
 echo "---------- docker exec image as user postgres-----------"
-cat <<EOF
-docker exec -it --user=postgres madlib bash | tee $workdir/logs/docker_exec.log
-EOF
-docker exec --user=postgres -it madlib-test bash | tee $workdir/logs/docker_exec.log
+docker exec madlib bash -c 'chown -R postgres:postgres /build'
+docker exec madlib bash -c 'chown -R postgres:postgres /madlib'
+docker exec --user=postgres -it madlib bash | tee $workdir/logs/docker_exec.log

--- a/tool/docker_start.sh
+++ b/tool/docker_start.sh
@@ -18,22 +18,24 @@
 
 ###############################################################################
 #  This is a script that does the following:
-#  * Pull madlib/postgres_9.6:latest from docker;
+#  * Pull madlib/postgres_9.6:$IMAGE_TAG(default tag is `latest`) from docker;
 #  * Mount your local madlib directory to docker container;
+#  * Name your docker container as $CONTAINER_NAME (default name is madlib)
 #  * Build madlib from source; build dir is /madlib/build_docker which 
 #    is mounted to your local madlib dir
 #  * Install madlib and run install check;
 #  * Log in to docker container from shell as postgres user, so that you
 #    can run psql and start using madlib from here
 #
-# Note: you have to run this script from one level up from your madlib 
-# directory, for example, ~/workspace which has madlib src directory there
+# Note: you have to run this script inside your local MADlib repo
+# Example command:
+# CONTAINER_NAME=my_madlib IMAGE_TAG=LaTex ./tool/docker_start.sh
 ###############################################################################
 set -o pipefail
 
 workdir=$(pwd)
 user_name=$(whoami)
-reponame="$(basename $(pwd))"
+reponame="$(basename "$(pwd)")"
 
 echo "======================================================================"
 echo "Build user: ${user_name}"
@@ -41,35 +43,28 @@ echo "Work directory: ${workdir}"
 echo "Git reponame: ${reponame}"
 echo "======================================================================"
 
-if [[ -z "${container_name}"]]; then
-	container_name = madlib
+if [[ -z "${CONTAINER_NAME}" ]]; then
+	CONTAINER_NAME=madlib
 fi
 
-if [[ -z "${image_tag}"]]; then
-	image_tag = latest
-fi
-
-if [[ ! -d "${workdir}/${reponame}" ]]; then
-  echo "Error: you have to run this script from one level up from your madlib \
-        directory, for example, ~/workspace which has madlib src directory \
-        there"
-  exit
+if [[ -z "${IMAGE_TAG}" ]]; then
+	IMAGE_TAG=latest
 fi
 
 rm -rf build_docker_logs
 mkdir build_docker_logs
 
 echo "-----------creating docker container madlib--------------------"
-docker kill "${container_name}"
-docker rm "${container_name}"
+docker kill "${CONTAINER_NAME}"
+docker rm "${CONTAINER_NAME}"
 
 # Pull down the base docker images
 echo "Creating docker container"
-docker pull madlib/postgres_9.6:"${image_tag}"
+docker pull madlib/postgres_9.6:"${IMAGE_TAG}"
 
 # Launch docker container with volume mounted from workdir
-docker run -d --name "${container_name}" -v "${workdir}":/"${reponame}" \
- 					madlib/postgres_9.6 | tee build_docker_logs/docker_setup.log
+docker run -d --name "${CONTAINER_NAME}" -v "${workdir}":/madlib \
+					madlib/postgres_9.6:"${IMAGE_TAG}" | tee build_docker_logs/docker_setup.log
 
 ## This sleep is required since it takes a couple of seconds for the docker
 ## container to come up, which is required by the docker exec command that 
@@ -80,27 +75,29 @@ echo "---------- Building MADlib -----------"
 # cmake, make, make install
 # The build folder is /madlib/build_docker, which is mounted to your local
 # madlib repo
-docker exec "${container_name}" bash -c "rm -rf /madlib/build_docker; \
+docker exec "${CONTAINER_NAME}" bash -c "rm -rf /madlib/build_docker; \
 							mkdir /madlib/build_docker; \
 							cd /madlib/build_docker; \
-							cmake ..; make; make install" \
+							cmake ..; make; make doc; make install" \
 			| tee "${workdir}/build_docker_logs/madlib_compile.log"
 
 echo "---------- Installing and running install-check --------------------"
 # Install MADlib and run install check
-docker exec "${container_name}" bash -c "/madlib/build_docker/src/bin/madpack -p postgres \
+docker exec "${CONTAINER_NAME}" bash -c "/madlib/build_docker/src/bin/madpack -p postgres \
 							 -c postgres/postgres@localhost:5432/postgres \
 							 install" \
 			| tee "${workdir}/build_docker_logs/madlib_install.log"
 
-docker exec "${container_name}" bash -c "/madlib/build_docker/src/bin/madpack -p postgres \
+docker exec "${CONTAINER_NAME}" bash -c "/madlib/build_docker/src/bin/madpack -p postgres \
 							-c postgres/postgres@localhost:5432/postgres \
 							install-check" \
 			| tee "${workdir}/build_docker_logs/madlib_install_check.log"
 
 # To run psql, you have to login as postgres, not root
 echo "---------- docker exec image as user postgres-----------"
-docker exec "${container_name}" bash -c 'chown -R postgres:postgres /madlib/build_docker'
-docker exec "${container_name}" bash -c 'chown -R postgres:postgres /madlib'
-docker exec --user=postgres -it "${container_name}" bash \
+docker exec "${CONTAINER_NAME}" bash -c 'chown -R postgres:postgres /madlib/build_docker'
+docker exec "${CONTAINER_NAME}" bash -c 'chown -R postgres:postgres /madlib'
+docker exec "${CONTAINER_NAME}" bash -c 'mkdir /home/postgres'
+docker exec "${CONTAINER_NAME}" bash -c 'chown -R postgres:postgres /home/postgres'
+docker exec --user=postgres -it "${CONTAINER_NAME}" bash \
 		| tee "${workdir}/build_docker_logs/docker_exec.log"


### PR DESCRIPTION
This is a script that does the following:
* Pull madlib/postgres_9.6:latest from docker;
* Mount your local madlib directory to docker container;
* Build madlib from source;
* Install madlib and run install check;
* Log into docker container from shell as postgres user, so that you
  can run psql and start using madlib from here