### PR TITLE
Correlation: Fix bug with international characters

### DIFF
--- a/src/ports/postgres/modules/stats/correlation.py_in
+++ b/src/ports/postgres/modules/stats/correlation.py_in
@@ -179,9 +179,9 @@ def _populate_output_table(schema_madlib, source_table, output_table,
             function_name = "Correlation"
             agg_str = "{0}.correlation_agg(x, mean)".format(schema_madlib)
 
-        cols = ','.join(["coalesce({0}, ".format(col)+add_postfix(col, "_avg")+")"
+        cols = ','.join(["coalesce({0}, {1})".format(col, add_postfix(col, "_avg"))
                         for col in col_names])
-        avgs = ','.join(["avg({0})".format(col)+" AS "+add_postfix(col, "_avg")
+        avgs = ','.join(["avg({0}) AS {1}".format(col, add_postfix(col, "_avg"))
                         for col in col_names])
         avg_array = ','.join([str(add_postfix(col, "_avg")) for col in col_names])
         # actual computation

--- a/src/ports/postgres/modules/stats/correlation.py_in
+++ b/src/ports/postgres/modules/stats/correlation.py_in
@@ -179,9 +179,11 @@ def _populate_output_table(schema_madlib, source_table, output_table,
             function_name = "Correlation"
             agg_str = "{0}.correlation_agg(x, mean)".format(schema_madlib)
 
-        cols = ','.join(["coalesce({0}, avg_{0})".format(col) for col in col_names])
-        avgs = ','.join(["avg({0}) AS avg_{0}".format(col) for col in col_names])
-        avg_array = ','.join(["avg_{0}".format(col) for col in col_names])
+        cols = ','.join(["coalesce({0}, ".format(col)+add_postfix(col, "_avg")+")"
+                        for col in col_names])
+        avgs = ','.join(["avg({0})".format(col)+" AS "+add_postfix(col, "_avg")
+                        for col in col_names])
+        avg_array = ','.join([str(add_postfix(col, "_avg")) for col in col_names])
         # actual computation
         sql1 = """
 


### PR DESCRIPTION
JIRA:MADLIB-1186

If the column name of an independent variable used in
madlib.correlation(...) has quotes in it, then the query fails due
to a regular string concat used for finding the average of a column.
This commit uses add_postfix() to create a new string out of a string
that has special chars instead.

Closes #214 