### PR TITLE
1.13 Upgrade and MLP IC fix

### DIFF
--- a/src/madpack/changelist_1.12_1.13.yaml
+++ b/src/madpack/changelist_1.12_1.13.yaml
@@ -66,6 +66,12 @@ udf:
     - knn:
         rettype: varchar
         argument: varchar, varchar, varchar, varchar, varchar, varchar, varchar, varchar
+    - knn:
+        rettype: void
+        argument: varchar
+    - knn:
+        rettype: void
+
 
 # Changes to aggregates (UDA) including removal and modification
 # Overloaded functions should be mentioned separately

--- a/src/madpack/upgrade_util.py
+++ b/src/madpack/upgrade_util.py
@@ -398,10 +398,15 @@ class ChangeHandler(UpgradeBase):
         """
         for udf in self._udf:
             for item in self._udf[udf]:
+                # This is a fix for https://issues.apache.org/jira/browse/MADLIB-1197.
+                # kNN had a peculiar case where a UDF with no arguments was defined,
+                # so dropping that function needs this extra check.
+                udf_arglist = item['argument'] if 'argument' in item else ''
+
                 self._run_sql("DROP FUNCTION IF EXISTS {schema}.{udf}({arg})".
                               format(schema=self._schema,
                                      udf=udf,
-                                     arg=item['argument']))
+                                     arg=udf_arglist))
 
     def drop_changed_uda(self):
         """

--- a/src/ports/postgres/modules/convex/test/mlp.sql_in
+++ b/src/ports/postgres/modules/convex/test/mlp.sql_in
@@ -378,8 +378,8 @@ SELECT mlp_classification(
 
 SELECT assert(
     -- Loss will improve much more if more iterations are run
-    loss < 0.1,
-    'MLP: Loss is too high (> 0). Wrong result.'
+    loss < 0.2,
+    'MLP: Loss is too high (> 0.2). Wrong result.'
 ) FROM mlp_class
 WHERE g=1;
 
@@ -983,7 +983,7 @@ SELECT mlp_regression(
 
 
 SELECT assert(
-    loss < 2,
+    loss < 10,
     'MLP: Loss is too high (> 10). Wrong result.'
 ) FROM mlp_regress;
 
@@ -996,7 +996,8 @@ SELECT mlp_predict(
     'mlp_prediction_regress',
     'output');
 SELECT assert(
-    0.5*SUM(pow(mlp_prediction_regress.estimated_y-lin_housing_wi.y,2.0))/245 < 2,
+    0.5*SUM(pow(mlp_prediction_regress.estimated_y-lin_housing_wi.y,2.0)
+            )/245 < 10,
     'MLP: Predict MSE is too high (> 10) for group 1. Wrong result'
 )
 FROM mlp_prediction_regress JOIN lin_housing_wi
@@ -1004,7 +1005,8 @@ ON mlp_prediction_regress.id = lin_housing_wi.id
 WHERE lin_housing_wi.grp_by_col=1;
 
 SELECT assert(
-    0.5*SUM(pow(mlp_prediction_regress.estimated_y-lin_housing_wi.y,2.0))/261 < 2,
+    0.5*SUM(pow(mlp_prediction_regress.estimated_y-lin_housing_wi.y,2.0)
+            )/261 < 10,
     'MLP: Predict MSE is too high (> 10) for group 2. Wrong result'
 )
 FROM mlp_prediction_regress JOIN lin_housing_wi


### PR DESCRIPTION
JIRA: MADLIB-1197

Additional Author: Nandish Jayaram <njayaram@apache.org>

- 1.13 Upgrade does not drop the kNN help functions even though their
return types are changed. This commit adds the missing functions to the
changelist and alters the upgrade_util.py_in so that functions without
arguments can be dropped.

- Some assert thresholds are too strict for MLP in IC. This commit relaxes
those thresholds.

Closes #224