### PR TITLE
Allow array feature with more than 1664 entries

### DIFF
--- a/src/ports/postgres/modules/recursive_partitioning/decision_tree.py_in
+++ b/src/ports/postgres/modules/recursive_partitioning/decision_tree.py_in
@@ -2425,87 +2425,42 @@ def _tree_train_grps_using_bins(
 # ------------------------------------------------------------
 
 
-def _tree_rmse(schema_madlib, source_table, dependent_varname, prediction_table,
-               pred_dep_name, id_col_name, grouping_cols, output_table,
-               use_existing_tables=False, k=0, **kwargs):
-    old_messages = plpy.execute("SELECT setting FROM pg_settings "
-                                "WHERE name = 'client_min_messages'")[0]['setting']
-    plpy.execute('SET client_min_messages TO warning')
-
-    fold = ", " + str(k) + " as k"
-    if use_existing_tables and table_exists(output_table):
-        # plpy.execute("truncate " + output_table)
-        header = "INSERT INTO " + output_table + " "
-    else:
-        header = "CREATE TABLE " + output_table + " AS "
-
-    grouping_str = '' if not grouping_cols else "GROUP BY " + grouping_cols
-    grouping_col_str = "" if not grouping_cols else grouping_cols + ','
-
-    sql = header + """
-        SELECT
-            {grouping_col_str}
-            sqrt(avg(
-                    ({prediction_table}.{pred_dep_name} -
-                     {source_table}.{dependent_varname})^2
+def _tree_error(schema_madlib, source_table, dependent_varname,
+                prediction_table, pred_dep_name, id_col_name, grouping_cols,
+                output_table, is_classification,
+                use_existing_tables=False, k=0, **kwargs):
+    with MinWarning("warning"):
+        if use_existing_tables and table_exists(output_table):
+            # plpy.execute("truncate " + output_table)
+            header = "INSERT INTO " + output_table + " "
+        else:
+            header = "CREATE TABLE " + output_table + " AS "
+        if is_classification:
+            error_func = """
+                1.0 * sum(CASE WHEN ({prediction_table}.{pred_dep_name} =
+                                     {source_table}.{dependent_varname})
+                               THEN 0
+                               ELSE 1
+                          END) / count(*)
+                """.format(**locals())
+        else:
+            error_func = """
+                sqrt(avg(({prediction_table}.{pred_dep_name} -
+                          {source_table}.{dependent_varname})^2
+                        )
                     )
-                ) as cv_error
-            {fold}
-        FROM {prediction_table}, {source_table}
-        WHERE {prediction_table}.{id_col_name} = {source_table}.{id_col_name}
-        {grouping_str}
-        """.format(output_table=output_table,
-                   prediction_table=prediction_table,
-                   pred_dep_name=pred_dep_name,
-                   source_table=source_table,
-                   dependent_varname=dependent_varname,
-                   grouping_col_str=grouping_col_str,
-                   grouping_str=grouping_str,
-                   id_col_name=id_col_name,
-                   fold=fold)
-    plpy.execute(sql)
-    plpy.execute('SET client_min_messages TO ' + old_messages)
+                """.format(**locals())
+        grouping_str = '' if not grouping_cols else "GROUP BY " + grouping_cols
+        grouping_col_str = '' if not grouping_cols else grouping_cols + ','
+
+        sql = header + """
+            SELECT
+                {grouping_col_str}
+                {error_func} as cv_error,
+                {k} as k
+            FROM {prediction_table}, {source_table}
+            WHERE {prediction_table}.{id_col_name} = {source_table}.{id_col_name}
+            {grouping_str}
+            """.format(**locals())
+        plpy.execute(sql)
 # ------------------------------------------------------------
-
-
-def _tree_misclassified(schema_madlib, source_table, dependent_varname,
-                        prediction_table, pred_dep_name, id_col_name,
-                        grouping_cols, output_table, use_existing_tables=False,
-                        k=0, **kwargs):
-    old_messages = plpy.execute(
-        "SELECT setting FROM pg_settings WHERE name = 'client_min_messages'")[0]['setting']
-    plpy.execute('SET client_min_messages TO warning')
-
-    fold = ", " + str(k) + " as k"
-    if use_existing_tables and table_exists(output_table):
-        # plpy.execute("truncate " + output_table)
-        header = "INSERT INTO " + output_table + " "
-    else:
-        header = "CREATE TABLE " + output_table + " AS "
-
-    grouping_str = '' if not grouping_cols else "GROUP BY " + grouping_cols
-    grouping_col_str = "" if not grouping_cols else grouping_cols + ','
-
-    sql = header + """
-        SELECT
-            {grouping_col_str}
-            1.0 * sum(CASE WHEN ({prediction_table}.{pred_dep_name} =
-                           {source_table}.{dependent_varname})
-                THEN 0 ELSE 1 END) / count(*) as cv_error
-            {fold}
-        FROM
-            {prediction_table}, {source_table}
-        WHERE
-          {prediction_table}.{id_col_name} = {source_table}.{id_col_name}
-        {grouping_str}
-        """.format(output_table=output_table,
-                   prediction_table=prediction_table,
-                   pred_dep_name=pred_dep_name,
-                   source_table=source_table,
-                   dependent_varname=dependent_varname,
-                   grouping_col_str=grouping_col_str,
-                   grouping_str=grouping_str,
-                   id_col_name=id_col_name,
-                   fold=fold)
-    plpy.execute(sql)
-    plpy.execute('SET client_min_messages TO ' + old_messages)

