### PR TITLE
Release 1.14: Version numbering and upgrade related changes

### DIFF
--- a/deploy/postflight.sh
+++ b/deploy/postflight.sh
@@ -2,7 +2,7 @@
 
 # $0 - Script Path, $1 - Package Path, $2 - Target Location, and $3 - Target Volume
 
-MADLIB_VERSION=1.14-dev
+MADLIB_VERSION=1.14
 
 find $2/usr/local/madlib/bin -type d -exec cp -RPf {} $2/usr/local/madlib/old_bin \; 2>/dev/null
 find $2/usr/local/madlib/bin -depth -type d -exec rm -r {} \; 2>/dev/null

--- a/doc/mainpage.dox.in
+++ b/doc/mainpage.dox.in
@@ -17,6 +17,7 @@ Useful links:
 <li><a href="https://mail-archives.apache.org/mod_mbox/madlib-user/">User mailing list</a></li>
 <li><a href="https://mail-archives.apache.org/mod_mbox/madlib-dev/">Dev mailing list</a></li>
 <li>User documentation for earlier releases:
+    <a href="../v1.14/index.html">v1.14</a>,
     <a href="../v1.13/index.html">v1.13</a>,
     <a href="../v1.12/index.html">v1.12</a>,
     <a href="../v1.11/index.html">v1.11</a>,

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.apache.madlib</groupId>
   <artifactId>madlib</artifactId>
-  <version>1.14-dev</version>
+  <version>1.14</version>
   <packaging>pom</packaging>
 
   <build>

--- a/src/config/Version.yml
+++ b/src/config/Version.yml
@@ -1,1 +1,1 @@
-version: 1.14-dev
+version: 1.14

--- a/src/madpack/changelist_1.12_1.13.yaml
+++ b/src/madpack/changelist_1.12_1.13.yaml
@@ -77,7 +77,7 @@ udf:
 # Overloaded functions should be mentioned separately
 uda:
     - mlp_igd_step:
-        rettype: mlp_step_result
+        rettype: schema_madlib.mlp_step_result
         argument: double precision[], double precision[], double precision[], double precision[], double precision, integer, integer, double precision, boolean, double precision[], integer, double precision, double precision[], double precision[]
 
 # Casts (UDC) updated/removed

--- a/src/madpack/changelist_1.13_1.14.yaml
+++ b/src/madpack/changelist_1.13_1.14.yaml
@@ -17,7 +17,7 @@
 # under the License.
 # ------------------------------------------------------------------------------
 
-# Changelist for MADlib version 1.12 to 1.13
+# Changelist for MADlib version 1.13 to 1.14
 
 # This file contains all changes that were introduced in a new version of
 # MADlib. This changelist is used by the upgrade script to detect what objects
@@ -28,12 +28,13 @@
 # file installed on the upgrade version. All other files (that don't have
 # updates), are cleaned up to remove object replacements
 new module:
-    # ----------------- Changes from 1.11 to 1.12 --------
-    hits:
+    # ----------------- Changes from 1.13 to 1.14 --------
+
 
 # Changes in the types (UDT) including removal and modification
 udt:
-
+    mlp_step_result:
+    summary_result:
 # List of the UDF changes that affect the user externally. This includes change
 # in function name, return type, argument order or types, or removal of
 # the function. In each case, the original function is as good as removed and a
@@ -41,45 +42,51 @@ udt:
 # are user views dependent on this function, since the original function will
 # not be present in the upgraded version.
 udf:
-    # ----------------- Changes from 1.12 to 1.13 ----------
+    # ----------------- Changes from 1.13 to 1.14 ----------
     - __build_tree:
         rettype: void
-        argument: boolean, text, text, text, text, text, boolean, character varying[], character varying[], character varying[], character varying[], text, text, integer, integer, integer, integer, text, smallint, text, integer
-    - mlp_classification:
-        rettype: void
-        argument: character varying, character varying, character varying, character varying
-    - mlp_igd_final:
-        rettype: mlp_step_result
-        argument: double precision[]
+        argument: boolean, text, text, text, text, text, boolean, text, character varying[], character varying[], character varying[], character varying[], text, text, integer, integer, integer, integer, text, smallint, text, integer
+    - internal_predict_mlp:
+        rettype: double precision[]
+        argument: double precision[], double precision[], double precision, double precision, double precision[], integer, double precision[], double precision[]
     - mlp_igd_transition:
         rettype: double precision[]
