### PR TITLE
Multiple: Add casting to allow compilation in GCC 6+

### DIFF
--- a/methods/kmeans/src/pg_gp/kmeans.c
+++ b/methods/kmeans/src/pg_gp/kmeans.c
@@ -92,8 +92,8 @@ compute_metric(PGFunction inMetricFn, MemoryContext inMemContext, Datum inVec1,
     /* PostgreSQL does not have the allBytesAlloc and allBytesFreed fields */
     MemoryContextReset(inMemContext);
 #endif
-    
-    MemoryContextSwitchTo(oldContext);    
+
+    MemoryContextSwitchTo(oldContext);
     return distance;
 }
 
@@ -117,19 +117,19 @@ internal_get_array_of_close_canopies(PG_FUNCTION_ARGS)
     int             num_all_canopies;
     float8          threshold;
     PGFunction      metric_fn;
-    
+
     ArrayType      *close_canopies_arr;
     int32          *close_canopies;
     int             num_close_canopies;
     size_t          bytes;
     MemoryContext   mem_context_for_function_calls;
-    
+
     svec = PG_GETARG_SVECTYPE_P(verify_arg_nonnull(fcinfo, 0));
     get_svec_array_elms(PG_GETARG_ARRAYTYPE_P(verify_arg_nonnull(fcinfo, 1)),
         &all_canopies, &num_all_canopies);
     threshold = PG_GETARG_FLOAT8(verify_arg_nonnull(fcinfo, 2));
     metric_fn = get_metric_fn(PG_GETARG_INT32(verify_arg_nonnull(fcinfo, 3)));
-    
+
     mem_context_for_function_calls = setup_mem_context_for_functional_calls();
     close_canopies = (int32 *) palloc(sizeof(int32) * num_all_canopies);
     num_close_canopies = 0;
