### PR TITLE
MLP: Print loss of all iterations in verbose mode

### DIFF
--- a/src/ports/postgres/modules/convex/mlp_igd.py_in
+++ b/src/ports/postgres/modules/convex/mlp_igd.py_in
@@ -322,12 +322,12 @@ def mlp(schema_madlib, source_table, output_table, independent_varname,
                             _state_current[{state_size}]) < {tolerance}
                         """):
                     break
-                if verbose and 1 < it.iteration <= n_iterations:
+                if verbose and it.iteration < n_iterations:
                     # Get loss value from the state.
                     res = it.get_param_value_per_group(
                         "_state_current[array_upper(_state_current, 1)] AS loss")
                     # Create a list of grouping values if grouping_cols was
-                    # used, it will be an empty list if there was not grouping.
+                    # used, it will be an empty list if there was no grouping.
                     groups = [t[col_grp_key] for t in res if t[col_grp_key]]
                     losses = [t['loss'] for t in res]
                     loss = zip(groups, losses) if groups else losses
@@ -359,7 +359,6 @@ def mlp(schema_madlib, source_table, output_table, independent_varname,
                          warm_start)
     plpy.execute("DROP TABLE IF EXISTS {0}".format(temp_output_table))
     return None
-
 
 def normalize_data(args):
     """

--- a/src/ports/postgres/modules/convex/utils_regularization.py_in
+++ b/src/ports/postgres/modules/convex/utils_regularization.py_in
@@ -7,6 +7,7 @@ from validation.cv_utils import __cv_split_data_using_id_tbl_compute
 from validation.cv_utils import __cv_generate_random_id
 from utilities.utilities import __mad_version
 from utilities.utilities import _check_groups
+from utilities.utilities import get_table_qualified_col_str
 from utilities.utilities import split_quoted_delimited_str
 
 version_wrapper = __mad_version()
@@ -219,9 +220,8 @@ def __utils_normalize_data_grouping(y_decenter=True, **kwargs):
     group_col_list = split_quoted_delimited_str(group_col)
     # If more than one column was specified for grouping, prefix each column
     # name with '{tbl_data}.' to avoid ambiguity.
-    select_grouping_cols = ', '.join(['{tbl_data}.{grp_col}'.format(
-                                        grp_col=grp_col, **kwargs)
-                                      for grp_col in group_col_list])
+    select_grouping_cols = get_table_qualified_col_str(kwargs.get('tbl_data'),
+                                                       group_col_list)
     x_mean_join_clause = ''
     y_mean_join_clause = ''
     if kwargs.get('x_mean_table'):

--- a/src/ports/postgres/modules/convex/utils_regularization.py_in
+++ b/src/ports/postgres/modules/convex/utils_regularization.py_in
@@ -217,6 +217,11 @@ def __utils_normalize_data_grouping(y_decenter=True, **kwargs):
     """
     group_col = kwargs.get('grouping_col')
     group_col_list = split_quoted_delimited_str(group_col)
+    # If more than one column was specified for grouping, prefix each column
+    # name with '{tbl_data}.' to avoid ambiguity.
+    select_grouping_cols = ', '.join(['{tbl_data}.{grp_col}'.format(
+                                        grp_col=grp_col, **kwargs)
+                                      for grp_col in group_col_list])
     x_mean_join_clause = ''
     y_mean_join_clause = ''
     if kwargs.get('x_mean_table'):
@@ -238,13 +243,15 @@ def __utils_normalize_data_grouping(y_decenter=True, **kwargs):
                                             __x__.std::double precision[]))
                     AS {col_ind_var_norm_new},
                 ({col_dep_var} {ydecenter_str})  AS {col_dep_var_norm_new},
-                {tbl_data}.{group_col}
+                {select_grouping_cols}
             FROM {tbl_data}
             {x_mean_join_clause}
             {y_mean_join_clause}
         """.format(ydecenter_str=ydecenter_str, group_col=group_col,
                     x_mean_join_clause=x_mean_join_clause,
-                    y_mean_join_clause=y_mean_join_clause, **kwargs))
+                    y_mean_join_clause=y_mean_join_clause,
+                    select_grouping_cols=select_grouping_cols,
+                    **kwargs))
     return None
 # ========================================================================
 

--- a/src/ports/postgres/modules/utilities/utilities.py_in
+++ b/src/ports/postgres/modules/utilities/utilities.py_in
@@ -760,8 +760,9 @@ def get_table_qualified_col_str(tbl_name, col_list):
 def get_grouping_col_str(schema_madlib, module_name, reserved_cols,
                          source_table, grouping_col):
     if grouping_col and grouping_col.lower() != 'null':
+        grouping_col_array = _string_to_array_with_quotes(grouping_col)
         cols_in_tbl_valid(source_table,
-                          _string_to_array_with_quotes(grouping_col),
+                          grouping_col_array,
                           module_name)
         intersect = frozenset(
             _string_to_array(grouping_col)).intersection(frozenset(reserved_cols))
@@ -773,7 +774,7 @@ def get_grouping_col_str(schema_madlib, module_name, reserved_cols,
         grouping_list = [i + "::text"
                          for i in explicit_bool_to_text(
                              source_table,
-                             _string_to_array_with_quotes(grouping_col),
+                             grouping_col_array,
                              schema_madlib)]
         grouping_str = ','.join(grouping_list)
     else:


### PR DESCRIPTION
JIRA: MADLIB-1228

- When verbose mode was set in mlp classification and regression training,
  the loss was printed only for 2 -> n-1 iterations. This commit fixes it
  and now prints loss for 1->n iterations (or whatever iteration
  convergence happens in).
- This commit also fixes another bug that was discovered in
  __utils_normalize_data_grouping in utilis_regularization.py_in. The
  issue was that if grouping_col had more than one column specified in
  it, the query used for normalization used to error out due to
  ambiguity in column names referenced. This commit prefixes the table
  name while accessing the grouping column names now.