--- a/src/ports/postgres/modules/recursive_partitioning/decision_tree.py_in
+++ b/src/ports/postgres/modules/recursive_partitioning/decision_tree.py_in
@@ -186,167 +186,6 @@ def _classify_features(feature_to_type, features):
 # ------------------------------------------------------------
 
 
-def tree_train_help_message(schema_madlib, message, **kwargs):
-    """ Help message for Decision Tree
-    """
-    if not message:
-        help_string = """
-------------------------------------------------------------
-                        SUMMARY
-------------------------------------------------------------
-Functionality: Decision Tree
-
-Decision trees use a tree-based predictive model to
-predict the value of a target variable based on several input variables.
-
-For more details on the function usage:
-    SELECT {schema_madlib}.tree_train('usage');
-For an example on using this function:
-    SELECT {schema_madlib}.tree_train('example');
-        """
-    elif message.lower().strip() in ['usage', 'help', '?']:
-        help_string = """
-------------------------------------------------------------
-                        USAGE
-------------------------------------------------------------
-SELECT {schema_madlib}.tree_train(
-    'training_table',       -- Data table name
-    'output_table',         -- Table name to store the tree model
-    'id_col_name',          -- Row ID, used in tree_predict
-    'dependent_variable',   -- The column to fit
-    'list_of_features',     -- Comma separated column names to be
-                                used as the predictors, can be '*'
-                                to include all columns except the
-                                dependent_variable
-    'features_to_exclude',  -- Comma separated column names to be
-                                excluded if list_of_features is '*'
-    'split_criterion',      -- How to split a node, options are
-                                'gini', 'misclassification' and
-                                'entropy' for classification, and
-                                'mse' for regression.
-    'grouping_cols',        -- Comma separated column names used to
-                                group the data. A decision tree model
-                                will be created for each group. Default
-                                is NULL
-    'weights',              -- A Column name containing weights for
-                                each observation. Default is NULL
-    max_depth,              -- Maximum depth of any node, default is 7
-    min_split,              -- Minimum number of observations that must
-                                exist in a node for a split to be
-                                attemped, default is 20
-    min_bucket,             -- Minimum number of observations in any
-                                terminal node, default is min_split/3
-    n_bins,                 -- Number of bins to find possible node
-                                split threshold values for continuous
-                                variables, default is 20 (Must be greater than 1)
-    pruning_params,         -- A comma-separated text containing
-                                key=value pairs of parameters for pruning.
-                                Parameters accepted:
-                                    'cp' - complexity parameter with default=0.01,
-                                    'n_folds' - number of cross-validation folds
-                                        with default value of 0 (= no cross-validation)
-    null_handling_params,   -- A comma-separated text containing
-                                key=value pairs of parameters for handling NULL values.
-                                Parameters accepted:
-                                    'max_surrogates' - Maximum number of surrogates to
-                                        compute for each split
-                                    'null_as_category' - Boolean to indicate if
-                                        NULL should be treated as a special category
-    verbose                 -- Boolean, whether to print more info, default is False
-);
-
-------------------------------------------------------------
-                        OUTPUT
-------------------------------------------------------------
-The output table ('output_table' above) has the following columns (quoted items
-are of type TEXT):
-    <grouping columns>      -- Grouping columns, only present when
-                                'grouping_cols' is not NULL or ''
-    tree                    -- The decision tree model as a binary string
-    cat_levels_in_text      -- Distinct levels (casted to text) of all
-                                categorical variables combined in a single array
-    cat_n_levels            -- Number of distinct levels of all categorical variables
-    tree_depth              -- Number of levels in the tree (root has level 0)
-    pruning_cp              -- The cost-complexity parameter used for pruning
-                                the trained tree(s). This would be different
-                                from the input cp value if cross-validation is used.
-
-The output summary table ('output_table_summary') has the following columns:
-    'method'                -- Method name: 'tree_train'
-    'source_table'          -- Data table name
-    'model_table'           -- Tree model table name
-    'id_col_name'           -- Name of the 'id' column
-    is_classification       -- Boolean value indicating if tree is classification or regression
-    'dependent_varname'     -- Response variable column name
-    'independent_varnames'  -- Comma-separated feature column names
-    'cat_features'          -- Comma-separated column names of categorical variables
-    'con_features'          -- Comma-separated column names of continuous variables
-    'grouping_cols'         -- Grouping column names
-    num_all_groups          -- Number of groups
-    num_failed_groups       -- Number of groups for which training failed
-    total_rows_processed    -- Number of rows used in the model training
-    total_rows_skipped      -- Number of rows skipped because NULL values
-    dependent_var_levels    -- For classification, the distinct levels of
-                                the dependent variable
-    dependent_var_type      -- The type of dependent variable
-    input_cp                -- The complexity parameter (cp) used for pruning the
-                                 trained tree(s) (before cross-validation is run)
-    independent_var_types   -- The types of independent variables, comma-separated
-    k                       -- Number of folds (NULL if not using cross validation)
-    null_proxy              -- String used as replacement for NULL values
-                                (NULL if null_as_category = False)
-
-        """
-    elif message.lower().strip() in ['example', 'examples']:
-        help_string = """
-------------------------------------------------------------
-                        EXAMPLE
-------------------------------------------------------------
-DROP TABLE IF EXISTS dummy_dt_con_src CASCADE;
-CREATE TABLE dummy_dt_con_src (
-    id  INTEGER,
-    cat INTEGER[],
-    con FLOAT8[],
-    y   FLOAT8
-);
-
-INSERT INTO dummy_dt_src VALUES
-(1, '{{0}}'::INTEGER[], ARRAY[0], 0.5),
-(2, '{{0}}'::INTEGER[], ARRAY[1], 0.5),
-(3, '{{0}}'::INTEGER[], ARRAY[4], 0.5),
-(4, '{{0}}'::INTEGER[], ARRAY[4], 0.5),
-(5, '{{0}}'::INTEGER[], ARRAY[4], 0.5),
-(6, '{{0}}'::INTEGER[], ARRAY[5], 0.1),
-(7, '{{0}}'::INTEGER[], ARRAY[6], 0.1),
-(8, '{{1}}'::INTEGER[], ARRAY[9], 0.1);
-(9, '{{1}}'::INTEGER[], ARRAY[9], 0.1);
-(10, '{{1}}'::INTEGER[], ARRAY[9], 0.1);
-(11, '{{1}}'::INTEGER[], ARRAY[9], 0.1);
-
-DROP TABLE IF EXISTS tree_out, tree_out_summary;
-SELECT madlib.tree_train(
-    'dummy_dt_src',
-    'tree_out',
-    'id',
-    'y',
-    'cat, con',
-    '',
-    'mse',
-    NULL::Text,
-    NULL::Text,
-    3,
-    2,
-    1,
-    5);
-
-SELECT madlib.tree_display('tree_out');
-        """
-    else:
-        help_string = "No such option. Use {schema_madlib}.tree_train('usage')"
-    return help_string.format(schema_madlib=schema_madlib)
-# ------------------------------------------------------------
-
-
 def _extract_pruning_params(pruning_params_str):
     """
     Args:
@@ -507,7 +346,7 @@ def get_grouping_array_str(table_name, grouping_cols, qualifier=None):
 # So it has some specific code for cv.
 def _build_tree(schema_madlib, is_classification, split_criterion,
                 training_table_name, output_table_name, id_col_name,
-                dependent_variable, dep_is_bool,
+                dependent_variable, dep_is_bool, list_of_features,
                 cat_features, ordered_cat_features,
                 boolean_cats, con_features, grouping_cols,
                 weights, max_depth, min_split, min_bucket, n_bins,
@@ -660,7 +499,7 @@ def tree_train(schema_madlib, training_table_name, output_table_name,
 def _create_output_tables(schema_madlib, training_table_name, output_table_name,
                           tree_states, bins,
                           split_criterion, cat_features, con_features,
-                          id_col_name, dependent_variable,
+                          id_col_name, dependent_variable, list_of_features,
                           is_classification, n_all_rows, n_rows, dep_list, cp,
                           all_cols_types, grouping_cols=None,
                           use_existing_tables=False, running_cv=False, k=0,
@@ -680,7 +519,8 @@ def _create_output_tables(schema_madlib, training_table_name, output_table_name,
     _create_summary_table(
         schema_madlib, split_criterion, training_table_name,
         output_table_name, id_col_name, cat_features, con_features,
-        dependent_variable, failed_groups, is_classification, n_all_rows,
+        dependent_variable, list_of_features,
+        failed_groups, is_classification, n_all_rows,
         n_rows, dep_list, all_cols_types, cp, grouping_cols, 1,
         use_existing_tables, running_cv, k, null_proxy)
 # -------------------------------------------------------------------------
@@ -1597,13 +1437,12 @@ def _get_dep_type(data_table, dep):
 def _create_summary_table(
         schema_madlib, split_criterion,
         training_table_name, output_table_name, id_col_name,
-        cat_features, con_features, dependent_variable,
+        cat_features, con_features, dependent_variable, list_of_features,
         num_failed_groups, is_classification, n_all_rows, n_rows,
         dep_list, all_cols_types, cp, grouping_cols=None, n_groups=1,
         use_existing_tables=False, running_cv=False, k=0, null_proxy=None):
 
     # dependent variables
-    features = ', '.join(cat_features + con_features)
     if dep_list:
         dep_list_str = ("$dep_list$" +
                         ','.join('"{0}"'.format(str(dep)) for dep in dep_list) +
@@ -1641,7 +1480,7 @@ def _create_summary_table(
                 '{output_table_name}'::text    AS model_table,
                 '{id_col_name}'::text          AS id_col_name,
                 '{dependent_variable}'::text   AS dependent_varname,
-                '{features}'::text             AS independent_varnames,
+                '{list_of_features}'::text     AS independent_varnames,
                 '{cat_features_str}'::text     AS cat_features,
                 '{con_features_str}'::text     AS con_features,
                 {grouping_cols_str}::text      AS grouping_cols,
@@ -1745,12 +1584,12 @@ def tree_predict(schema_madlib, model, source, output, pred_type='response',
     # obtain the cat_features and con_features from model table
     summary_elements = plpy.execute("SELECT * FROM {0}".format(model_summary))[0]
 
+    list_of_features = split_quoted_delimited_str(summary_elements["independent_varnames"])
     cat_features = split_quoted_delimited_str(summary_elements["cat_features"])
     con_features = split_quoted_delimited_str(summary_elements["con_features"])
-    _assert(
-        is_var_valid(source, ','.join(cat_features + con_features)),
-        "Decision tree error: Missing columns in predict data table ({0}) "
-        "that were used during training".format(source))
+    _assert(is_var_valid(source, ','.join(list_of_features)),
+            "Decision tree error: Missing columns in predict data table ({0}) "
+            "that were used during training".format(source))
     id_col_name = summary_elements["id_col_name"]
     grouping_cols_str = summary_elements.get("grouping_cols")  # optional, default = None
     dep_varname = summary_elements["dependent_varname"]
@@ -1977,77 +1816,6 @@ def tree_display(schema_madlib, model_table, dot_format=True, verbose=False,
         return_str_list.append("} //---end of digraph--------- ")
     return ("\n".join(return_str_list))
 # -------------------------------------------------------------------------
-
-
-def tree_predict_help_message(schema_madlib, message, **kwargs):
-    """ Help message for Decision Tree predict
-    """
-    if not message:
-        help_string = """
-------------------------------------------------------------
-                        SUMMARY
-------------------------------------------------------------
-Functionality: Decision Tree Prediction
-
-Prediction for a decision tree (trained using {schema_madlib}.tree_train) can
-be performed on a new data table.
-
-For more details on the function usage:
-    SELECT {schema_madlib}.tree_predict('usage');
-For an example on using this function:
-    SELECT {schema_madlib}.tree_predict('example');
-        """
-    elif message.lower().strip() in ['usage', 'help', '?']:
-        help_string = """
-------------------------------------------------------------
-                        USAGE
-------------------------------------------------------------
-SELECT {schema_madlib}.tree_predict(
-    'tree_model',           -- Model table name (output of tree_train)
-    'new_data_table',       -- Prediction source table
-    'output_table',         -- Table name to store the predictions
-    'type'                  -- Type of prediction output
-);
-
-Note: The 'new_data_table' should have the same 'id_col_name' column as used
-in the training function. This is used to corelate the prediction data row with
-the actual prediction in the output table.
-
-------------------------------------------------------------
-                        OUTPUT
-------------------------------------------------------------
-The output table ('output_table' above) has the '<id_col_name>' column giving
-the 'id' for each prediction and the prediction columns for the response
-variable (also called as dependent variable).
-
-If prediction type = 'response', then the table has a single column with the
-prediction value of the response. The type of this column depends on the type
-of the response variable used during training.
-
-If prediction type = 'prob', then the table has multiple columns, one for each
-possible value of the response variable. The columns are labeled as
-'estimated_prob_<dep value>', where <dep value> represents for each value
-of the response.
-        """
-    elif message.lower().strip() in ['example', 'examples']:
-        help_string = """
-------------------------------------------------------------
-                        EXAMPLE
-------------------------------------------------------------
--- Assuming the example of tree_train() has been run
-SELECT {schema_madlib}.tree_predict(
-    'tree_out',
-    'dummy_dt_src',
-    'tree_predict_out',
-    'response'
-);
-
-SELECT * FROM tree_predict_out;
-        """
-    else:
-        help_string = "No such option. Use {schema_madlib}.tree_predict('usage')"
-    return help_string.format(schema_madlib=schema_madlib)
-# ------------------------------------------------------------
 
 
 def _prune_and_cplist(schema_madlib, tree, cp, compute_cp_list=False):
@@ -2298,6 +2066,7 @@ def _get_xvalidate_params(**kwargs):
                        quoted_args['id_col_name'],
                        quoted_args['dependent_variable'],
                        quoted_args['dep_is_bool'],
+                       quoted_args['list_of_features'],
                        all_feature_str[0],
                        all_feature_str[1],
                        all_feature_str[2],
@@ -2305,14 +2074,18 @@ def _get_xvalidate_params(**kwargs):
                        quoted_args['grouping_str'],
                        quoted_args['weights'],
                        quoted_args['max_depth'],
-                       quoted_args['min_split'], quoted_args['min_bucket'], quoted_args['n_bins'],
-                       "%explore%", quoted_args['max_n_surr'], quoted_args['msg_level']
+                       quoted_args['min_split'],
+                       quoted_args['min_bucket'],
+                       quoted_args['n_bins'],
+                       "%explore%",
+                       quoted_args['max_n_surr'],
+                       quoted_args['msg_level']
                        ]
-    modeling_param_types = (["BOOLEAN"] + ["TEXT"] * 5 + ["BOOLEAN"] +
+    modeling_param_types = (["BOOLEAN"] + ["TEXT"] * 5 + ["BOOLEAN"] + ["TEXT"] +
                             ["VARCHAR[]"] * 4 + ["TEXT"] * 2 + ["INTEGER"] * 4 +
                             ["TEXT", "SMALLINT", "TEXT"])
     predict_params = ["%model%", "%data%", "%prediction%", "'response'", "True"]
-    predict_param_types = ["VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "BOOLEAN"]
+    predict_param_types = (["VARCHAR"] * 4 + ["BOOLEAN"])
     metric_params = ["%data%",
                      quoted_args['dependent_variable'],
                      "%prediction%",
@@ -2321,7 +2094,8 @@ def _get_xvalidate_params(**kwargs):
                      quoted_args['grouping_cols'],
                      "%error%",
                      "True"]
-    metric_param_types = ["VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "TEXT", "VARCHAR", "BOOLEAN"]
+    metric_param_types = ["VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR",
+                          "VARCHAR", "TEXT", "VARCHAR", "BOOLEAN"]
     return [modeling_params, modeling_param_types,
             predict_params, predict_param_types,
             metric_params, metric_param_types]
@@ -2368,11 +2142,13 @@ def _tree_train_using_bins(
 
 
 def _tree_train_grps_using_bins(
-        schema_madlib, bins, training_table_name, cat_features, con_features,
-        boolean_cats, n_bins, weights, grouping_cols, grouping_array_str, dep_var_str,
-        min_split, min_bucket, max_depth, filter_dep, dep_n_levels,
-        is_classification, split_criterion, subsample=False,
-        n_random_features=1, tree_terminated=None, max_n_surr=0, null_proxy=None,
+        schema_madlib, bins, training_table_name,
+        cat_features, con_features, boolean_cats, n_bins, weights,
+        grouping_cols, grouping_array_str,
+        dep_var_str, min_split, min_bucket, max_depth, filter_dep,
+        dep_n_levels, is_classification, split_criterion,
+        subsample=False, n_random_features=1, tree_terminated=None,
+        max_n_surr=0, null_proxy=None,
         **kwargs):
 
     """Trains a tree with grouping columns included """
@@ -2463,4 +2239,236 @@ def _tree_error(schema_madlib, source_table, dependent_varname,
             {grouping_str}
             """.format(**locals())
         plpy.execute(sql)
