### PR TITLE
leftover minor RF user doc update

### DIFF
--- a/doc/mainpage.dox.in
+++ b/doc/mainpage.dox.in
@@ -17,6 +17,8 @@ Useful links:
 <li><a href="https://mail-archives.apache.org/mod_mbox/madlib-user/">User mailing list</a></li>
 <li><a href="https://mail-archives.apache.org/mod_mbox/madlib-dev/">Dev mailing list</a></li>
 <li>User documentation for earlier releases:
+    <a href="../v1.13/index.html">v1.13</a>,
+    <a href="../v1.12/index.html">v1.12</a>,
     <a href="../v1.11/index.html">v1.11</a>,
     <a href="../v1.10/index.html">v1.10.0</a>,
     <a href="../v1.9.1/index.html">v1.9.1</a>,

--- a/src/ports/postgres/modules/recursive_partitioning/random_forest.sql_in
+++ b/src/ports/postgres/modules/recursive_partitioning/random_forest.sql_in
@@ -733,6 +733,7 @@ A higher value means higher importance for the variable.
 -# Predict output categories. For the purpose of this 
 example, we use the same data that was used for training:
 <pre class="example">
+\\x off
 DROP TABLE IF EXISTS prediction_results;
 SELECT madlib.forest_predict('train_output',        -- tree model    
                              'rf_golf',             -- new data table
@@ -740,6 +741,37 @@ SELECT madlib.forest_predict('train_output',        -- tree model
                              'response');           -- show response
 SELECT g.id, class, estimated_class FROM prediction_results p, 
 rf_golf g WHERE p.id = g.id ORDER BY g.id;
+</pre>
+<pre class="result">
+ id |   class    | estimated_class 
+----+------------+-----------------
+  1 | Don't Play | Don't Play
+  2 | Don't Play | Don't Play
+  3 | Play       | Play
+  4 | Play       | Play
+  5 | Play       | Play
+  6 | Don't Play | Don't Play
+  7 | Play       | Play
+  8 | Don't Play | Don't Play
+  9 | Play       | Play
+ 10 | Play       | Play
+ 11 | Play       | Play
+ 12 | Play       | Play
+ 13 | Play       | Play
+ 14 | Don't Play | Don't Play
+(14 rows)
+</pre>
+To display the probabilities associated with each 
+value of the dependent variable, set the 'type' 
+parameter to 'prob':
+<pre class="example">
+DROP TABLE IF EXISTS prediction_results;
+SELECT madlib.forest_predict('train_output',        -- tree model    
+                             'rf_golf',             -- new data table
+                             'prediction_results',  -- output table
+                             'prob');               -- show probability
+SELECT g.id, class, "estimated_prob_Don't Play",  "estimated_prob_Play" 
+FROM prediction_results p, rf_golf g WHERE p.id = g.id ORDER BY g.id;
 </pre>
 <pre class="result">
  id |   class    | estimated_prob_Don't Play | estimated_prob_Play 
@@ -878,6 +910,7 @@ SELECT madlib.forest_train('rf_golf',         -- source table
                            1::integer,        -- min bucket
                            10::integer        -- number of splits per continuous variable
                            );
+\\x on
 SELECT * FROM train_output_summary;
 </pre>
 <pre class="result">
@@ -1026,6 +1059,7 @@ SELECT madlib.forest_train('mt_cars',         -- source table
                            10,                -- number of splits per continuous variable
                            'max_surrogates=2' -- NULL handling
                            );
+\\x on
 SELECT * FROM mt_cars_output_summary;
 </pre>
 <pre class="result">
@@ -1085,6 +1119,7 @@ con_var_importance | {14.6258526998299,0.631733333333333,0}
 
 -# Predict regression output for the same data and compare with original:
 <pre class="example">
+\\x off
 DROP TABLE IF EXISTS prediction_results;
 SELECT madlib.forest_predict('mt_cars_output',
                              'mt_cars',
@@ -1209,6 +1244,7 @@ SELECT madlib.forest_train('null_handling_example',  -- source table
                            3::integer,        -- number of splits per continuous variable
                            'null_as_category=TRUE'
                            );
+\\x on
 SELECT * FROM train_output_summary;
 </pre>
 <pre class='result'>
@@ -1243,7 +1279,6 @@ null_proxy            | __NULL__
 </pre>
 View the summary table:
 <pre class='example'>
-\\x on
 SELECT * FROM train_output_group;
 </pre>
 <pre class='result'>


### PR DESCRIPTION
A few remaining RF user doc changes I missed in 
https://github.com/apache/madlib/commit/7f3aae92f2d84bf7e4501ac5efec1ebfc7a80834

Also added links to 2 prev versions that were missing on front page of user docs 