### PR TITLE
DT: Ensure proper quoting in grouping coalesce

### DIFF
--- a/src/ports/postgres/modules/recursive_partitioning/decision_tree.py_in
+++ b/src/ports/postgres/modules/recursive_partitioning/decision_tree.py_in
@@ -949,7 +949,7 @@ def _get_bins_grps(
                                             " THEN 'True' ELSE 'False' END)")
             else:
                 if null_proxy is not None:
-                    all_col_expressions[col] = ("COALESCE({0}, {1})".
+                    all_col_expressions[col] = ("COALESCE({0}::TEXT, '{1}')".
                                                 format(col, null_proxy))
                 else:
                     all_col_expressions[col] = col
@@ -1033,7 +1033,7 @@ def get_feature_str(schema_madlib, boolean_cats,
         cat_features_str = "NULL"
 
     if len(con_features) > 0:
-        con_features_list = ["coalesce(" + str(con) + ", 'nan'::double precision)"
+        con_features_list = ["COALESCE(" + str(con) + ", 'nan'::double precision)"
                              for con in con_features]
         con_features_str = "ARRAY[" + ", ".join(con_features_list) + "]"
     else:

--- a/src/ports/postgres/modules/recursive_partitioning/decision_tree.py_in
+++ b/src/ports/postgres/modules/recursive_partitioning/decision_tree.py_in
@@ -970,16 +970,35 @@ def _get_bins_grps(
                          "one value are dropped from the tree model.")
             cat_features = [feature for feature in cat_features if feature in use_cat_features]
 
-        grp_to_col_to_row = dict((grp_key, dict(
-            (row['colname'], row['levels']) for row in items))
-            for grp_key, items in groupby(all_levels, key=itemgetter('grp_key')))
-
+        # grp_col_to_levels is a list of tuples (pairs) with
+        #   first value = group value,
+        #   second value = a dict mapping a categorical column to its levels in data
+        #           (these levels are specific to the group and can be different
+        #               for different groups)
+        #   The list of tuples can be converted to a dict, but the ordering
+        #   will be lost.
+        # eg. grp_col_to_levels =
+        #   [
+        #       ('3', {'vs': [0, 1], 'cyl': [4,6,8]}),
+        #       ('4', {'vs': [0, 1], 'cyl': [4,6]}),
+        #       ('5', {'vs': [0, 1], 'cyl': [4,6,8]})
+        #   ]
+        grp_to_col_to_levels = [
+            (grp_key, dict((row['colname'], row['levels']) for row in items))
+            for grp_key, items in groupby(all_levels, key=itemgetter('grp_key'))]
     if cat_features:
-        cat_items_list = [rows[col] for col in cat_features
-                          for grp_key, rows in grp_to_col_to_row.items() if col in rows]
+        # Below statements collect the grp_to_col_to_levels into multiple variables
+        # From above eg.
+        #   cat_items_list = [[0,1], [4,6,8], [0,1], [4,6], [0,1], [4,6,8]]
+        #   cat_n = [2, 3, 2, 2, 2, 3]
+        #   cat_n = [0, 1, 4, 6, 8, 0, 1, 4, 6, 0, 1, 4, 6, 8]
+        #   grp_key_cat = ['3', '4', '5']
+        cat_items_list = [rows[col]
+                            for grp_key, rows in grp_to_col_to_levels
+                            for col in cat_features if col in rows]
         cat_n = [len(i) for i in cat_items_list]
-        cat_origin = [item for subl in cat_items_list for item in subl]
-        grp_key_cat=[grp_key for grp_key in grp_to_col_to_row]
+        cat_origin = [item for sublist in cat_items_list for item in sublist]
+        grp_key_cat=[item[0] for item in grp_to_col_to_levels]
     else:
         cat_n = []
         cat_origin = []

--- a/src/ports/postgres/modules/recursive_partitioning/decision_tree.sql_in
+++ b/src/ports/postgres/modules/recursive_partitioning/decision_tree.sql_in
@@ -363,9 +363,9 @@ tree_train(
 
     <tr>
     <th>null_proxy</th>
-    <td>TEXT. Describes how NULLs are handled.  If NULL is not 
+    <td>TEXT. Describes how NULLs are handled.  If NULL is not
     treated as a separate categorical variable, this will be NULL.
-    If NULL is treated as a separate categorical value, this will be 
+    If NULL is treated as a separate categorical value, this will be
     set to "__NULL__"</td>
     </tr>
    </table>

--- a/src/ports/postgres/modules/recursive_partitioning/test/decision_tree.sql_in
+++ b/src/ports/postgres/modules/recursive_partitioning/test/decision_tree.sql_in
@@ -236,6 +236,7 @@ FROM (
 DROP TABLE IF EXISTS dt_golf CASCADE;
 CREATE TABLE dt_golf (
     id integer NOT NULL,
+    id_2 integer,
     "OUTLOOK" text,
     temperature double precision,
     humidity double precision,
@@ -263,8 +264,11 @@ INSERT INTO dt_golf (id,"OUTLOOK",temperature,humidity,"Cont_features",cat_featu
 (16, 'overcast', NULL, 75, ARRAY[81, 75], ARRAY['a', 'd'], false, 'Play'),
 (14, 'rain', 71, 80, ARRAY[71, 80], ARRAY['c', 'b'], true, 'Don''t Play');
 
--- no grouping
-DROP TABLE IF EXISTS train_output, train_output_summary;
+update dt_golf set id_2 = id % 2;
+-------------------------------------------------------------------------
+
+-- no grouping, with cross_validation
+DROP TABLE IF EXISTS train_output, train_output_summary, train_output_cv;
 SELECT tree_train('dt_golf'::text,         -- source table
                          'train_output'::text,    -- output model table
                          'id'::text,              -- id column
@@ -277,12 +281,13 @@ SELECT tree_train('dt_golf'::text,         -- source table
                          10::integer,       -- max depth
                          6::integer,        -- min split
                          2::integer,        -- min bucket
-                         8::integer,        -- number of bins per continuous variable
-                         'cp=0.01'          -- cost-complexity pruning parameter
+                         3::integer,        -- number of bins per continuous variable
+                         'cp=0.01, n_folds=2'          -- cost-complexity pruning parameter
                          );
 
 SELECT _print_decision_tree(tree) from train_output;
 SELECT tree_display('train_output', False);
+SELECT * FROM train_output_cv;
 -------------------------------------------------------------------------
 
 -- grouping
@@ -311,7 +316,7 @@ SELECT tree_display('train_output', False);
 CREATE TABLE dt_golf2 as
 SELECT * FROM dt_golf
 UNION
-SELECT 15 as id, 'humid' as "OUTLOOK", 71 as temperature, 80 as humidity,
+SELECT 15 as id, 1 as id_2, 'humid' as "OUTLOOK", 71 as temperature, 80 as humidity,
        ARRAY[90, 90] as "Cont_features", ARRAY['b', 'c'] as cat_features,
        true as windy, 'Don''t Play' as class;
 \x off
@@ -328,24 +333,24 @@ select * from train_output;
 select * from train_output_summary;
 -------------------------------------------------------------------------
 
--- no grouping, cross-validation
-DROP TABLE IF EXISTS train_output, train_output_summary, train_output_cv, predict_output;
+-- grouping and null_as_category=True
+DROP TABLE IF EXISTS train_output, train_output_summary, predict_output;
 SELECT tree_train('dt_golf'::text,         -- source table
-                         'train_output'::text,    -- output model table
-                         'id'::text,              -- id column
-                         'temperature::double precision'::text,           -- response
-                         '"OUTLOOK", cat_features, "Cont_features"'::text,   -- features
-                         NULL::text,        -- exclude columns
-                         'mse'::text,      -- split criterion
-                         NULL::text,        -- no grouping
-                         NULL::text,        -- no weights
-                         NULL::integer,     -- max depth
-                         6::integer,        -- min split
-                         2::integer,        -- min bucket
-                         8::integer,        -- number of bins per continuous variable
-                         'cp=0.01, n_folds=3',
-                         'max_surrogates=2, null_as_category=True'
-                         );
+                  'train_output'::text,    -- output model table
+                  'id'::text,              -- id column
+                  'temperature::double precision'::text,           -- response
+                  '"OUTLOOK", humidity'::text,   -- features
+                  NULL::text,        -- exclude columns
+                  'mse'::text,       -- split criterion
+                  'id_2'::text,      -- grouping col
+                  NULL::text,        -- no weights
+                  NULL::integer,     -- max depth
+                  6::integer,        -- min split
+                  2::integer,        -- min bucket
+                  3::integer,        -- number of bins per continuous variable
+                  'cp=0.01',
+                  'max_surrogates=2, null_as_category=True'
+                  );
 
 SELECT _print_decision_tree(tree) from train_output;
 SELECT tree_display('train_output', False);
@@ -360,7 +365,6 @@ USING (id);
 \x on
 select * from train_output;
 select * from train_output_summary;
-select * from train_output_cv;
 -------------------------------------------------------------------------
 
 drop table if exists group_cp;

--- a/src/ports/postgres/modules/recursive_partitioning/test/random_forest.sql_in
+++ b/src/ports/postgres/modules/recursive_partitioning/test/random_forest.sql_in
@@ -134,7 +134,7 @@ SELECT forest_train(
                   10,                -- num of trees
                   1,                 -- num of random features
                   TRUE,     -- importance
-                  1,         -- num_permutations
+                  3,         -- num_permutations
                   10,       -- max depth
                   1,        -- min split
                   1,        -- min bucket
@@ -148,7 +148,7 @@ SELECT * from train_output_summary;
 SELECT * from train_output_group;
 SELECT
     assert(cat_var_importance[1] > con_var_importance[1], 'class should be important!'),
-    assert(cat_var_importance[1] > con_var_importance[2], 'class should be important!')
+    assert(cat_var_importance[1] > cat_var_importance[2], 'class should be important!')
 FROM train_output_group;
 
 -------------------------------------------------------------------------
@@ -165,7 +165,7 @@ SELECT forest_train(
                   10,                -- num of trees
                   1,                 -- num of random features
                   TRUE,     -- importance
-                  1,         -- num_permutations
+                  3,         -- num_permutations
                   10,       -- max depth
                   1,        -- min split
                   1,        -- min bucket


### PR DESCRIPTION
JIRA: MADLIB-1217

Grouping column value is coalesced with null_proxy to get the right null
identifier when null_as_category is True. The null_proxy needs to be
quoted appropriately as a string.

Closes #248