### PR TITLE
MLP: Simplify initialization of model coefficients

### DIFF
--- a/src/modules/convex/type/model.hpp
+++ b/src/modules/convex/type/model.hpp
@@ -164,7 +164,7 @@ struct MLPModel {
         for (k =0; k < N; ++k){
             // Initalize according to Glorot and Bengio (2010)
             // See design doc for more info
-            span = sqrt(6.0 / (n[k] + n[k+1]));
+            span = 0.5 * sqrt(6.0 / (n[k] + n[k+1]));
             u[k] << span * Matrix::Random(u[k].rows(), u[k].cols());
         }
     }

--- a/src/modules/convex/type/state.hpp
+++ b/src/modules/convex/type/state.hpp
@@ -732,8 +732,8 @@ public:
      * @brief Reset the intra-iteration fields.
      */
     inline void reset() {
-        algo.numRows = 0;
-        algo.loss = 0.;
+        numRows = 0;
+        loss = 0.;
     }
 
     /**
@@ -760,11 +760,11 @@ public:
         // effect. I can also do something like "mStorage[0] = N",
         // but I am not clear about the type binding/alignment
         rebind();
-        task.numberOfStages = inNumberOfStages;
+        numberOfStages = inNumberOfStages;
         uint16_t N = inNumberOfStages;
         uint16_t k;
         for (k = 0; k <= N; k ++) {
-            task.numbersOfUnits[k] = inNumbersOfUnits[k];
+            numbersOfUnits[k] = inNumbersOfUnits[k];
         }
 
         // This time all the member fields are correctly binded
@@ -823,23 +823,22 @@ private:
      * - N + 9 + sizeOfModel: loss (loss value, the sum of squared errors)
      */
     void rebind() {
+        numberOfStages.rebind(&mStorage[0]);
+        size_t N = numberOfStages;
 
-        task.numberOfStages.rebind(&mStorage[0]);
-        size_t N = task.numberOfStages;
-
-        task.numbersOfUnits =
+        numbersOfUnits =
             reinterpret_cast<dimension_pointer_type>(&mStorage[1]);
-        task.stepsize.rebind(&mStorage[N + 2]);
-        task.lambda.rebind(&mStorage[N + 3]);
-        size_t sizeOfModel = task.model.rebind(&mStorage[N + 4],
+        stepsize.rebind(&mStorage[N + 2]);
+        lambda.rebind(&mStorage[N + 3]);
+        size_t sizeOfModel = model.rebind(&mStorage[N + 4],
                                                &mStorage[N + 5],
                                                &mStorage[N + 6],
-                                               task.numberOfStages,
-                                               task.numbersOfUnits);
-        algo.numRows.rebind(&mStorage[N + 6 + sizeOfModel]);
-        algo.batchSize.rebind(&mStorage[N + 7 + sizeOfModel]);
-        algo.nEpochs.rebind(&mStorage[N + 8 + sizeOfModel]);
-        algo.loss.rebind(&mStorage[N + 9 + sizeOfModel]);
+                                               numberOfStages,
+                                               numbersOfUnits);
+        numRows.rebind(&mStorage[N + 6 + sizeOfModel]);
+        batchSize.rebind(&mStorage[N + 7 + sizeOfModel]);
+        nEpochs.rebind(&mStorage[N + 8 + sizeOfModel]);
+        loss.rebind(&mStorage[N + 9 + sizeOfModel]);
     }
 
 
@@ -849,20 +848,17 @@ private:
     typedef typename HandleTraits<Handle>::ReferenceToDouble numeric_type;
 
 public:
-    struct TaskState {
-        dimension_type numberOfStages;
-        dimension_pointer_type numbersOfUnits;
-        numeric_type stepsize;
-        numeric_type lambda;
-        MLPModel<Handle> model;
-    } task;
+    dimension_type numberOfStages;
+    dimension_pointer_type numbersOfUnits;
+    numeric_type stepsize;
+    numeric_type lambda;
+    MLPModel<Handle> model;
 
-    struct AlgoState {
-        count_type numRows;
-        dimension_type batchSize;
-        dimension_type nEpochs;
-        numeric_type loss;
-    } algo;
+    count_type numRows;
+    dimension_type batchSize;
+    dimension_type nEpochs;
+    numeric_type loss;
+
 };
 
 

--- a/src/ports/postgres/modules/convex/mlp.sql_in
+++ b/src/ports/postgres/modules/convex/mlp.sql_in
@@ -1277,7 +1277,6 @@ CREATE FUNCTION MADLIB_SCHEMA.mlp_igd_transition(
         activation         INTEGER,
         is_classification  INTEGER,
         weight             DOUBLE PRECISION,
-        warm_start         BOOLEAN,
         warm_start_coeff   DOUBLE PRECISION[],
         lambda             DOUBLE PRECISION
     )