+# ------------------------------------------------------------
+
+
+def tree_train_help_message(schema_madlib, message, **kwargs):
+    """ Help message for Decision Tree
+    """
+    if not message:
+        help_string = """
+------------------------------------------------------------
+                        SUMMARY
+------------------------------------------------------------
+Functionality: Decision Tree
+
+Decision trees use a tree-based predictive model to
+predict the value of a target variable based on several input variables.
+
+For more details on the function usage:
+    SELECT {schema_madlib}.tree_train('usage');
+For an example on using this function:
+    SELECT {schema_madlib}.tree_train('example');
+        """
+    elif message.lower().strip() in ['usage', 'help', '?']:
+        help_string = """
+------------------------------------------------------------
+                        USAGE
+------------------------------------------------------------
+SELECT {schema_madlib}.tree_train(
+    'training_table',       -- Data table name
+    'output_table',         -- Table name to store the tree model
+    'id_col_name',          -- Row ID, used in tree_predict
+    'dependent_variable',   -- The column to fit
+    'list_of_features',     -- Comma separated column names to be
+                                used as the predictors, can be '*'
+                                to include all columns except the
+                                dependent_variable
+    'features_to_exclude',  -- Comma separated column names to be
+                                excluded if list_of_features is '*'
+    'split_criterion',      -- How to split a node, options are
+                                'gini', 'misclassification' and
+                                'entropy' for classification, and
+                                'mse' for regression.
+    'grouping_cols',        -- Comma separated column names used to
+                                group the data. A decision tree model
+                                will be created for each group. Default
+                                is NULL
+    'weights',              -- A Column name containing weights for
+                                each observation. Default is NULL
+    max_depth,              -- Maximum depth of any node, default is 7
+    min_split,              -- Minimum number of observations that must
+                                exist in a node for a split to be
+                                attemped, default is 20
+    min_bucket,             -- Minimum number of observations in any
+                                terminal node, default is min_split/3
+    n_bins,                 -- Number of bins to find possible node
+                                split threshold values for continuous
+                                variables, default is 20 (Must be greater than 1)
+    pruning_params,         -- A comma-separated text containing
+                                key=value pairs of parameters for pruning.
+                                Parameters accepted:
+                                    'cp' - complexity parameter with default=0.01,
+                                    'n_folds' - number of cross-validation folds
+                                        with default value of 0 (= no cross-validation)
+    null_handling_params,   -- A comma-separated text containing
+                                key=value pairs of parameters for handling NULL values.
+                                Parameters accepted:
+                                    'max_surrogates' - Maximum number of surrogates to
+                                        compute for each split
+                                    'null_as_category' - Boolean to indicate if
+                                        NULL should be treated as a special category
+    verbose                 -- Boolean, whether to print more info, default is False
+);
+
+------------------------------------------------------------
+                        OUTPUT
+------------------------------------------------------------
+The output table ('output_table' above) has the following columns (quoted items
+are of type TEXT):
+    <grouping columns>      -- Grouping columns, only present when
+                                'grouping_cols' is not NULL or ''
+    tree                    -- The decision tree model as a binary string
+    cat_levels_in_text      -- Distinct levels (casted to text) of all
+                                categorical variables combined in a single array
+    cat_n_levels            -- Number of distinct levels of all categorical variables
+    tree_depth              -- Number of levels in the tree (root has level 0)
+    pruning_cp              -- The cost-complexity parameter used for pruning
+                                the trained tree(s). This would be different
+                                from the input cp value if cross-validation is used.
+
+The output summary table ('output_table_summary') has the following columns:
+    'method'                -- Method name: 'tree_train'
+    'source_table'          -- Data table name
+    'model_table'           -- Tree model table name
+    'id_col_name'           -- Name of the 'id' column
+    is_classification       -- Boolean value indicating if tree is classification or regression
+    'dependent_varname'     -- Response variable column name
+    'independent_varnames'  -- Comma-separated feature column names
+    'cat_features'          -- Comma-separated column names of categorical variables
+    'con_features'          -- Comma-separated column names of continuous variables
+    'grouping_cols'         -- Grouping column names
+    num_all_groups          -- Number of groups
+    num_failed_groups       -- Number of groups for which training failed
+    total_rows_processed    -- Number of rows used in the model training
+    total_rows_skipped      -- Number of rows skipped because NULL values
+    dependent_var_levels    -- For classification, the distinct levels of
+                                the dependent variable
+    dependent_var_type      -- The type of dependent variable
+    input_cp                -- The complexity parameter (cp) used for pruning the
+                                 trained tree(s) (before cross-validation is run)
+    independent_var_types   -- The types of independent variables, comma-separated
+    k                       -- Number of folds (NULL if not using cross validation)
+    null_proxy              -- String used as replacement for NULL values
+                                (NULL if null_as_category = False)
+
+        """
+    elif message.lower().strip() in ['example', 'examples']:
+        help_string = """
+------------------------------------------------------------
+                        EXAMPLE
+------------------------------------------------------------
+DROP TABLE IF EXISTS dummy_dt_con_src CASCADE;
+CREATE TABLE dummy_dt_con_src (
+    id  INTEGER,
+    cat INTEGER[],
+    con FLOAT8[],
+    y   FLOAT8
+);
+
+INSERT INTO dummy_dt_src VALUES
+(1, '{{0}}'::INTEGER[], ARRAY[0], 0.5),
+(2, '{{0}}'::INTEGER[], ARRAY[1], 0.5),
+(3, '{{0}}'::INTEGER[], ARRAY[4], 0.5),
+(4, '{{0}}'::INTEGER[], ARRAY[4], 0.5),
+(5, '{{0}}'::INTEGER[], ARRAY[4], 0.5),
+(6, '{{0}}'::INTEGER[], ARRAY[5], 0.1),
+(7, '{{0}}'::INTEGER[], ARRAY[6], 0.1),
+(8, '{{1}}'::INTEGER[], ARRAY[9], 0.1);
+(9, '{{1}}'::INTEGER[], ARRAY[9], 0.1);
+(10, '{{1}}'::INTEGER[], ARRAY[9], 0.1);
+(11, '{{1}}'::INTEGER[], ARRAY[9], 0.1);
+
+DROP TABLE IF EXISTS tree_out, tree_out_summary;
+SELECT madlib.tree_train(
+    'dummy_dt_src',
+    'tree_out',
+    'id',
+    'y',
+    'cat, con',
+    '',
+    'mse',
+    NULL::Text,
+    NULL::Text,
+    3,
+    2,
+    1,
+    5);
+
+SELECT madlib.tree_display('tree_out');
+        """
+    else:
+        help_string = "No such option. Use {schema_madlib}.tree_train('usage')"
+    return help_string.format(schema_madlib=schema_madlib)
+# ------------------------------------------------------------
+
+
+def tree_predict_help_message(schema_madlib, message, **kwargs):
+    """ Help message for Decision Tree predict
+    """
+    if not message:
+        help_string = """
+------------------------------------------------------------
+                        SUMMARY
+------------------------------------------------------------
+Functionality: Decision Tree Prediction
+
+Prediction for a decision tree (trained using {schema_madlib}.tree_train) can
+be performed on a new data table.
+
+For more details on the function usage:
+    SELECT {schema_madlib}.tree_predict('usage');
+For an example on using this function:
+    SELECT {schema_madlib}.tree_predict('example');
+        """
+    elif message.lower().strip() in ['usage', 'help', '?']:
+        help_string = """
+------------------------------------------------------------
+                        USAGE
+------------------------------------------------------------
+SELECT {schema_madlib}.tree_predict(
+    'tree_model',           -- Model table name (output of tree_train)
+    'new_data_table',       -- Prediction source table
+    'output_table',         -- Table name to store the predictions
+    'type'                  -- Type of prediction output
+);
+
+Note: The 'new_data_table' should have the same 'id_col_name' column as used
+in the training function. This is used to corelate the prediction data row with
+the actual prediction in the output table.
+
+------------------------------------------------------------
+                        OUTPUT
+------------------------------------------------------------
+The output table ('output_table' above) has the '<id_col_name>' column giving
+the 'id' for each prediction and the prediction columns for the response
+variable (also called as dependent variable).
+
+If prediction type = 'response', then the table has a single column with the
+prediction value of the response. The type of this column depends on the type
+of the response variable used during training.
+
+If prediction type = 'prob', then the table has multiple columns, one for each
+possible value of the response variable. The columns are labeled as
+'estimated_prob_<dep value>', where <dep value> represents for each value
+of the response.
+        """
+    elif message.lower().strip() in ['example', 'examples']:
+        help_string = """
+------------------------------------------------------------
+                        EXAMPLE
+------------------------------------------------------------
+-- Assuming the example of tree_train() has been run
+SELECT {schema_madlib}.tree_predict(
+    'tree_out',
+    'dummy_dt_src',
+    'tree_predict_out',
+    'response'
+);
+
+SELECT * FROM tree_predict_out;
+        """
+    else:
+        help_string = "No such option. Use {schema_madlib}.tree_predict('usage')"
+    return help_string.format(schema_madlib=schema_madlib)
 # ------------------------------------------------------------

