### PR TITLE
Multiple: Hard-wire values for construct_array calls

### DIFF
--- a/src/modules/crf/viterbi.cpp
+++ b/src/modules/crf/viterbi.cpp
@@ -18,22 +18,8 @@ namespace modules {
 namespace crf {
 
 using namespace dbal::eigen_integration;
-using madlib::dbconnector::postgres::madlib_get_typlenbyvalalign;
 using madlib::dbconnector::postgres::madlib_construct_array;
 
-typedef struct __type_info{
-    Oid oid;
-    int16_t len;
-    bool    byval;
-    char    align;
-
-    __type_info(Oid oid):oid(oid)
-    {
-        madlib_get_typlenbyvalalign(oid, &len, &byval, &align);
-    }
-} type_info;
-
-static type_info INT4TI(INT4OID);
 
 AnyType vcrf_top1_label::run(AnyType& args) {
 
@@ -124,10 +110,12 @@ AnyType vcrf_top1_label::run(AnyType& args) {
      * elements are used to store the best labels and the last element is used
      * to store the conditional probability of the sequence.
      */
+
+    // FIXME: construct_array functions circumvent the abstraction layer. These
+    // should be replaced with appropriate Allocator:: calls.
     MutableArrayHandle<int> result(
         madlib_construct_array(
-            NULL, doc_len+1, INT4TI.oid,
-               INT4TI.len, INT4TI.byval, INT4TI.align));
+            NULL, doc_len + 1, INT4OID, sizeof(int32_t), true, 'i'));
 
     /* trace back to get the labels for the rest tokens in a sentence */
     result[doc_len - 1] = top1_label;

--- a/src/ports/postgres/CMakeLists.txt
+++ b/src/ports/postgres/CMakeLists.txt
@@ -307,8 +307,14 @@ function(add_extension_support)
     # The workhorse for extension target
     # It is hard to interpret Modules.yml in this cmake file, thus we use
     # sort-module.py to sort modules based on the dependencies.
+    #   awk is used to read and print each line from each file into {EXTENSION_SQL}
+    #       awk's prog contains two parts:
+    #           1. FNR==1{print ""}: add an empty newline if reading the
+    #               first line of a file
+    #           2. 1: Print each line. This part takes advantage of the default
+    #               action of {print}
     add_custom_command(OUTPUT ${EXTENSION_SQL}
-        COMMAND cat ${EXTENSION_SQL_BASE}
+        COMMAND awk 'FNR==1{print \"\"}1' ${EXTENSION_SQL_BASE}
             `cd ${CMAKE_BINARY_DIR}/src/madpack &&
             python sort-module.py ${MODULE_SQL_POST_FILES}` >${EXTENSION_SQL}
         DEPENDS ${MODULE_SQL_POST_FILES} madpackFiles configFiles pythonFiles_${DBMS} madlib_${DBMS}


### PR DESCRIPTION
JIRA: MADLIB-1185

Original investigation and RCA performed by
  Nikhil Kak <nkak@pivotal.io> and
  Orhan Kislal <okislal@pivotal.io>

Multiple modules called get_typlenbyvalalign in the constructor of a
struct, which led to querying the catalog during dlopen. This is frowned
down upon [1] and the problem got exposed in PG10. This commit provides
a temporary solution by hard-wiring the necessary values. This is OK in
these scenarios, since the types used are INT4, INT8 and FLOAT8, all
with fixed, stable storage and alignment patterns. Ideal solution to the
problem is to use MADlib's Allocator::allocateArray instead of the
construct_array functions.

[1] https://www.postgresql.org/message-id/96420364a3d055172776752a1de80714%40smtp.hushmail.com

Closes #219