-        argument: double precision[], double precision[], double precision[], double precision[], double precision[], double precision, integer, integer, double precision, boolean, double precision[], integer, double precision, double precision[], double precision[]
-    - mlp_regression:
-        rettype: void
-        argument: character varying, character varying, character varying, character varying
-    - __knn_validate_src:
-        rettype: integer
-        argument: character varying, character varying, character varying, character varying, character varying, character varying, character varying, character varying, integer
-    - knn:
-        rettype: character varying
-        argument: character varying, character varying, character varying, character varying, character varying, character varying, character varying, character varying, integer
-    - knn:
-        rettype: character varying
-        argument: character varying, character varying, character varying, character varying, character varying, character varying, character varying, character varying
-    - knn:
-        rettype: void
-        argument: character varying
-    - knn:
-        rettype: void
+        argument: double precision[], double precision[], double precision[], double precision[], double precision[], double precision, integer, integer, double precision, boolean, double precision[], double precision
+    - summary:
+        rettype: schema_madlib.summary_result
+        argument: text, text
+    - summary:
+        rettype: schema_madlib.summary_result
+        argument: text, text, text
+    - summary:
+        rettype: schema_madlib.summary_result
+        argument: text, text, text, text
+    - summary:
+        rettype: schema_madlib.summary_result
+        argument: text, text, text, text, boolean
+    - summary:
+        rettype: schema_madlib.summary_result
+        argument: text, text, text, text, boolean, boolean
+    - summary:
+        rettype: schema_madlib.summary_result
+        argument: text, text, text, text, boolean, boolean, double precision[]
+    - summary:
+        rettype: schema_madlib.summary_result
+        argument: text, text, text, text, boolean, boolean, double precision[], integer
+    - summary:
+        rettype: schema_madlib.summary_result
+        argument: text, text, text, text, boolean, boolean, double precision[], integer, boolean
+    - summary:
+        rettype: schema_madlib.summary_result
+        argument: text, text, text, text, boolean, boolean, double precision[], integer, boolean, integer
 
 
 # Changes to aggregates (UDA) including removal and modification
 # Overloaded functions should be mentioned separately
 uda:
-    - mlp_igd_step:
-        rettype: mlp_step_result
-        argument: double precision[], double precision[], double precision[], double precision[], double precision, integer, integer, double precision, boolean, double precision[], integer, double precision, double precision[], double precision[]
-
+- mlp_igd_step:
+    rettype: double precision[]
+    argument: double precision[], double precision[], double precision[], double precision[], double precision, integer, integer, double precision, boolean, double precision[], double precision
 # Casts (UDC) updated/removed
 udc:
 

--- a/src/madpack/changelist_1.13_1.14.yaml
+++ b/src/madpack/changelist_1.13_1.14.yaml
@@ -29,6 +29,8 @@
 # updates), are cleaned up to remove object replacements
 new module:
     # ----------------- Changes from 1.13 to 1.14 --------
+    balance_sample:
+    minibatch_preprocessing:
 
 
 # Changes in the types (UDT) including removal and modification

--- a/src/madpack/template_changelist.yaml
+++ b/src/madpack/template_changelist.yaml
@@ -17,7 +17,7 @@
 # under the License.
 # ------------------------------------------------------------------------------
 
-# Changelist for MADlib version 1.12 to 1.13
+# Changelist for MADlib version <old> to <new>
 
 # This file contains all changes that were introduced in a new version of
 # MADlib. This changelist is used by the upgrade script to detect what objects
@@ -28,8 +28,8 @@
 # file installed on the upgrade version. All other files (that don't have
 # updates), are cleaned up to remove object replacements
 new module:
-    # ----------------- Changes from 1.11 to 1.12 --------
-    hits:
+    # ----------------- Changes from <old> to <new> --------
+
 
 # Changes in the types (UDT) including removal and modification
 udt:
@@ -41,44 +41,12 @@ udt:
 # are user views dependent on this function, since the original function will
 # not be present in the upgraded version.
 udf:
-    # ----------------- Changes from 1.12 to 1.13 ----------
-    - __build_tree:
-        rettype: void
-        argument: boolean, text, text, text, text, text, boolean, character varying[], character varying[], character varying[], character varying[], text, text, integer, integer, integer, integer, text, smallint, text, integer
-    - mlp_classification:
-        rettype: void
-        argument: character varying, character varying, character varying, character varying
-    - mlp_igd_final:
-        rettype: mlp_step_result
-        argument: double precision[]
-    - mlp_igd_transition:
-        rettype: double precision[]
-        argument: double precision[], double precision[], double precision[], double precision[], double precision[], double precision, integer, integer, double precision, boolean, double precision[], integer, double precision, double precision[], double precision[]
-    - mlp_regression:
-        rettype: void
-        argument: character varying, character varying, character varying, character varying
-    - __knn_validate_src:
-        rettype: integer
-        argument: character varying, character varying, character varying, character varying, character varying, character varying, character varying, character varying, integer
-    - knn:
-        rettype: character varying
-        argument: character varying, character varying, character varying, character varying, character varying, character varying, character varying, character varying, integer
-    - knn:
-        rettype: character varying
-        argument: character varying, character varying, character varying, character varying, character varying, character varying, character varying, character varying
-    - knn:
-        rettype: void
-        argument: character varying
-    - knn:
-        rettype: void
+    # ----------------- Changes from <old> to <new> ----------
 
 
 # Changes to aggregates (UDA) including removal and modification
 # Overloaded functions should be mentioned separately
 uda:
-    - mlp_igd_step:
-        rettype: mlp_step_result
-        argument: double precision[], double precision[], double precision[], double precision[], double precision, integer, integer, double precision, boolean, double precision[], integer, double precision, double precision[], double precision[]
 
 # Casts (UDC) updated/removed
 udc:

--- a/src/madpack/upgrade_util.py
+++ b/src/madpack/upgrade_util.py
@@ -71,7 +71,29 @@ class UpgradeBase:
         pg_catalog.pg_get_function_result in PG for a complete implementation, which are
         not supported by GP
         """
-        row = self._run_sql("""
+
+        # Check if the function has any arguments
+        proargtypes = self._run_sql(
+            """
+            SELECT
+                array_upper(proargtypes,1) as proargtypes
+            FROM pg_proc
+            WHERE oid = {oid}
+            """.format(oid=oid))
+        # If it does not have any arguments then the unnest will not return
+        # any rows. We need a single row with an empty string.
+        unnest_proargtypes = "\'\'::VARCHAR"
+        gen_series_proargtypes = "1"
+        if proargtypes[0]['proargtypes'] != "-1":
+            # Convert the argument types to text
+            unnest_proargtypes = "textin(regtypeout(unnest(proargtypes)::regtype))"
+            gen_series_proargtypes = "generate_series(0, array_upper(proargtypes, 1))"
+
+        # Convert the return type to text. The aggregate (max) is necessary for
+        # the array_to_string aggregate to work. Every row should have the same
+        # proname and rettype.
+        row = self._run_sql(
+            """
             SELECT
                 max(proname) AS proname,
                 max(rettype) AS rettype,
@@ -81,26 +103,14 @@ class UpgradeBase:
                 SELECT
                     proname,
                     textin(regtypeout(prorettype::regtype)) AS rettype,
-                    CASE array_upper(proargtypes,1) WHEN -1 THEN ''
-                        ELSE textin(regtypeout(foo))
-                    END AS argtype,
-                    CASE WHEN proargnames IS NULL THEN ''
-                        ELSE bar
-                    END AS argname,
-                    CASE array_upper(proargtypes,1) WHEN -1 THEN 1
-                        ELSE zee
-                    END AS i
+                    {unnest_proargtypes} AS argtype,
+                    {gen_series_proargtypes} AS i
                 FROM
-                    (SELECT *, oid,
-                        unnest(proargtypes)::regtype AS foo,
-                        unnest(proargnames) AS bar,
-                        generate_series(0, array_upper(proargtypes, 1)) AS zee
-                        FROM pg_proc
-                    ) AS p
+                    pg_proc AS p
                 WHERE
                     oid = {oid}
             ) AS f
-            """.format(oid=oid))
+            """.format(**locals()))
         return {"proname": row[0]['proname'],
                 "rettype": row[0]['rettype'],
                 "argument": row[0]['argument']}
@@ -1012,8 +1022,10 @@ class ScriptCleaner(UpgradeBase):
 
     def _get_existing_uda(self):
         """
-        @brief Get the existing UDAs in the current version
+        @brief Get the existing UDAs in the current version.
         """
+        # See _get_function_info for explanations.
+
         rows = self._run_sql("""
             SELECT
                 max(proname) AS proname,
@@ -1025,20 +1037,10 @@ class ScriptCleaner(UpgradeBase):
                     p.oid AS procoid,
                     proname,
                     textin(regtypeout(prorettype::regtype)) AS rettype,
-
-                    CASE array_upper(proargtypes,1) WHEN -1 THEN ''
-                        ELSE textin(regtypeout(foo))
-                    END AS argtype,
-
-                    CASE array_upper(proargtypes,1) WHEN -1 THEN 1
-                        ELSE zee
-                    END AS i
+                    textin(regtypeout(unnest(proargtypes)::regtype)) AS argtype,
+                    generate_series(0, array_upper(proargtypes, 1)) AS i
                 FROM
-                    (SELECT *, oid,
-                        unnest(proargtypes)::regtype AS foo,
-                        generate_series(0, array_upper(proargtypes, 1)) AS zee
-                        FROM pg_proc
-                    ) as p,
+                    pg_proc AS p,
                     pg_namespace AS nsp
                 WHERE
                     p.pronamespace = nsp.oid AND


### PR DESCRIPTION
Updates the version number to 1.14 for the release candidate.
Updates the changelists and other related files for upgrade.
Note that upgrade is not supported from versions prior to 1.11.

Co-authored-by: Nikhil Kak <nkak@pivotal.io>