--- a/src/ports/postgres/modules/recursive_partitioning/decision_tree.sql_in
+++ b/src/ports/postgres/modules/recursive_partitioning/decision_tree.sql_in
@@ -1947,7 +1947,11 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA._tree_rmse(
     grouping_cols          TEXT,
     output_table           VARCHAR
 ) RETURNS VOID AS $$
-    PythonFunction(recursive_partitioning, decision_tree, _tree_rmse)
+    PythonFunctionBodyOnly(recursive_partitioning, decision_tree)
+    decision_tree._tree_error(
+        schema_madlib, source_table, dependent_varname,
+        prediction_table, pred_dep_name, id_col_name, grouping_cols,
+        output_table, False)
 $$ LANGUAGE plpythonu VOLATILE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -1962,7 +1966,11 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA._tree_rmse(
     use_existing_tables    BOOLEAN,
     k                      INTEGER
 ) RETURNS VOID AS $$
-    PythonFunction(recursive_partitioning, decision_tree, _tree_rmse)
+    PythonFunctionBodyOnly(recursive_partitioning, decision_tree)
+    decision_tree._tree_error(
+        schema_madlib, source_table, dependent_varname,
+        prediction_table, pred_dep_name, id_col_name, grouping_cols,
+        output_table, False, use_existing_tables, k)
 $$ LANGUAGE plpythonu VOLATILE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 -------------------------------------------------------------------------
