### PR TITLE
Bugfix: Hard coded schema name in WCC install check

### DIFF
--- a/src/ports/postgres/modules/graph/test/wcc.sql_in
+++ b/src/ports/postgres/modules/graph/test/wcc.sql_in
@@ -117,7 +117,7 @@ SELECT assert(relative_error(count(distinct component_id), 3) < 0.00001,
 
 -- Test WCC helper functions:
 DROP TABLE IF EXISTS largest_cpt_table;
-SELECT madlib.graph_wcc_largest_cpt(
+SELECT graph_wcc_largest_cpt(
      'wcc_out',             -- WCC's output table
      'largest_cpt_table');  -- output table
 SELECT assert(relative_error(num_vertices, 6) < 0.00001,
@@ -125,7 +125,7 @@ SELECT assert(relative_error(num_vertices, 6) < 0.00001,
     ) FROM largest_cpt_table WHERE user_id=2;
 
 DROP TABLE IF EXISTS histogram_table;
-SELECT madlib.graph_wcc_histogram(
+SELECT graph_wcc_histogram(
      'wcc_out',           -- WCC's output table
      'histogram_table');  -- output table
 SELECT assert(relative_error(num_vertices, 4) < 0.00001,
@@ -133,7 +133,7 @@ SELECT assert(relative_error(num_vertices, 4) < 0.00001,
     ) FROM histogram_table WHERE user_id=1 and component_id=10;
 
 DROP TABLE IF EXISTS vc_table;
-SELECT madlib.graph_wcc_vertex_check(
+SELECT graph_wcc_vertex_check(
      'wcc_out',    -- WCC's output table
      '14,15',      -- Pair of vertex IDs
      'vc_table');  -- output table
@@ -142,7 +142,7 @@ SELECT assert(relative_error(component_id, 14) < 0.00001,
     ) FROM vc_table WHERE user_id=1;
 
 DROP TABLE IF EXISTS reach_table;
-SELECT madlib.graph_wcc_reachable_vertices(
+SELECT graph_wcc_reachable_vertices(
      'wcc_out',         -- WCC's output table
      '0',               -- source vertex
      'reach_table');    -- output table
@@ -151,7 +151,7 @@ SELECT assert(relative_error(count(dest), 5) < 0.00001,
     ) FROM reach_table WHERE user_id=2 and component_id=0;
 
 DROP TABLE IF EXISTS count_table;
-SELECT madlib.graph_wcc_num_cpts(
+SELECT graph_wcc_num_cpts(
      'wcc_out',       -- WCC's output table
      'count_table');  -- output table
 SELECT assert(relative_error(num_components, 3) < 0.00001,


### PR DESCRIPTION
JIRA: MADLIB-1177

WCC install check sql file had madlib hard coded as the schema name.
This commit removes the schema name altogether, since install-check
anyway sets the schema name in the search path at the beginning.

Closes #199