@@ -164,9 +164,9 @@ static float8 calc_l2norm_distance(float8* array1, float8* array2, int32 dimensi
 {
     if( array1 == NULL || array2 == NULL )
     {
-        elog(ERROR, "In %s, arrays should not be NULL", __FUNCTION__);
+        elog(ERROR, "In %s, arrays should not be NULL", __func__);
     }
-    
+
     float8 distance =0;
     for(int index=0; index<dimension; index++)
     {
@@ -182,9 +182,9 @@ static float8 calc_l1norm_distance(float8* array1, float8* array2, int32 dimensi
 {
     if( array1 == NULL || array2 == NULL )
     {
-        elog(ERROR, "In %s, arrays should not be NULL", __FUNCTION__);
+        elog(ERROR, "In %s, arrays should not be NULL", __func__);
     }
-    
+
     float8 distance =0;
     for(int index=0; index<dimension; index++)
     {
@@ -219,20 +219,20 @@ static float8 calc_cosine_distance(float8* array1, float8* array2, int32 dimensi
 {
     if( array1 == NULL || array2 == NULL )
     {
-        elog(ERROR, "In %s, arrays should not be NULL", __FUNCTION__);
+        elog(ERROR, "In %s, arrays should not be NULL", __func__);
     }
-    
+
     float8 dot_product = calc_dot_product(array1, array2, dimension);
     float8 array1_l2norm = calc_l2norm_val(array1, dimension);
     float8 array2_l2norm = calc_l2norm_val(array2, dimension);
 
     float8 distance = dot_product/(array1_l2norm*array2_l2norm);
 
-    if (distance > 1.0) 
+    if (distance > 1.0)
     {
         distance = 1.0;
     }
-    else if (distance < -1.0) 
+    else if (distance < -1.0)
     {
         distance = -1.0;
     }
@@ -245,22 +245,22 @@ static float8 calc_tanimoto_distance(float8* array1, float8* array2, int32 dimen
 {
     if( array1 == NULL || array2 == NULL )
     {
-        elog(ERROR, "In %s, arrays should not be NULL", __FUNCTION__);
+        elog(ERROR, "In %s, arrays should not be NULL", __func__);
     }
-    
+
     float8 dot_product = calc_dot_product(array1, array2, dimension);
     float8 array1_l2norm = calc_l2norm_val(array1, dimension);
     float8 array2_l2norm = calc_l2norm_val(array2, dimension);
-    
+
     float8 denominator = array1_l2norm*array1_l2norm+
         array2_l2norm*array2_l2norm-dot_product;
     float8 distance = dot_product/denominator;
 
-    if (distance > 1.0) 
+    if (distance > 1.0)
     {
         distance = 1.0;
     }
-    else if (distance < 0) 
+    else if (distance < 0)
     {
         distance = 0;
     }
@@ -280,7 +280,7 @@ get_metric_fn_for_array(KMeansMetric inMetric)
             calc_cosine_distance,
             calc_tanimoto_distance
         };
-    
+
     if (inMetric < 1 || inMetric > sizeof(metrics)/sizeof(PGFunction)) {
         ereport(ERROR,
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -307,18 +307,18 @@ internal_kmeans_closest_centroid(PG_FUNCTION_ARGS) {
     float8* c_centroids_array = (float8 *)ARR_DATA_PTR(centroids_array);
 
     int dimension = PG_GETARG_INT32(verify_arg_nonnull(fcinfo, 2));
-    int num_of_centroids = PG_GETARG_INT32(verify_arg_nonnull(fcinfo, 3)); 
+    int num_of_centroids = PG_GETARG_INT32(verify_arg_nonnull(fcinfo, 3));
     int centroids_array_len = num_of_centroids*dimension;
-    int dist_metric = PG_GETARG_INT32(verify_arg_nonnull(fcinfo, 4)); 
+    int dist_metric = PG_GETARG_INT32(verify_arg_nonnull(fcinfo, 4));
 
     ArrayType      *canopy_ids_arr = NULL;
     int32          *canopy_ids = NULL;
     bool            indirect;
-    if (PG_ARGISNULL(5)) 
+    if (PG_ARGISNULL(5))
     {
         indirect = false;
-    } 
-    else 
+    }
+    else
     {
         indirect = true;
         canopy_ids_arr = PG_GETARG_ARRAYTYPE_P(5);
@@ -336,7 +336,7 @@ internal_kmeans_closest_centroid(PG_FUNCTION_ARGS) {
         ereport(ERROR,
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                  errmsg("function \"%s\", Invalid dimension:%d",
-                    format_procedure(fcinfo->flinfo->fn_oid), 
+                    format_procedure(fcinfo->flinfo->fn_oid),
                     dimension)));
     }
 
@@ -345,7 +345,7 @@ internal_kmeans_closest_centroid(PG_FUNCTION_ARGS) {
         ereport(ERROR,
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                  errmsg("function \"%s\", Invalid num_of_centroids:%d",
-                    format_procedure(fcinfo->flinfo->fn_oid), 
+                    format_procedure(fcinfo->flinfo->fn_oid),
                     num_of_centroids)));
     }
 
@@ -359,7 +359,7 @@ internal_kmeans_closest_centroid(PG_FUNCTION_ARGS) {
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                  errmsg("function \"%s\", Invalid point array length. "
                     "Expected: %d, Actual:%d",
-                    format_procedure(fcinfo->flinfo->fn_oid), 
+                    format_procedure(fcinfo->flinfo->fn_oid),
                     dimension, array_length)));
     }
 
@@ -373,15 +373,15 @@ internal_kmeans_closest_centroid(PG_FUNCTION_ARGS) {
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                  errmsg("function \"%s\", Invalid centroids array length. "
                     "Expected: %d, Actual:%d",
-                    format_procedure(fcinfo->flinfo->fn_oid), 
+                    format_procedure(fcinfo->flinfo->fn_oid),
                     centroids_array_len, array_length)));
     }
 
-    for (int i = 0; i< num_of_centroids; i++) 
+    for (int i = 0; i< num_of_centroids; i++)
     {
         cid = indirect ? canopy_ids[i] - ARR_LBOUND(canopy_ids_arr)[0] : i;
 	    double * centroid = c_centroids_array+cid*dimension;
-        
+
         MetricFunc func = get_metric_fn_for_array(dist_metric);
         distance = (*func)(centroid, c_point_array, dimension);
 
@@ -390,7 +390,7 @@ internal_kmeans_closest_centroid(PG_FUNCTION_ARGS) {
             min_distance = distance;
         }
     }
-    
+
     PG_RETURN_INT32(closest_centroid+ARR_LBOUND(centroids_array)[0]);
 }
 
@@ -405,7 +405,7 @@ internal_kmeans_agg_centroid_trans(PG_FUNCTION_ARGS) {
     int32           centroid_index;
     bool            rebuild_array = false;
     int32           expected_array_len;
-    
+
     float8          *c_array = NULL;
     cent_array = PG_GETARG_ARRAYTYPE_P(verify_arg_nonnull(fcinfo, 1));
 
@@ -417,14 +417,14 @@ internal_kmeans_agg_centroid_trans(PG_FUNCTION_ARGS) {
     dimension = PG_GETARG_INT32(verify_arg_nonnull(fcinfo, 2));
     num_of_centroids = PG_GETARG_INT32(verify_arg_nonnull(fcinfo, 3));
     centroid_index = PG_GETARG_INT32(verify_arg_nonnull(fcinfo, 4));
-    
+
     expected_array_len = num_of_centroids*dimension;
     if (dimension < 1)
     {
         ereport(ERROR,
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                  errmsg("function \"%s\", Invalid dimension:%d",
-                    format_procedure(fcinfo->flinfo->fn_oid), 
+                    format_procedure(fcinfo->flinfo->fn_oid),
                     dimension)));
     }
 
@@ -434,7 +434,7 @@ internal_kmeans_agg_centroid_trans(PG_FUNCTION_ARGS) {
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                  errmsg("function \"%s\", Inconsistent Dimension. "
                      "Expected:%d, Actual:%d",
-                    format_procedure(fcinfo->flinfo->fn_oid), 
+                    format_procedure(fcinfo->flinfo->fn_oid),
                     dimension, array_length)));
 
     }
@@ -444,7 +444,7 @@ internal_kmeans_agg_centroid_trans(PG_FUNCTION_ARGS) {
         ereport(ERROR,
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                  errmsg("function \"%s\", Invalid num_of_centroids:%d",
-                    format_procedure(fcinfo->flinfo->fn_oid), 
+                    format_procedure(fcinfo->flinfo->fn_oid),
                     num_of_centroids)));
     }
 
@@ -453,7 +453,7 @@ internal_kmeans_agg_centroid_trans(PG_FUNCTION_ARGS) {
         ereport(ERROR,
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                  errmsg("function \"%s\", Invalid centroid_index:%d",
-                    format_procedure(fcinfo->flinfo->fn_oid), 
+                    format_procedure(fcinfo->flinfo->fn_oid),
                     centroid_index)));
     }
 
@@ -467,8 +467,8 @@ internal_kmeans_agg_centroid_trans(PG_FUNCTION_ARGS) {
         if (fcinfo->context && IsA(fcinfo->context, AggState))
             array = PG_GETARG_ARRAYTYPE_P(0);
         else
-            array = PG_GETARG_ARRAYTYPE_P_COPY(0);        
-        
+            array = PG_GETARG_ARRAYTYPE_P_COPY(0);
+
         array_dim = ARR_NDIM(array);
         p_array_dim = ARR_DIMS(array);
         array_length = ArrayGetNItems(array_dim, p_array_dim);
@@ -479,19 +479,19 @@ internal_kmeans_agg_centroid_trans(PG_FUNCTION_ARGS) {
                     (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                      errmsg("function \"%s\", Invalid array length. "
                         "Expected: %d, Actual:%d",
-                        format_procedure(fcinfo->flinfo->fn_oid), 
+                        format_procedure(fcinfo->flinfo->fn_oid),
                         expected_array_len, array_length)));
         }
         c_array = (float8 *)ARR_DATA_PTR(array);
     }
-    
-    
+
+
     float8 * data_ptr = c_array+(centroid_index-1)*dimension;
     for(int index=0; index<dimension; index++)
     {
         data_ptr[index] = c_cent_array[index];
     }
-    
+
     if (rebuild_array)
     {
         /* construct a new array to keep the aggr states. */
@@ -514,12 +514,12 @@ Datum
 internal_kmeans_agg_centroid_merge(PG_FUNCTION_ARGS) {
     /* This function is declared as strict. No checking null here. */
     ArrayType       *array = NULL;
-    ArrayType       *array2 = NULL;    
+    ArrayType       *array2 = NULL;
     if (fcinfo->context && IsA(fcinfo->context, AggState))
         array = PG_GETARG_ARRAYTYPE_P(0);
     else
-        array = PG_GETARG_ARRAYTYPE_P_COPY(0);        
-    
+        array = PG_GETARG_ARRAYTYPE_P_COPY(0);
+
     int array_dim = ARR_NDIM(array);
     int *p_array_dim = ARR_DIMS(array);
     int array_length = ArrayGetNItems(array_dim, p_array_dim);
@@ -535,7 +535,7 @@ internal_kmeans_agg_centroid_merge(PG_FUNCTION_ARGS) {
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                  errmsg("function \"%s\", Inconsistent array length. "
                     "first: %d, second:%d",
-                    format_procedure(fcinfo->flinfo->fn_oid), 
+                    format_procedure(fcinfo->flinfo->fn_oid),
                     array_length, array2_length)));
     }
 
@@ -561,13 +561,13 @@ internal_kmeans_canopy_transition(PG_FUNCTION_ARGS) {
     float8          threshold;
 
     MemoryContext   mem_context_for_function_calls;
-    
+
     canopies_arr = PG_GETARG_ARRAYTYPE_P(verify_arg_nonnull(fcinfo, 0));
     get_svec_array_elms(canopies_arr, &canopies, &num_canopies);
     point = PG_GETARG_SVECTYPE_P(verify_arg_nonnull(fcinfo, 1));
     metric_fn = get_metric_fn(PG_GETARG_INT32(verify_arg_nonnull(fcinfo, 2)));
     threshold = PG_GETARG_FLOAT8(verify_arg_nonnull(fcinfo, 3));
-    
+
     mem_context_for_function_calls = setup_mem_context_for_functional_calls();
     for (int i = 0; i < num_canopies; i++) {
         if (compute_metric(metric_fn, mem_context_for_function_calls,
@@ -575,7 +575,7 @@ internal_kmeans_canopy_transition(PG_FUNCTION_ARGS) {
             PG_RETURN_ARRAYTYPE_P(canopies_arr);
     }
     MemoryContextDelete(mem_context_for_function_calls);
-    
+
     int idx = (ARR_NDIM(canopies_arr) == 0)
         ? 1
         : ARR_LBOUND(canopies_arr)[0] + ARR_DIMS(canopies_arr)[0];
@@ -601,7 +601,7 @@ internal_remove_close_canopies(PG_FUNCTION_ARGS) {
     int             num_all_canopies;
     PGFunction      metric_fn;
     float8          threshold;
-    
+
     Datum          *close_canopies;
     int             num_close_canopies;
     bool            addIndexI;
@@ -611,7 +611,7 @@ internal_remove_close_canopies(PG_FUNCTION_ARGS) {
     get_svec_array_elms(all_canopies_arr, &all_canopies, &num_all_canopies);
     metric_fn = get_metric_fn(PG_GETARG_INT32(verify_arg_nonnull(fcinfo, 1)));
     threshold = PG_GETARG_FLOAT8(verify_arg_nonnull(fcinfo, 2));
-    
+
     mem_context_for_function_calls = setup_mem_context_for_functional_calls();
     close_canopies = (Datum *) palloc(sizeof(Datum) * num_all_canopies);
     num_close_canopies = 0;
@@ -620,7 +620,7 @@ internal_remove_close_canopies(PG_FUNCTION_ARGS) {
         for (int j = 0; j < num_close_canopies; j++) {
             if (compute_metric(metric_fn, mem_context_for_function_calls,
                 all_canopies[i], close_canopies[j]) < threshold) {
-                
+
                 addIndexI = false;
                 break;
             }
@@ -629,7 +629,7 @@ internal_remove_close_canopies(PG_FUNCTION_ARGS) {
             close_canopies[num_close_canopies++] = all_canopies[i];
     }
     MemoryContextDelete(mem_context_for_function_calls);
-    
+
     PG_RETURN_ARRAYTYPE_P(
         construct_array(
             close_canopies, /* elems */

--- a/methods/sketch/src/pg_gp/countmin.c
+++ b/methods/sketch/src/pg_gp/countmin.c
@@ -178,17 +178,6 @@ Datum countmin_trans_c(countmin sketch, Datum dat, Oid outFuncOid, Oid typOid)
 static const char _base64[] =
 "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-static const int8 b64lookup[128] = {
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63,
-    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1,
-    -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
-    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1,
-    -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1,
-};
-
 static unsigned
 b64_encode(const char *src, unsigned len, char *dst)
 {

--- a/src/modules/elastic_net/elastic_net_optimizer_igd.hpp
+++ b/src/modules/elastic_net/elastic_net_optimizer_igd.hpp
@@ -66,7 +66,7 @@ AnyType Igd<Model>::igd_transition (AnyType& args, const Allocator& inAllocator)
             state.ymean = args[10].getAs<double>();
             // dual vector theta
             state.theta.setZero();
-            state.p = 2 * log(state.dimension);
+            state.p = 2 * log(double(state.dimension));
             state.lambda = lambda;
             state.q = state.p / (state.p - 1);
             link_fn(state.theta, state.coef, state.p);

--- a/src/modules/lda/lda.cpp
+++ b/src/modules/lda/lda.cpp
@@ -184,7 +184,8 @@ AnyType lda_gibbs_sample::run(AnyType & args)
     int32_t voc_size = args[6].getAs<int32_t>();
     int32_t topic_num = args[7].getAs<int32_t>();
     int32_t iter_num = args[8].getAs<int32_t>();
-    size_t model64_size = static_cast<size_t>(voc_size * (topic_num + 1) + 1) * sizeof(int32_t) / sizeof(int64_t);
+    size_t model64_size =
+        static_cast<size_t>(voc_size * (topic_num + 1) + 1) * sizeof(int32_t) / sizeof(int64_t);
 
     if(alpha <= 0)
         throw std::invalid_argument("invalid argument - alpha");
@@ -621,9 +622,9 @@ AnyType lda_perplexity_sfunc::run(AnyType & args){
         }
 
         state =  madlib_construct_array(NULL,
-                                        static_cast<int>(model64.size())
-                                            + topic_num
-                                            + sizeof(double) / sizeof(int64_t),
+                                        static_cast<int>(model64.size()) +
+                                            topic_num +
+                                            static_cast<int>(sizeof(double) / sizeof(int64_t)),
                                         INT8TI.oid,
                                         INT8TI.len,
                                         INT8TI.byval,

--- a/src/modules/recursive_partitioning/DT_impl.hpp
+++ b/src/modules/recursive_partitioning/DT_impl.hpp
@@ -127,7 +127,7 @@ DecisionTree<Container>::bind(ByteStream_type& inStream) {
     size_t n_labels = 0;
     size_t max_surrogates = 0;
     if (!tree_depth.isNull()) {
-        n_nodes = static_cast<size_t>(pow(2, tree_depth) - 1);
+        n_nodes = static_cast<size_t>(pow(2.0, tree_depth) - 1);
         // for classification n_labels = n_y_labels + 1 since the last element
         // is the count of actual (unweighted) tuples landing on a node
         // for regression, n_y_labels is same as REGRESS_N_STATS
@@ -173,7 +173,7 @@ inline
 DecisionTree<Container>&
 DecisionTree<Container>::incrementInPlace() {
     // back up current tree
-    size_t n_orig_nodes = static_cast<size_t>(pow(2, tree_depth) - 1);
+    size_t n_orig_nodes = static_cast<size_t>(pow(2.0, tree_depth) - 1);
     DecisionTree<Container> orig = DecisionTree<Container>();
     orig.rebind(tree_depth, n_y_labels, max_n_surr, is_regression);
     orig.copy(*this);
@@ -712,7 +712,7 @@ DecisionTree<Container>::pickSurrogates(
             Index surr_count = 0;
             for(Index j=0; j < max_size; j++){
                 Index curr_surr = sorted_surr_indices(j);
-                if (all_counts(curr_surr) < getMajorityCount(curr_node)){
+                if (all_counts(curr_surr) < double(getMajorityCount(curr_node))){
                     break;
                 }
                 Index to_update_surr = curr_node * max_n_surr + surr_count;
@@ -1084,7 +1084,7 @@ DecisionTree<Container>::recomputeTreeDepth() const{
         return tree_depth;
 
     for(uint16_t depth_counter = 2; depth_counter <= tree_depth; depth_counter++){
-        uint32_t n_leaf_nodes = static_cast<uint32_t>(pow(2, depth_counter - 1));
+        uint32_t n_leaf_nodes = static_cast<uint32_t>(pow(2.0, depth_counter - 1));
         uint32_t leaf_start_index = n_leaf_nodes - 1;
         bool all_non_existing = true;
         for (uint32_t leaf_index=0; leaf_index < n_leaf_nodes; leaf_index++){
@@ -1605,7 +1605,7 @@ TreeAccumulator<Container, DTree>::rebind(
     total_n_cat_levels = in_n_total_levels;
     weights_as_rows = in_weights_as_rows;
     if (tree_depth > 0)
-        n_leaf_nodes = static_cast<uint32_t>(pow(2, tree_depth - 1));
+        n_leaf_nodes = static_cast<uint32_t>(pow(2.0, tree_depth - 1));
     else
         n_leaf_nodes = 1;
     if (n_reachable_leaves >= n_leaf_nodes)

--- a/src/modules/regress/logistic.cpp
+++ b/src/modules/regress/logistic.cpp
@@ -1516,7 +1516,7 @@ AnyType marginalstateToResult(
     const ColumnVector &inCoef,
     const ColumnVector &diagonal_of_variance_matrix,
     const double inmarginal_effects_per_observation,
-    const double numRows) {
+    const Index numRows) {
 
     MutableNativeColumnVector marginal_effects(
         inAllocator.allocateArray<double>(inCoef.size()));
@@ -1531,7 +1531,7 @@ AnyType marginalstateToResult(
 
     for (Index i = 0; i < inCoef.size(); ++i) {
         coef(i) = inCoef(i);
-        marginal_effects(i) = inCoef(i) * inmarginal_effects_per_observation / numRows;
+        marginal_effects(i) = inCoef(i) * inmarginal_effects_per_observation / static_cast<double>(numRows);
         stdErr(i) = std::sqrt(diagonal_of_variance_matrix(i));
         tStats(i) = marginal_effects(i) / stdErr(i);
 
@@ -1673,7 +1673,7 @@ marginal_logregr_step_final::run(AnyType &args) {
                                  state.coef,
                                  std_err.diagonal(),
                                  state.marginal_effects_per_observation,
-                                 static_cast<double>(state.numRows));
+                                 state.numRows);
 }
 
 // ------------------------ End of Marginal ------------------------------------

--- a/src/modules/regress/mlogr_margins.cpp
+++ b/src/modules/regress/mlogr_margins.cpp
@@ -322,7 +322,7 @@ mlogregr_marginal_step_transition::run(AnyType &args) {
                     state.delta(index, idx) += prob(j) *
                         (e_k_K_j_J - prob(J) * e_k_K - x(K) * margins_matrix(J,k));
                 }
-            }      
+            }
         }
     }
 
@@ -356,7 +356,7 @@ mlogregr_marginal_step_merge_states::run(AnyType &args) {
 
 AnyType mlogregr_marginalstateToResult(
     const Allocator &inAllocator,
-    const double numRows,
+    const Index numRows,
     const ColumnVector &inCoef,
     const ColumnVector &inMargins,
     const ColumnVector &inVariance
@@ -446,7 +446,7 @@ mlogregr_marginal_step_final::run(AnyType &args) {
     variance.setOnes();
 
     variance = (state.delta * V * trans(state.delta) / static_cast<double>(state.numRows*state.numRows)).diagonal();
-    
+
     // Add in reference variables to all the calculations
     // ----------------------------------------------------------
     ColumnVector coef_with_ref(size);
@@ -462,7 +462,7 @@ mlogregr_marginal_step_final::run(AnyType &args) {
     }
 
     return mlogregr_marginalstateToResult(*this,
-                                          static_cast<double>(state.numRows),
+                                          state.numRows,
                                           coef_with_ref,
                                           margins_with_ref,
                                           variance);

--- a/src/modules/utilities/path.cpp
+++ b/src/modules/utilities/path.cpp
@@ -46,7 +46,7 @@ AnyType path_pattern_match::run(AnyType & args)
     MappedColumnVector row_id = args[2].getAs<MappedColumnVector>();
     bool overlapping_patterns = args[3].getAs<bool>();
 
-    if (sym_str.size() != row_id.size()) {
+    if (sym_str.size() != static_cast<size_t>(row_id.size())) {
         std::stringstream errorMsg;
         errorMsg << "dimensions mismatch: " << sym_str.size() <<
                     " != " << row_id.size() <<


### PR DESCRIPTION
JIRA: MADLIB-1025

GCC 6+ introduced stricter rules for implicit casting where loss of
information is possible.

Closes #202