### PR TITLE
Add error message for checking postgres install configuration

### DIFF
--- a/src/madpack/madpack.py
+++ b/src/madpack/madpack.py
@@ -513,8 +513,8 @@ def _plpy_check(py_min_ver):
             _internal_run_query("CREATE LANGUAGE plpythonu;", True)
         except:
             _error("""Cannot create language plpythonu. Please check if you
-                have configured and installed postgres with `--with-python`
-                option. Stopping installation...""", False)
+                have configured and installed portid (your platform) with
+                `--with-python` option. Stopping installation...""", False)
             raise Exception
 
     # Check PL/Python version

--- a/src/madpack/madpack.py
+++ b/src/madpack/madpack.py
@@ -512,7 +512,9 @@ def _plpy_check(py_min_ver):
         try:
             _internal_run_query("CREATE LANGUAGE plpythonu;", True)
         except:
-            _error('Cannot create language plpythonu. Stopping installation...', False)
+            _error("""Cannot create language plpythonu. Please check if you
+                have configured and installed postgres with `--with-python`
+                option. Stopping installation...""", False)
             raise Exception
 
     # Check PL/Python version


### PR DESCRIPTION
MADlib needs to be installed on a postgres with python extension. If
postgres is not configured with the `--with-python` option, madpack
installation will failed for not finding $libdir/plpython2 directory.
This commit add some instructions when this failure happens.