### PR TITLE
MADLIB-1154. PostgreSQL 10 (beta 4) support.

### DIFF
--- a/methods/kmeans/src/pg_gp/kmeans.c
+++ b/methods/kmeans/src/pg_gp/kmeans.c
@@ -1,6 +1,10 @@
 #include <postgres.h>
 #include <nodes/memnodes.h>
+#if PG_VERSION_NUM >= 100000
+#include <utils/regproc.h>
+#else
 #include <utils/builtins.h>
+#endif
 #include <utils/memutils.h>
 #include <math.h>
 #include "../../../svec/src/pg_gp/sparse_vector.h"

--- a/methods/sketch/src/pg_gp/sketch_support.c
+++ b/methods/sketch/src/pg_gp/sketch_support.c
@@ -42,7 +42,11 @@
 #include <nodes/execnodes.h>
 #include <fmgr.h>
 #include <utils/builtins.h>
+#if PG_VERSION_NUM >= 100000
+#include <common/md5.h>
+#else
 #include <libpq/md5.h>
+#endif
 #include <utils/lsyscache.h>
 #include "sketch_support.h"
 

--- a/methods/svec/src/pg_gp/SparseData.c
+++ b/methods/svec/src/pg_gp/SparseData.c
@@ -19,6 +19,9 @@
 #include <float.h>
 #include "SparseData.h"
 #include "utils/builtins.h"
+#if PG_VERSION_NUM >= 100000
+#include "utils/varlena.h"
+#endif
 #include "utils/syscache.h"
 #include "parser/parse_func.h"
 #include "access/htup.h"

--- a/methods/utils/src/pg_gp/exec_sql_using.c
+++ b/methods/utils/src/pg_gp/exec_sql_using.c
@@ -4,6 +4,9 @@
 #include <catalog/pg_proc.h>
 #include <catalog/pg_type.h>
 #include <utils/builtins.h>
+#if PG_VERSION_NUM >= 100000
+#include <utils/regproc.h>
+#endif
 #include <utils/datum.h>
 #include <utils/lsyscache.h>
 #include <utils/syscache.h>

--- a/src/ports/postgres/10.0/CMakeLists.txt
+++ b/src/ports/postgres/10.0/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ------------------------------------------------------------------------------
+
+add_current_postgresql_version()
+add_extension_support()

--- a/src/ports/postgres/cmake/FindPostgreSQL_10_0.cmake
+++ b/src/ports/postgres/cmake/FindPostgreSQL_10_0.cmake
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ------------------------------------------------------------------------------
+
+set(_FIND_PACKAGE_FILE "${CMAKE_CURRENT_LIST_FILE}")
+include("${CMAKE_CURRENT_LIST_DIR}/FindPostgreSQL.cmake")

--- a/src/ports/postgres/dbconnector/dbconnector.hpp
+++ b/src/ports/postgres/dbconnector/dbconnector.hpp
@@ -31,6 +31,9 @@ extern "C" {
     #include <utils/acl.h>
     #include <utils/array.h>
     #include <utils/builtins.h>    // needed for format_procedure()
+#if PG_VERSION_NUM >= 100000
+    #include <utils/regproc.h>     // needed for format_procedure() - PostgreSQL 10
+#endif
     #include <utils/datum.h>
     #include <utils/lsyscache.h>   // for type lookup, e.g., type_is_rowtype
     #include <utils/memutils.h>

--- a/src/ports/postgres/modules/utilities/utilities.py_in
+++ b/src/ports/postgres/modules/utilities/utilities.py_in
@@ -369,7 +369,7 @@ class __mad_version:
         return False
 
     def is_less_than_pg90(self):
-        regex = re.compile('PostgreSQL\s*([0-9])([0-9.]+)', re.IGNORECASE)
+        regex = re.compile('PostgreSQL\s*([0-9]+)([0-9.beta]+)', re.IGNORECASE)
         version = regex.findall(self.version)
         if len(version) > 0 and self.is_pg() and int(version[0][0]) < 9:
             return True


### PR DESCRIPTION
**Postgres 10 header file movement**

  Move some things from builtins.h to new header files
  https://github.com/postgres/postgres/commit/f21a563d25dbae153937aec062161184189478b8

  o format_procedure has moved into utils/regproc.h (from
    utils/builtins.h)

  o Functions for the variable-length built-in types moved into
    utils/varlena.h (from utils/builtins.h)

**libpq/md5.h has moved to common/md5.h**

  Postgres 10 change
  Move code shared between libpq and backend from backend/libpq/ to common/.
  https://github.com/postgres/postgres/commit/ec136d19b21791c845b1deeff43df137add0639e

**Convert sketch to Version 1 Calling Conventions.**

**Update "is_less_than_pg90" to accommodate "10beta" version.**

**PlEASE NOTE** The Postgres Beta string is non-standard and I have been able to account for it in "is_less_than_pg90". There are other checks when installing madlib and running install-check that fail and it fallbacks to using the newest supported version. Here is the message received:

> Could not parse version string reported by PostgreSQL. Will default to newest supported version of PostgreSQL (10.0).

For reference, this is the "select_version()" output for Postgres 10 beta4:

```
psql -c "select version()"
                                                    version                                                     
----------------------------------------------------------------------------------------------------------------
 PostgreSQL 10beta4 on x86_64-apple-darwin16.7.0, compiled by Apple LLVM version 8.1.0 (clang-802.0.42), 64-bit
(1 row)

```
I have successfully built and run install/install-check against PostgreSQL 9.6 and 10beta4.