@@ -1295,7 +1294,6 @@ CREATE FUNCTION MADLIB_SCHEMA.mlp_minibatch_transition(
         activation         INTEGER,
         is_classification  INTEGER,
         weight             DOUBLE PRECISION,
-        warm_start         BOOLEAN,
         warm_start_coeff   DOUBLE PRECISION[],
         lambda             DOUBLE PRECISION,
         batch_size         INTEGER,
@@ -1344,7 +1342,6 @@ CREATE AGGREGATE MADLIB_SCHEMA.mlp_igd_step(
         /* activation */          INTEGER,
         /* is_classification */   INTEGER,
         /* weight */              DOUBLE PRECISION,
-        /* warm_start */          BOOLEAN,
         /* warm_start_coeff */    DOUBLE PRECISION[],
         /* lambda */              DOUBLE PRECISION
         )(
@@ -1369,7 +1366,6 @@ CREATE AGGREGATE MADLIB_SCHEMA.mlp_minibatch_step(
         /* activation */          INTEGER,
         /* is_classification */   INTEGER,
         /* weight */              DOUBLE PRECISION,
-        /* warm_start */          BOOLEAN,
         /* warm_start_coeff */    DOUBLE PRECISION[],
         /* lambda */              DOUBLE PRECISION,
         /* batch_size */          INTEGER,

--- a/src/ports/postgres/modules/convex/mlp_igd.py_in
+++ b/src/ports/postgres/modules/convex/mlp_igd.py_in
@@ -81,7 +81,7 @@ def mlp(schema_madlib, source_table, output_table, independent_varname,
     step_size = step_size_init
     n_tries = optimizer_params["n_tries"]
     # lambda is a reserved word in python
-    lmbda = optimizer_params["lambda"]
+    lambda_ = optimizer_params["lambda"]
     batch_size = optimizer_params['batch_size']
     n_epochs = optimizer_params['n_epochs']
 
@@ -195,6 +195,10 @@ def mlp(schema_madlib, source_table, output_table, independent_varname,
                 """.format(**locals())
         else:
             start_coeff = PY2SQL(coeff, array_type="DOUBLE PRECISION")
+    else:
+        # if warm start not enabled then initialization is the responsibility of
+        # the model
+        start_coeff = "NULL::DOUBLE PRECISION[]"
 
     if grouping_col:
         group_by_clause = "GROUP BY {0}, {1}".format(grouping_col, col_grp_key)
@@ -219,12 +223,13 @@ def mlp(schema_madlib, source_table, output_table, independent_varname,
         "warm_start": warm_start,
         "n_iterations": n_iterations,
         "tolerance": tolerance,
-        "lmbda": lmbda,
+        "lambda_": lambda_,
         "grouping_col": grouping_col,
         "grouping_str": grouping_str,
         "x_mean_table": x_mean_table,
         "batch_size": batch_size,
-        "n_epochs": n_epochs
+        "n_epochs": n_epochs,
+        "start_coeff": start_coeff
     }
     # variables to be used by GroupIterationController
     it_args.update({
@@ -252,17 +257,6 @@ def mlp(schema_madlib, source_table, output_table, independent_varname,
 
     for _ in range(n_tries):
         prev_state = None
-        if not warm_start:
-            coeff = []
-            for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:]):
-                # Initalize according to Glorot and Bengio (2010)
-                # See design doc for more info
-                span = math.sqrt(6.0 / (fan_in + fan_out))
-                dim = (fan_in + 1) * fan_out
-                rand = [span * (random() - 0.5) for _ in range(dim)]
-                coeff += rand
-            start_coeff = PY2SQL(coeff, "double precision")
-        it_args['start_coeff'] = start_coeff
         iterationCtrl = GroupIterationController(it_args)
         with iterationCtrl as it:
             it.iteration = 0
@@ -286,9 +280,8 @@ def mlp(schema_madlib, source_table, output_table, independent_varname,
                             {activation},
                             {is_classification},
                             ({weights})::DOUBLE PRECISION,
-                            {warm_start},
                             ({start_coeff})::DOUBLE PRECISION[],
-                            {lmbda},
+                            {lambda_},
                             {batch_size}::integer,
                             {n_epochs}::integer
                         )
@@ -304,9 +297,8 @@ def mlp(schema_madlib, source_table, output_table, independent_varname,
                             {activation},
                             {is_classification},
                             ({weights})::DOUBLE PRECISION,
-                            {warm_start},
                             ({start_coeff})::DOUBLE PRECISION[],
-                            {lmbda}
+                            {lambda_}
                         )
                         """
                 it.update(train_sql)
@@ -520,10 +512,13 @@ def _create_output_table(output_table, temp_output_table,
         plpy.execute("DROP TABLE IF EXISTS {0}".format(output_table))
     build_output_query = """
         CREATE TABLE {output_table} AS
-        SELECT {grouping_col_comma} coeff, loss, num_iterations FROM
-        (SELECT {temp_output_table}.*, row_number()
-        OVER ({partition_by} ORDER BY loss)
-        AS rank FROM {temp_output_table}) x WHERE x.rank=1;
+            SELECT {grouping_col_comma} coeff, loss, num_iterations
+            FROM (
+                SELECT {temp_output_table}.*,
+                        row_number() OVER ({partition_by} ORDER BY loss) AS rank
+                FROM {temp_output_table}
+            ) x
+            WHERE x.rank = 1;
     """.format(**locals())
     plpy.execute(build_output_query)
 


### PR DESCRIPTION
Changes:

1. Model initialization now happens in the C++ code instead of being
passed via Python.
2. Warm start coefficients are still passed from Python. These
coefficients are copied into the model. The vectorized form of the copy
raises an Eigen assertion when used with a MappedMatrix, possibly due
to the actual block size not being available via the Map.
3. The distinction between a "TaskState" and an "AlgoState" within a
State type has been removed in the MLPMiniBatchState. This demarcation
seemed to be confusing and didn't provide much abstraction.

Closes #251