### PR TITLE
MLP: Fix step size initialization based on learning rate policy

### DIFF
--- a/src/ports/postgres/modules/convex/mlp_igd.py_in
+++ b/src/ports/postgres/modules/convex/mlp_igd.py_in
@@ -112,6 +112,7 @@ def mlp(schema_madlib, source_table, output_table, independent_varname,
     num_output_nodes = 0
     classes = []
     dependent_type = get_expr_type(dependent_varname, source_table)
+    classes_str = None
     original_dependent_varname = dependent_varname
 
     x_mean_table = unique_string(desp='x_mean_table')
@@ -249,14 +250,13 @@ def mlp(schema_madlib, source_table, output_table, independent_varname,
         with iterationCtrl as it:
             it.iteration = 0
             while True:
-                zero_indexed_iteration = current_iteration - 1
                 if learning_rate_policy == "exp":
-                    step_size = step_size_init * gamma**zero_indexed_iteration
+                    step_size = step_size_init * gamma**it.iteration
                 elif learning_rate_policy == "inv":
-                    step_size = step_size_init * (current_iteration)**(-power)
+                    step_size = step_size_init * (it.iteration+1)**(-power)
                 elif learning_rate_policy == "step":
                     step_size = step_size_init * gamma**(
-                        math.floor(zero_indexed_iteration / iterations_per_step))
+                        math.floor(it.iteration / iterations_per_step))
                 it.kwargs['step_size'] = step_size
 
                 it.update("""

--- a/src/ports/postgres/modules/convex/mlp_igd.py_in
+++ b/src/ports/postgres/modules/convex/mlp_igd.py_in
@@ -112,7 +112,6 @@ def mlp(schema_madlib, source_table, output_table, independent_varname,
     num_output_nodes = 0
     classes = []
     dependent_type = get_expr_type(dependent_varname, source_table)
-    classes_str = None
     original_dependent_varname = dependent_varname
 
     x_mean_table = unique_string(desp='x_mean_table')


### PR DESCRIPTION
JIRA: MADLIB-1212

The step_size is supposed to be updated based on the learning rate. The
formulae for different policies depend on the current iteration number,
which was not consumed correctly. This commit fixes it by using
it.iteration for the current iteration number in that update.

Co-authored-by: Nikhil Kak <nkak@pivotal.io>