### PR TITLE
Infra: Install MADlib on non-default schema in Jenkins

### DIFF
--- a/tool/jenkins/jenkins_build.sh
+++ b/tool/jenkins/jenkins_build.sh
@@ -69,17 +69,17 @@ docker exec madlib bash -c 'rm -rf /build; mkdir /build; cd /build; cmake ../mad
 echo "---------- Installing and running install-check --------------------"
 # Install MADlib and run install check
 cat <<EOF
-docker exec madlib bash -c '/build/src/bin/madpack -p postgres -c postgres/postgres@localhost:5432/postgres install' | tee $workdir/logs/madlib_install.log
+docker exec madlib bash -c '/build/src/bin/madpack -s mad -p postgres -c postgres/postgres@localhost:5432/postgres install' | tee $workdir/logs/madlib_install.log
 EOF
-docker exec madlib bash -c '/build/src/bin/madpack -p postgres -c postgres/postgres@localhost:5432/postgres install' | tee $workdir/logs/madlib_install.log
+docker exec madlib bash -c '/build/src/bin/madpack -s mad -p postgres -c postgres/postgres@localhost:5432/postgres install' | tee $workdir/logs/madlib_install.log
 
 cat <<EOF
 docker exec madlib bash -c 'mkdir /tmp'
-docker exec madlib bash -c '/build/src/bin/madpack -p postgres  -c postgres/postgres@localhost:5432/postgres -d /tmp install-check' | tee $workdir/logs/madlib_install_check.log
+docker exec madlib bash -c '/build/src/bin/madpack -s mad -p postgres  -c postgres/postgres@localhost:5432/postgres -d /tmp install-check' | tee $workdir/logs/madlib_install_check.log
 EOF
 
 docker exec madlib bash -c 'mkdir /tmp'
-docker exec madlib bash -c '/build/src/bin/madpack -p postgres  -c postgres/postgres@localhost:5432/postgres -d /tmp install-check' | tee $workdir/logs/madlib_install_check.log
+docker exec madlib bash -c '/build/src/bin/madpack -s mad -p postgres  -c postgres/postgres@localhost:5432/postgres -d /tmp install-check' | tee $workdir/logs/madlib_install_check.log
 
 echo "--------- Copying packages -----------------"
 echo "docker cp madlib:build $workdir"


### PR DESCRIPTION
The Jenkins build that runs for every PR and for every master
commit is great. Installing MADlib on a non-default schema name
such as `mad` would help us identify many issues early (issues
that correspond to hard-coding `madlib` in the code/tests).

PS: The Jenkins build for this PR is expected to fail due to
https://issues.apache.org/jira/browse/MADLIB-1184

Closes #207