@@ -1977,7 +1985,11 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA._tree_misclassified(
     grouping_cols          TEXT,
     output_table           VARCHAR
 ) RETURNS VOID AS $$
-    PythonFunction(recursive_partitioning, decision_tree, _tree_misclassified)
+    PythonFunctionBodyOnly(recursive_partitioning, decision_tree)
+    decision_tree._tree_error(
+        schema_madlib, source_table, dependent_varname,
+        prediction_table, pred_dep_name, id_col_name, grouping_cols,
+        output_table, True)
 $$ LANGUAGE plpythonu VOLATILE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -1992,6 +2004,10 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA._tree_misclassified(
     use_existing_tables    BOOLEAN,
     k                      INTEGER
 ) RETURNS VOID AS $$
-    PythonFunction(recursive_partitioning, decision_tree, _tree_misclassified)
+    PythonFunctionBodyOnly(recursive_partitioning, decision_tree)
+    decision_tree._tree_error(
+        schema_madlib, source_table, dependent_varname,
+        prediction_table, pred_dep_name, id_col_name, grouping_cols,
+        output_table, True, use_existing_tables, k)
 $$ LANGUAGE plpythonu VOLATILE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');

--- a/src/ports/postgres/modules/recursive_partitioning/decision_tree.sql_in
+++ b/src/ports/postgres/modules/recursive_partitioning/decision_tree.sql_in
@@ -1114,6 +1114,7 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__build_tree(
     id_col_name           TEXT,
     dependent_variable    TEXT,
     dep_is_bool           BOOLEAN,
+    list_of_features      TEXT,
     cat_features          VARCHAR[],
     ordered_cat_features  VARCHAR[],
     boolean_cats          VARCHAR[],

--- a/src/ports/postgres/modules/recursive_partitioning/test/decision_tree.sql_in
+++ b/src/ports/postgres/modules/recursive_partitioning/test/decision_tree.sql_in
@@ -382,6 +382,7 @@ select __build_tree(
     'id',
     'temperature::double precision',
     FALSE,
+    '"OUTLOOK"',
     ARRAY['"OUTLOOK"']::text[],
     '{}',
     '{}',
@@ -404,3 +405,30 @@ select tree_display('train_output', FALSE);
 \x on
 select * from train_output;
 select * from train_output_summary;
+
+-------------------------------------------------------------------------
+CREATE TABLE array_test AS
+SELECT i as id, array_fill(array_of_float(2000), random() * i) as feat, i as dep
+FROM generate_series(1, 10) as i;
+
+
+-- no grouping, cross-validation
+DROP TABLE IF EXISTS train_output, train_output_summary, train_output_cv, predict_output;
+SELECT tree_train('array_test'::text,         -- source table
+                  'train_output'::text,    -- output model table
+                  'id'::text,              -- id column
+                  'dep::double precision'::text,           -- response
+                  'feat'::text,   -- features
+                  NULL::text,        -- exclude columns
+                  'mse'::text,      -- split criterion
+                  NULL::text,        -- no grouping
+                  NULL::text,        -- no weights
+                  2::integer,     -- max depth
+                  6::integer,        -- min split
+                  2::integer,        -- min bucket
+                  8::integer        -- number of bins per continuous variable
+              );
+SELECT * FROM train_output_summary;
+SELECT _print_decision_tree(tree) FROM train_output;
+SELECT tree_display('train_output', False);
+SELECT tree_predict('train_output', 'array_test', 'predict_output');

--- a/src/ports/postgres/modules/utilities/validate_args.py_in
+++ b/src/ports/postgres/modules/utilities/validate_args.py_in
@@ -546,7 +546,7 @@ def _tbl_dimension_rownum(schema_madlib, tbl_source, col_ind_var):
                      SELECT array_upper({col_ind_var},1) AS dimension
                      FROM {tbl_source} LIMIT 1
                  """.format(tbl_source=tbl_source,
-                        col_ind_var=col_ind_var))[0]["dimension"]
+                            col_ind_var=col_ind_var))[0]["dimension"]
     # total row number of data source table
     # The WHERE clause here ignores rows in the table that contain one or more
     # NULLs in the independent variable (x). There is no NULL check made for
@@ -561,6 +561,7 @@ def _tbl_dimension_rownum(schema_madlib, tbl_source, col_ind_var):
 
     return (dimension, row_num)
 # ------------------------------------------------------------------------
+
 
 def is_var_valid(tbl, var, order_by=None):
     """
@@ -578,7 +579,8 @@ def is_var_valid(tbl, var, order_by=None):
             {order_by_str}
             LIMIT 0
             """.format(**locals()))
-    except Exception:
+    except Exception as e:
+        plpy.warning(str(e))
         return False
     return True
 # -------------------------------------------------------------------------


### PR DESCRIPTION
JIRA: MADLIB-1173

The tree_predict function concatenates cat_feature_str and
con_feature_str in summary table to obtain the feature string. This
contains individual elements of any array feature. The concatenated
string is used in a SELECT operation for validation, which limits the
number of target entries to 1664. To allow arrays with more than 1664
entries, the validation has been udpated to use the original feature
string, which contains the array feature name instead of its indexed
elements.

Closes #201