### PR TITLE
Statistics: Add grouping support for correlation functions

### DIFF
--- a/doc/mainpage.dox.in
+++ b/doc/mainpage.dox.in
@@ -175,7 +175,7 @@ Contains graph algorithms.
             @defgroup grp_mfvsketch MFV (Most Frequent Values)
         @}
 
-        @defgroup grp_correlation Pearson's Correlation
+        @defgroup grp_correlation Covariance and Correlation
         @ingroup grp_desc_stats
 
         @defgroup grp_summary Summary

--- a/src/ports/postgres/modules/stats/correlation.py_in
+++ b/src/ports/postgres/modules/stats/correlation.py_in
@@ -14,9 +14,9 @@ from utilities.utilities import get_table_qualified_col_str
 from utilities.utilities import py_list_to_sql_string
 from utilities.utilities import split_quoted_delimited_str
 from utilities.utilities import unique_string
-from utilities.utilities import validate_reserved_and_target_cols_intersection
-from utilities.validate_args import get_cols_and_types
 from utilities.validate_args import cols_in_tbl_valid
+from utilities.validate_args import does_exclude_reserved
+from utilities.validate_args import get_cols_and_types
 from utilities.validate_args import input_tbl_valid
 from utilities.validate_args import output_tbl_valid
 
@@ -40,10 +40,7 @@ def correlation(schema_madlib, source_table, output_table,
         Tuple (output table name, number of columns, time for computation)
     """
     with MinWarning("info" if verbose else "error"):
-        if get_cov:
-            function_name = "Covariance"
-        else:
-            function_name = "Correlation"
+        function_name = 'Covariance' if get_cov else 'Correlation'
         _validate_corr_arg(source_table, output_table, function_name)
         _numeric_column_names, _nonnumeric_column_names = _get_numeric_columns(source_table)
         _target_cols = _analyze_target_cols(source_table, target_cols,
@@ -131,10 +128,8 @@ def _validate_grouping_cols_param(source_table, grouping_cols, function_name):
                                           'column_names',
                                           'mean_vector',
                                           'total_rows_processed'])
-    validate_reserved_and_target_cols_intersection(source_table,
-                                                   grouping_cols_list,
-                                                   reserved_cols_in_summary_table,
-                                                   function_name)
+    cols_in_tbl_valid(source_table, grouping_cols_list, function_name)
+    does_exclude_reserved(grouping_cols_list, reserved_cols_in_summary_table)
 
 def _get_numeric_columns(source_table):
     """
@@ -171,10 +166,8 @@ def _analyze_target_cols(source_table, target_cols, function_name):
         target_cols =  split_quoted_delimited_str(target_cols)
         reserved_cols_in_output_table = set(['column_position',
                                              'variable'])
-        validate_reserved_and_target_cols_intersection(source_table,
-                                                       target_cols,
-                                                       reserved_cols_in_output_table,
-                                                       function_name)
+        cols_in_tbl_valid(source_table, target_cols, function_name)
+        does_exclude_reserved(target_cols, reserved_cols_in_output_table)
     return target_cols
 # ------------------------------------------------------------------------------
 
@@ -283,22 +276,21 @@ def _populate_output_table(schema_madlib, source_table, output_table,
         # create output table
         plpy.info(col_names)
         create_output_table_query = """
-        CREATE TABLE {output_table} AS
-        SELECT {grouping_cols_comma} column_position, variable, {target_cols}
-        FROM
-        (
-            SELECT
-                generate_series(1, {num_cols}) AS column_position,
-                unnest({col_names_as_text_array}) AS variable
-        ) {variable_subquery}
-        JOIN
-        (
-            {deconstruction_query}
-        ) {matrix_subquery}
-        USING (column_position)
-        """.format( num_cols=len(col_names),
-                    target_cols=' , '.join(col_names),
-                    **locals())
+
+            CREATE TABLE {output_table} AS
+            SELECT *
+            FROM
+            (
+                SELECT
+                    generate_series(1, {num_cols}) AS column_position,
+                    unnest({col_names_as_text_array}) AS variable
+            ) {variable_subquery}
+            JOIN
+            (
+                {deconstruction_query}
+            ) {matrix_subquery}
+            USING (column_position)
+            """.format(num_cols=len(col_names), **locals())
         plpy.execute(create_output_table_query)
 
          # create summary table

--- a/src/ports/postgres/modules/stats/correlation.py_in
+++ b/src/ports/postgres/modules/stats/correlation.py_in
@@ -84,17 +84,19 @@ def correlation(schema_madlib, source_table, output_table,
                                       _existing_target_cols, grouping_cols,
                                       function_name, get_cov, verbose)
     # ---- Output message ----
-    output_text_list = ["Summary for 'correlation' function"]
+    output_text_list = ["Summary for '{0}' function".format(function_name)]
     output_text_list.append("Output table = " + str(output_table))
     if _nonnumeric_target_cols:
-        output_text_list.append(("Non-numeric columns ignored: {0}".
-                                 format(str(_nonnumeric_target_cols))))
+        output_text_list.append("Non-numeric columns ignored: {0}".
+                                 format(','.join(_nonnumeric_target_cols)))
     if _nonexisting_target_cols:
-        output_text_list.append(("Columns that don't exist in '{0}' ignored: {1}".
-                                format(source_table, str(_nonexisting_target_cols))))
-
-    output_text_list.append(("Producing correlation for columns: {0}".
-                            format(str(_existing_target_cols))))
+        output_text_list.append("Columns that don't exist in '{0}' ignored: {1}".
+                                format(source_table, ','.join(_nonexisting_target_cols)))
+    if grouping_cols:
+        output_text_list.append("Grouping columns: {0}".
+                                 format(grouping_cols))
+    output_text_list.append("Producing {0} for columns: {1}".
+                            format(function_name.lower(), ','.join(_existing_target_cols)))
     output_text_list.append("Total run time = " + str(run_time))
     # ---- Output message ----
     return '\n'.join(output_text_list)
@@ -274,7 +276,6 @@ def _populate_output_table(schema_madlib, source_table, output_table,
         variable_subquery = unique_string(desp='variable_subq')
         matrix_subquery = unique_string(desp='matrix_subq')
         # create output table
-        plpy.info(col_names)
         create_output_table_query = """
 
             CREATE TABLE {output_table} AS

--- a/src/ports/postgres/modules/stats/correlation.py_in
+++ b/src/ports/postgres/modules/stats/correlation.py_in
@@ -339,13 +339,17 @@ def _create_deconstruction_query(schema_madlib, col_names, grouping_cols,
     # With grouping, calling that UDF becomes a lot more complex, so
     # construct the query accordingly.
 
-    variable_list = []
-    for k, c in enumerate(col_names):
-        if k % 10 == 0:
-            variable_list.append("\n                ")
-        variable_list.append(str(c) + " float8")
-        variable_list.append(",")
-    variable_list_str = ''.join(variable_list[:-1])  # remove the last comma
+    COL_WIDTH = 10
+    # split the col_names to equal size sets with newline between to prevent a long query
+    # Build a 2d array of the col_names, each inner array with COL_WIDTH number of names.
+    col_names_split = [col_names[x : x + COL_WIDTH]
+                                 for x in range(0, len(col_names), COL_WIDTH)]
+    variable_list_str = ', \n'.join([', '.join(
+                                        ['{0} float8'.format(col)
+                                            for col in cols_blob
+                                         ]) for cols_blob in col_names_split
+                                     ])
+
 
     if grouping_cols:
         grp_dict_rows = plpy.execute("SELECT {0} FROM {1}".format(

--- a/src/ports/postgres/modules/stats/correlation.py_in
+++ b/src/ports/postgres/modules/stats/correlation.py_in
@@ -9,15 +9,21 @@ from time import time
 
 import plpy
 from utilities.control import MinWarning
-from utilities.utilities import unique_string, add_postfix
-from utilities.validate_args import get_cols_and_types
-from utilities.validate_args import input_tbl_valid, output_tbl_valid, cols_in_tbl_valid
+from utilities.utilities import add_postfix
+from utilities.utilities import get_table_qualified_col_str
 from utilities.utilities import py_list_to_sql_string
+from utilities.utilities import split_quoted_delimited_str
+from utilities.utilities import unique_string
+from utilities.utilities import validate_reserved_and_target_cols_intersection
+from utilities.validate_args import get_cols_and_types
+from utilities.validate_args import cols_in_tbl_valid
+from utilities.validate_args import input_tbl_valid
+from utilities.validate_args import output_tbl_valid
 
 
 def correlation(schema_madlib, source_table, output_table,
-                target_cols, get_cov=False, verbose=False,
-                **kwargs):
+                target_cols, grouping_cols, get_cov=False,
+                verbose=False, **kwargs):
     """
     Populates an output table with the coefficients of correlation between
     the columns in a source table
@@ -34,9 +40,18 @@ def correlation(schema_madlib, source_table, output_table,
         Tuple (output table name, number of columns, time for computation)
     """
     with MinWarning("info" if verbose else "error"):
-        _validate_corr_arg(source_table, output_table)
+        if get_cov:
+            function_name = "Covariance"
+        else:
+            function_name = "Correlation"
+        _validate_corr_arg(source_table, output_table, function_name)
         _numeric_column_names, _nonnumeric_column_names = _get_numeric_columns(source_table)
-        _target_cols = _analyze_target_cols(source_table, target_cols)
+        _target_cols = _analyze_target_cols(source_table, target_cols,
+                                            function_name)
+        # Validate grouping_cols param
+        if grouping_cols:
+            _validate_grouping_cols_param(source_table, grouping_cols,
+                                          function_name)
         if _target_cols:
             # prune all non-numeric column types from target columns
             _existing_target_cols = []
@@ -69,7 +84,8 @@ def correlation(schema_madlib, source_table, output_table,
             plpy.error("Correlation error: Only one numeric column found in the target list.")
 
     run_time = _populate_output_table(schema_madlib, source_table, output_table,
-                                      _existing_target_cols, get_cov, verbose)
+                                      _existing_target_cols, grouping_cols,
+                                      function_name, get_cov, verbose)
     # ---- Output message ----
     output_text_list = ["Summary for 'correlation' function"]
     output_text_list.append("Output table = " + str(output_table))
@@ -88,7 +104,7 @@ def correlation(schema_madlib, source_table, output_table,
 # ------------------------------------------------------------------------------
 
 
-def _validate_corr_arg(source_table, output_table):
+def _validate_corr_arg(source_table, output_table, function_name):
     """
     Validates all arguments and raises an error if there is an invalid argument
 
@@ -100,11 +116,25 @@ def _validate_corr_arg(source_table, output_table):
     Returns:
         True if all arguments are valid
     """
-    input_tbl_valid(source_table, "Correlation")
-    output_tbl_valid(output_table, "Correlation")
-    output_tbl_valid(add_postfix(output_table, "_summary"), "Correlation")
+    input_tbl_valid(source_table, function_name)
+    output_tbl_valid(output_table, function_name)
+    output_tbl_valid(add_postfix(output_table, "_summary"), function_name)
 # ------------------------------------------------------------------------------
 
+
+def _validate_grouping_cols_param(source_table, grouping_cols, function_name):
+    grouping_cols_list = split_quoted_delimited_str(grouping_cols)
+    # Column names that are used in summary table.
+    reserved_cols_in_summary_table = set(['method',
+                                          'source',
+                                          'output_table',
+                                          'column_names',
+                                          'mean_vector',
+                                          'total_rows_processed'])
+    validate_reserved_and_target_cols_intersection(source_table,
+                                                   grouping_cols_list,
+                                                   reserved_cols_in_summary_table,
+                                                   function_name)
 
 def _get_numeric_columns(source_table):
     """
@@ -131,21 +161,27 @@ def _get_numeric_columns(source_table):
 # ------------------------------------------------------------------------------
 
 
-def _analyze_target_cols(source_table, target_cols):
+def _analyze_target_cols(source_table, target_cols, function_name):
     """
     Analyzes target_cols string input and converts it to a list
     """
     if not target_cols or target_cols.strip() in ('', '*'):
         target_cols = None
     else:
-        target_cols = [i.strip() for i in target_cols.split(',')]
-        cols_in_tbl_valid(source_table, target_cols, "Correlation")
+        target_cols =  split_quoted_delimited_str(target_cols)
+        reserved_cols_in_output_table = set(['column_position',
+                                             'variable'])
+        validate_reserved_and_target_cols_intersection(source_table,
+                                                       target_cols,
+                                                       reserved_cols_in_output_table,
+                                                       function_name)
     return target_cols
 # ------------------------------------------------------------------------------
 
 
 def _populate_output_table(schema_madlib, source_table, output_table,
-                           col_names, get_cov=False, verbose=False):
+                           col_names, grouping_cols, function_name,
+                           get_cov=False, verbose=False):
     """
     Creates a relation with the appropriate number of columns given a list of
     column names and populates with the correlation coefficients. If the table
@@ -158,6 +194,7 @@ def _populate_output_table(schema_madlib, source_table, output_table,
         @param col_names      Name of all columns to place in output table
         @param get_cov        If False return the correlation matrix else
                                 return covariance matrix
+        @param grouping_cols  Name of all columns to be used for grouping
 
     Returns:
         Tuple (output table name, number of columns, time for computation)
@@ -166,101 +203,184 @@ def _populate_output_table(schema_madlib, source_table, output_table,
         start = time()
         col_len = len(col_names)
         col_names_as_text_array = py_list_to_sql_string(col_names, "varchar")
-        temp_table = unique_string()
+        # Create unique strings to be used in queries.
+        coalesced_col_array = unique_string(desp='coalesced_col_array')
+        mean_col = unique_string(desp='mean')
         if get_cov:
-            function_name = "Covariance"
             agg_str = """
                 (CASE WHEN count(*) > 0
-                      THEN {0}.array_scalar_mult({0}.covariance_agg(x, mean),
+                      THEN {0}.array_scalar_mult({0}.covariance_agg({1}, {2}),
                                                  1.0 / count(*)::double precision)
                       ELSE NULL
-                END) """.format(schema_madlib)
+                END) """.format(schema_madlib, coalesced_col_array, mean_col)
         else:
-            function_name = "Correlation"
-            agg_str = "{0}.correlation_agg(x, mean)".format(schema_madlib)
+            agg_str = "{0}.correlation_agg({1}, {2})".format(schema_madlib,
+                                                             coalesced_col_array,
+                                                             mean_col)
 
         cols = ','.join(["coalesce({0}, {1})".format(col, add_postfix(col, "_avg"))
                         for col in col_names])
         avgs = ','.join(["avg({0}) AS {1}".format(col, add_postfix(col, "_avg"))
                         for col in col_names])
         avg_array = ','.join([str(add_postfix(col, "_avg")) for col in col_names])
-        # actual computation
-        sql1 = """
+        # Create unique strings to be used in queries.
+        tot_cnt = unique_string(desp='tot_cnt')
+        cor_mat = unique_string(desp='cor_mat')
+        temp_output_table = unique_string(desp='temp_output')
+        subquery1 = unique_string(desp='subq1')
+        subquery2 = unique_string(desp='subq2')
 
-            CREATE TEMP TABLE {temp_table} AS
-            SELECT
-                count(*) AS tot_cnt,
-                mean,
-                {agg_str} as cor_mat
-            FROM
-            (
-                SELECT ARRAY[ {cols} ] AS x,
-                        ARRAY [ {avg_array} ] AS mean
-                FROM {source_table},
+        grouping_cols_comma = ''
+        subquery_grouping_cols_comma = ''
+        inner_group_by = ''
+        # Cross join if there are no groups to consider
+        join_condition = ' ON (1=1) '
+
+        if grouping_cols:
+            group_col_list = split_quoted_delimited_str(grouping_cols)
+            grouping_cols_comma = add_postfix(grouping_cols, ', ')
+            subquery_grouping_cols_comma = get_table_qualified_col_str(
+                                                subquery2, group_col_list) + " , "
+
+            inner_group_by = " GROUP BY {0}".format(grouping_cols)
+            join_condition = " USING ({0})".format(grouping_cols)
+
+        create_temp_output_table_query = """
+                CREATE TEMP TABLE {temp_output_table} AS
+                SELECT
+                    {subquery_grouping_cols_comma}
+                    count(*) AS {tot_cnt},
+                    {mean_col},
+                    {agg_str} AS {cor_mat}
+                FROM
                 (
-                    SELECT {avgs}
+                    SELECT {grouping_cols_comma}
+                           ARRAY[ {cols} ] AS {coalesced_col_array},
+                           ARRAY [ {avg_array} ] AS {mean_col}
+
                     FROM {source_table}
-                )sub1
-            ) sub2
-            GROUP BY mean
-            """.format(**locals())
+                    JOIN
+                    (
+                        SELECT {grouping_cols_comma} {avgs}
+                        FROM {source_table}
+                        {inner_group_by}
+                    ) {subquery1}
+                    {join_condition}
+                ) {subquery2}
+                GROUP BY {grouping_cols_comma} {mean_col}
+                """.format(**locals())
+        plpy.execute(create_temp_output_table_query)
 
-        plpy.execute(sql1)
+        # Prepare the query for converting the matrix into the lower triangle
+        deconstruction_query = _create_deconstruction_query(schema_madlib,
+                                                            col_names,
+                                                            grouping_cols,
+                                                            temp_output_table,
+                                                            cor_mat)
 
-        # create summary table
+        variable_subquery = unique_string(desp='variable_subq')
+        matrix_subquery = unique_string(desp='matrix_subq')
+        # create output table
+        plpy.info(col_names)
+        create_output_table_query = """
+        CREATE TABLE {output_table} AS
+        SELECT {grouping_cols_comma} column_position, variable, {target_cols}
+        FROM
+        (
+            SELECT
+                generate_series(1, {num_cols}) AS column_position,
+                unnest({col_names_as_text_array}) AS variable
+        ) {variable_subquery}
+        JOIN
+        (
+            {deconstruction_query}
+        ) {matrix_subquery}
+        USING (column_position)
+        """.format( num_cols=len(col_names),
+                    target_cols=' , '.join(col_names),
+                    **locals())
+        plpy.execute(create_output_table_query)
+
+         # create summary table
         summary_table = add_postfix(output_table, "_summary")
-        q_summary = """
+        create_summary_table_query = """
             CREATE TABLE {summary_table} AS
             SELECT
                 '{function_name}'::varchar  AS method,
                 '{source_table}'::varchar   AS source,
                 '{output_table}'::varchar   AS output_table,
                 {col_names_as_text_array}   AS column_names,
-                mean                        AS mean_vector,
-                tot_cnt                     AS total_rows_processed
-            FROM {temp_table}
+                {grouping_cols_comma}
+                {mean_col}                  AS mean_vector,
+                {tot_cnt}                   AS total_rows_processed
+            FROM {temp_output_table}
             """.format(**locals())
-
-        plpy.execute(q_summary)
-
-        # create output table
-        variable_list = []
-        for k, c in enumerate(col_names):
-            if k % 10 == 0:
-                variable_list.append("\n                ")
-            variable_list.append(str(c) + " float8")
-            variable_list.append(",")
-        variable_list_str = ''.join(variable_list[:-1])  # remove the last comma
-
-        plpy.execute("""
-            CREATE TABLE {output_table} AS
-            SELECT
-                *
-            FROM
-            (
-                SELECT
-                    generate_series(1, {num_cols}) AS column_position,
-                    unnest({col_names_as_text_array}) AS variable
-            ) variable_subq
-            JOIN
-            (
-                SELECT
-                    *
-                FROM
-                    {schema_madlib}.__deconstruct_lower_triangle(
-                        (SELECT cor_mat FROM {temp_table})
-                    )
-                    AS deconstructed(column_position integer, {variable_list_str})
-            ) matrix_subq
-            USING (column_position)
-            """.format(num_cols=len(col_names), **locals()))
+        plpy.execute(create_summary_table_query)
 
         # clean up and return
-        plpy.execute("DROP TABLE {temp_table}".format(**locals()))
+        plpy.execute("DROP TABLE IF EXISTS {temp_output_table}".format(**locals()))
+
         end = time()
         return (output_table, len(col_names), end - start)
 # ------------------------------------------------------------------------------
 
+def _create_deconstruction_query(schema_madlib, col_names, grouping_cols,
+                                 temp_output_table, cor_mat):
+    """
+    Creates the query to convert the matrix into the lower-traingular format.
+
+    Args:
+        @param schema_madlib        Schema of MADlib
+        @param col_names            Name of all columns to place in output table
+        @param grouping_cols        Name of all columns to be used for grouping
+        @param temp_output_table    Name of the temporary table that contains
+                                    the matrix to deconstruct
+        @param cor_mat              Name of column that containss the matrix
+                                    to deconstruct
+
+    Returns:
+        String (SQL querry for deconstructing the matrix)
+    """
+    # The matrix that holds the PCC computation must be converted to a
+    # table capturing all pair wise PCC values. That is done using
+    # a UDF named __deconstruct_lower_triangle.
+    # With grouping, calling that UDF becomes a lot more complex, so
+    # construct the query accordingly.
+
+    variable_list = []
+    for k, c in enumerate(col_names):
+        if k % 10 == 0:
+            variable_list.append("\n                ")
+        variable_list.append(str(c) + " float8")
+        variable_list.append(",")
+    variable_list_str = ''.join(variable_list[:-1])  # remove the last comma
+
+    if grouping_cols:
+        grp_dict_rows = plpy.execute("SELECT {0} FROM {1}".format(
+                                        grouping_cols,
+                                        temp_output_table))
+        deconstruction_queries_list = list()
+        for grp_dict in grp_dict_rows:
+            where_condition = 'WHERE ' + ' AND '.join("{0} = '{1}'".format(k, v)
+                                             for k, v in grp_dict.items())
+
+            select_grouping_cols = ' , '.join("'{1}' AS {0}".format(k, v)
+                                         for k, v in grp_dict.items())
+            deconstruction_queries_list.append("""
+                    SELECT {select_grouping_cols}, *
+                    FROM {schema_madlib}.__deconstruct_lower_triangle(
+                        (SELECT {cor_mat} FROM {temp_output_table} {where_condition})
+                    ) AS deconstructed(column_position integer, {variable_list_str})
+                """.format(**locals()))
+        deconstruction_query = ' UNION ALL '.join(deconstruction_queries_list)
+    else:
+        deconstruction_query = """
+            SELECT * FROM
+            {schema_madlib}.__deconstruct_lower_triangle(
+                (SELECT {cor_mat} FROM {temp_output_table})
+            ) AS deconstructed(column_position integer, {variable_list_str})
+        """.format(**locals())
+    return deconstruction_query
 
 def correlation_help_message(schema_madlib, message, cov=False, **kwargs):
     """
@@ -275,11 +395,12 @@ Usage:
 -----------------------------------------------------------------------
 SELECT {schema_madlib}.{func}
 (
-    source_table TEXT,   -- Source table name (Required)
-    output_table TEXT,   -- Output table name (Required)
-    target_cols  TEXT,   -- Comma separated columns for which summary is desired
-                         --   (Default: '*' - produces result for all columns)
-    verbose      BOOLEAN -- Verbosity
+    source_table   TEXT,    -- Source table name (Required)
+    output_table   TEXT,    -- Output table name (Required)
+    target_cols    TEXT,    -- Comma separated columns for which summary is desired
+                            --   (Default: '*' - produces result for all columns)
+    verbose        BOOLEAN, -- Verbosity
+    grouping_cols  TEXT     -- Comma separated columns for grouping
 )
 -----------------------------------------------------------------------
 Output will be a table with N+2 columns and N rows, where N is the number

--- a/src/ports/postgres/modules/stats/correlation.sql_in
+++ b/src/ports/postgres/modules/stats/correlation.sql_in
@@ -25,19 +25,23 @@ m4_include(`SQLCommon.m4')
 </ul>
 </div>
 
-@brief Generates a cross-correlation matrix for all pairs of numeric columns in a table.
+@brief Generates a cross-correlation matrix for pairs of numeric columns in a table.
 
 A correlation function is the degree and direction of association of two
-variables&mdash;how well one random variable can be predicted from the other. The
-coefficient of correlation varies from -1 to 1. A coefficient of 1 implies perfect
-correlation, 0 means no correlation, and -1 means perfect anti-correlation.
+variables&mdash;how well one random variable can be predicted from the other. 
+It is a normalized version of covariance.
+The Pearson correlation coefficient has a value between -1 and 1,
+where 1 implies total positive linear correlation, 0 means no linear correlation, 
+and -1 means total negative linear correlation.
 
-This function provides a cross-correlation matrix for all pairs of numeric
-columns in a <em>source_table</em>. A correlation matrix describes correlation
-among \f$ M \f$ variables. It is a square symmetrical \f$ M \f$x \f$M \f$ matrix
-with the \f$ (ij) \f$th element equal to the correlation coefficient between the
+This function generates an \f$N\f$x\f$N\f$ cross correlation matrix for 
+pairs of numeric columns in a <em>source_table</em>. It is square symmetrical
+with the \f$ (i,j) \f$th element equal to the correlation coefficient between the
 \f$i\f$th and the \f$j\f$th variable. The diagonal elements (correlations of
 variables with themselves) are always equal to 1.0.
+
+We also provide a covariance function which is similar in nature to correlation,
+and is a measure of the joint variability of two random variables.
 
 @anchor usage
 @par Correlation Function
@@ -52,61 +56,66 @@ correlation( source_table,
            )
 </pre>
 
-The covariance function, with a similar syntax,
-can be used to compute the covariance between features.
+The covariance function has a similar syntax:
 <pre class="syntax">
 covariance( source_table,
-             output_table,
-             target_cols,
-             verbose,
-             grouping_cols
-           )
+            output_table,
+            target_cols,
+            verbose,
+            grouping_cols
+          )
 </pre>
 
 <dl class="arglist">
 
 <dt>source_table</dt>
-<dd>TEXT. The name of the data containing the input data.</dd>
+<dd>TEXT. Name of the table containing the input data.</dd>
 
 <dt>output_table</dt>
-<dd>TEXT. The name of the table where the cross-correlation matrix will be saved.
-The output is a table with N+2 columns and N rows, where N is the number of
-target columns. It contains the following columns.
+<dd>TEXT. Name of the table containing the cross correlation matrix.
+The output table has N rows, where N is the number 
+of '<em>target_cols</em>' in the '<em>source_table'</em> for which 
+correlation or covariance is being computed. 
+It has the following columns:
 <table class="output">
 <tr>
-<th>grouping_cols</th>
-<td>Contains the grouping columns if applicable.</td>
-</tr>
-<tr>
 <th>column_position</th>
-<td>A sequential counter indicating the position of the variable in the '<em>output_table</em>' (for its group if applicable).</td>
+<td>An automatically generated sequential counter indicating the order of the 
+variable in the '<em>output_table</em>'.</td>
 </tr>
 <tr>
 <th>variable</th>
-<td>Contains the row-header for the variables.</td>
+<td>Contains the row header for the variables of interest.</td>
+</tr>
+<tr>
+<th>grouping_cols</th>
+<td>Contains the grouping columns, if any.</td>
 </tr>
 <tr>
 <th><...></th>
 <td>The remainder of the table is the NxN correlation matrix for the pairs of
-numeric 'source_table' columns.</td>
+variables of interest.</td>
 </tr>
 </table>
 The output table is arranged as a lower-triangular matrix with the upper
 triangle set to NULL and the diagonal elements set to 1.0. To obtain the result
-from the '<em>output_table</em>' in this matrix format ensure to order the
-elements using the '<em>column_position</em>', as shown in the example below.
+from the '<em>output_table</em>' order by '<em>column_position</em>':
 <pre class="example">
 SELECT * FROM output_table ORDER BY column_position;
 </pre>
 
 In addition to output table, a summary table named \<output_table\>_summary
-is also created at the same time, which has the following columns:
+is also created, which has the following columns:
 <table class="output">
-<tr><th>method</th><td>'correlation'</td></tr>
-<tr><th>source_table</th><td>VARCHAR. The data source table name.</td></tr>
-<tr><th>output_table</th><td>VARCHAR. The output table name.</td></tr>
-<tr><th>column_names</th><td>VARCHAR. Column names used for correlation computation, comma-separated string.</td></tr>
-<tr><th>mean_vector</th><td>FLOAT8[]. Vector where each is the mean of a column.</td></tr>
+<tr><th>method</th><td>'Correlation' or 'Covariance'</td></tr>
+<tr><th>source_table</th><td>VARCHAR. Data source table name.</td></tr>
+<tr><th>output_table</th><td>VARCHAR. Output table name.</td></tr>
+<tr><th>column_names</th><td>VARCHAR. Column names used for correlation 
+computation, as a comma-separated string.</td></tr>
+<tr><th>grouping_cols</th>
+<td>Contains the grouping columns, if any.</td></tr>
+<tr><th>mean_vector</th><td>FLOAT8[]. Mean value of column 
+for variables of interest.</td></tr>
 <tr>
   <th>total_rows_processed</th>
   <td>BIGINT. Total numbers of rows processed.</td>
@@ -119,7 +128,7 @@ is also created at the same time, which has the following columns:
 If NULL or <tt>'*'</tt>, results are produced for all numeric columns.</dd>
 
 <dt>verbose (optional)</dt>
-<dd>BOOLEAN, default: FALSE. Print verbose debugging information if TRUE.</dd>
+<dd>BOOLEAN, default: FALSE. Print verbose information if TRUE.</dd>
 
 <dt>grouping_cols (optional)</dt>
 <dd>TEXT, default: NULL. A comma-separated list of the columns to group by.</dd>
@@ -129,182 +138,204 @@ If NULL or <tt>'*'</tt>, results are produced for all numeric columns.</dd>
 @anchor examples
 @examp
 
--# View online help for the correlation function.
-<pre class="example">
-SELECT madlib.correlation();
-</pre>
-
 -# Create an input dataset.
 <pre class="example">
 DROP TABLE IF EXISTS example_data CASCADE;
-CREATE TABLE example_data(
-    id SERIAL, outlook TEXT,
-    temperature FLOAT8, humidity FLOAT8,
-    windy TEXT, class TEXT,
-    g TEXT);
+CREATE TABLE example_data( 
+    id SERIAL, 
+    outlook TEXT,
+    temperature FLOAT8, 
+    humidity FLOAT8,
+    windy TEXT, 
+    class TEXT,
+    day TEXT
+);
 INSERT INTO example_data VALUES
-(1, 'sunny', 85, 85, 'false', 'Dont Play', 1),
-(2, 'sunny', 80, 90, 'true', 'Dont Play', 1),
-(3, 'overcast', 83, 78, 'false', 'Play', 1),
-(4, 'rain', 70, 96, 'false', 'Play', 1),
-(5, 'rain', 68, 80, 'false', 'Play', 1),
-(6, 'rain', 65, 70, 'true', 'Dont Play', 1),
-(7, 'overcast', 64, 65, 'true', 'Play', 1),
-(8, 'sunny', 72, 95, 'false', 'Dont Play', 1),
-(9, 'sunny', 69, 70, 'false', 'Play', 1),
-(10, 'rain', 75, 80, 'false', 'Play', 1),
-(11, 'sunny', 75, 70, 'true', 'Play', 1),
-(12, 'overcast', 72, 90, 'true', 'Play', 1),
-(13, 'overcast', 81, 75, 'false', 'Play', 1),
-(14, 'rain', 71, 80, 'true', 'Dont Play', 1),
-(15, NULL, 100, 100, 'true', NULL, 1),
-(16, NULL, 110, 100, 'true', NULL, 1);
-INSERT INTO example_data VALUES
-(1, 'sunny', 85, 85, 'false', 'Dont Play', 2),
-(2, 'sunny', 80, 90, 'true', 'Dont Play', 2),
-(3, 'overcast', 83, 78, 'false', 'Play', 2),
-(4, 'rain', 70, 96, 'false', 'Play', 2),
-(5, 'rain', 68, 80, 'false', 'Play', 2),
-(6, 'rain', 65, 70, 'true', 'Dont Play', 2),
-(7, 'overcast', 64, 65, 'true', 'Play', 2),
-(8, 'sunny', 72, 95, 'false', 'Dont Play', 2),
-(9, 'sunny', 69, 70, 'false', 'Play', 2),
-(10, 'rain', 75, 80, 'false', 'Play', 2),
-(11, 'sunny', 75, 70, 'true', 'Play', 2),
-(12, 'overcast', 72, 90, 'true', 'Play', 2),
-(13, 'overcast', 81, 75, 'false', 'Play', 2),
-(14, 'rain', 71, 80, 'true', 'Dont Play', 2),
-(15, NULL, 100, 100, 'true', NULL, 2),
-(16, NULL, 110, 100, 'true', NULL, 2);
-INSERT INTO example_data VALUES
-(1, 'sunny', 85, 85, 'false', 'Dont Play', 3),
-(2, 'sunny', 80, 90, 'true', 'Dont Play', 3),
-(3, 'overcast', 83, 78, 'false', 'Play', 3),
-(4, 'rain', 70, 96, 'false', 'Play', 3),
-(5, 'rain', 68, 80, 'false', 'Play', 3),
-(6, 'rain', 65, 70, 'true', 'Dont Play', 3),
-(7, 'overcast', 64, 65, 'true', 'Play', 3),
-(8, 'sunny', 7, 95, 'false', 'Dont Play', 3),
-(9, 'sunny', 6, 70, 'false', 'Play', 3),
-(10, 'rain', 7, 80, 'false', 'Play', 3),
-(11, 'sunny', 75, 70, 'true', 'Play', 3),
-(12, 'overcast', 72, 90, 'true', 'Play', 3),
-(13, 'overcast', 81, 75, 'false', 'Play', 3),
-(14, 'rain', 71, 80, 'true', 'Dont Play', 3),
-(15, NULL, 10, 100, 'true', NULL, 3),
-(16, NULL, 10, 100, 'true', NULL, 3),
-(21, 'sunny', 85, 85, 'false', 'Dont Play', 3),
-(22, 'sunny', 80, 9, 'true', 'Dont Play', 3),
-(23, 'overcast', 83, 78, 'false', 'Play', 3),
-(24, 'rain', 70, 9, 'false', 'Play', 3),
-(25, 'rain', 68, 80, 'false', 'Play', 3),
-(26, 'rain', 65, 7, 'true', 'Dont Play', 3),
-(27, 'overcast', 64, 65, 'true', 'Play', 3),
-(28, 'sunny', 72, 95, 'false', 'Dont Play', 3),
-(29, 'sunny', 69, 7, 'false', 'Play', 3),
-(210, 'rain', 75, 8, 'false', 'Play', 3),
-(211, 'sunny', 75, 70, 'true', 'Play', 3),
-(212, 'overcast', 72, 90, 'true', 'Play', 3),
-(213, 'overcast', 1, 75, 'false', 'Play', 3),
-(214, 'rain', 71, 80, 'true', 'Dont Play', 3),
-(215, NULL, 100, 100, 'true', NULL, 3),
-(216, NULL, 110, 100, 'true', NULL, 3);
+(1, 'sunny', 85, 85, 'false', 'Dont Play', 'Mon'),
+(2, 'sunny', 80, 90, 'true', 'Dont Play', 'Mon'),
+(3, 'overcast', 83, 78, 'false', 'Play', 'Mon'),
+(4, 'rain', 70, 96, 'false', 'Play', 'Mon'),
+(5, 'rain', 68, 80, 'false', 'Play', 'Mon'),
+(6, 'rain', 65, 70, 'true', 'Dont Play', 'Mon'),
+(7, 'overcast', 64, 65, 'true', 'Play', 'Mon'),
+(8, 'sunny', 72, 95, 'false', 'Dont Play', 'Mon'),
+(9, 'sunny', 69, 70, 'false', 'Play', 'Mon'),
+(10, 'rain', 75, 80, 'false', 'Play', 'Mon'),
+(11, 'sunny', 75, 70, 'true', 'Play', 'Mon'),
+(12, 'overcast', 72, 90, 'true', 'Play', 'Mon'),
+(13, 'overcast', 81, 75, 'false', 'Play', 'Mon'),
+(14, 'rain', 71, 80, 'true', 'Dont Play', 'Mon'),
+(15, NULL, 100, 100, 'true', NULL, 'Mon'),
+(16, NULL, 110, 100, 'true', NULL, 'Mon'),
+(101, 'sunny', 85, 85, 'false', 'Dont Play', 'Tues'),
+(102, 'sunny', 80, 90, 'true', 'Dont Play', 'Tues'),
+(103, 'overcast', 83, 78, 'false', 'Play', 'Tues'),
+(104, 'rain', 70, 96, 'false', 'Play', 'Tues'),
+(105, 'rain', 68, 80, 'false', 'Play', 'Tues'),
+(106, 'rain', 65, 70, 'true', 'Dont Play', 'Tues'),
+(107, 'overcast', 64, 65, 'true', 'Play', 'Tues'),
+(108, 'sunny', 72, 95, 'false', 'Dont Play', 'Tues'),
+(109, 'sunny', 69, 70, 'false', 'Play', 'Tues'),
+(110, 'rain', 75, 80, 'false', 'Play', 'Tues'),
+(111, 'sunny', 75, 70, 'true', 'Play', 'Tues'),
+(112, 'overcast', 72, 90, 'true', 'Play', 'Tues'),
+(113, 'overcast', 81, 75, 'false', 'Play', 'Tues'),
+(114, 'rain', 71, 80, 'true', 'Dont Play', 'Tues'),
+(115, NULL, 100, 100, 'true', NULL, 'Tues'),
+(116, NULL, 110, 100, 'true', NULL, 'Tues'),
+(201, 'sunny', 85, 85, 'false', 'Dont Play', 'Wed'),
+(202, 'sunny', 80, 90, 'true', 'Dont Play', 'Wed'),
+(203, 'overcast', 83, 78, 'false', 'Play', 'Wed'),
+(204, 'rain', 70, 96, 'false', 'Play', 'Wed'),
+(205, 'rain', 68, 80, 'false', 'Play', 'Wed'),
+(206, 'rain', 65, 70, 'true', 'Dont Play', 'Wed'),
+(207, 'overcast', 64, 65, 'true', 'Play', 'Wed'),
+(208, 'sunny', 7, 95, 'false', 'Dont Play', 'Wed'),
+(209, 'sunny', 6, 70, 'false', 'Play', 'Wed'),
+(210, 'rain', 7, 80, 'false', 'Play', 'Wed'),
+(211, 'sunny', 75, 70, 'true', 'Play', 'Wed'),
+(212, 'overcast', 72, 90, 'true', 'Play', 'Wed'),
+(213, 'overcast', 81, 75, 'false', 'Play', 'Wed'),
+(214, 'rain', 71, 80, 'true', 'Dont Play', 'Wed'),
+(215, NULL, 10, 100, 'true', NULL, 'Wed'),
+(216, NULL, 10, 100, 'true', NULL, 'Wed'),
+(217, 'sunny', 85, 85, 'false', 'Dont Play', 'Wed'),
+(218, 'sunny', 80, 9, 'true', 'Dont Play', 'Wed'),
+(219, 'overcast', 83, 78, 'false', 'Play', 'Wed'),
+(220, 'rain', 70, 9, 'false', 'Play', 'Wed'),
+(221, 'rain', 68, 80, 'false', 'Play', 'Wed');
 </pre>
 
-
--# Create a view for a single group.
+-# Get correlation between temperature and humidity:
 <pre class="example">
-DROP VIEW IF EXISTS example_view;
-CREATE VIEW example_view AS SELECT * FROM example_data WHERE g = '1';
-</pre>
-
--# Run the correlation() function on the dataset.
-<pre class="example">
--- Correlate all numeric columns
-DROP TABLE IF EXISTS example_view_output, example_view_output_summary;
-SELECT madlib.correlation( 'example_view',
-                           'example_view_output'
-                         );
--- Setting target_cols to NULL or '*' also correlates all numeric columns
-DROP TABLE IF EXISTS example_view_output, example_view_output_summary;
-SELECT madlib.correlation( 'example_view',
-                           'example_view_output',
-                           '*'
-                         );
--- Correlate only the temperature and humidity columns
-DROP TABLE IF EXISTS example_view_output, example_view_output_summary;
-SELECT madlib.correlation( 'example_view',
-                           'example_view_output',
+DROP TABLE IF EXISTS example_data_output, example_data_output_summary;
+SELECT madlib.correlation( 'example_data',
+                           'example_data_output',
                            'temperature, humidity'
                          );
 </pre>
-
--# View the correlation matrix.
+View the correlation matrix:
 <pre class="example">
-SELECT * FROM example_view_output ORDER BY column_position;
+SELECT * FROM example_data_output ORDER BY column_position; 
 </pre>
-Result:
 <pre class="result">
- column_position |  variable   |    temperature    | humidity
------------------+-------------+-------------------+----------
-               1 | temperature |               1.0 |
-               2 | humidity    | 0.616876934548786 |      1.0
+ column_position |  variable   |     temperature     | humidity 
+-----------------+-------------+---------------------+----------
+               1 | temperature |                   1 |         
+               2 | humidity    | 0.00607993890408995 |        1
 (2 rows)
 </pre>
-
--# Compute the correlation for multiple groups
+View the summary table:
 <pre class="example">
+\\x on
+SELECT * FROM example_data_output_summary; 
+</pre>
+<pre class="result">
+-[ RECORD 1 ]--------+-----------------------------------
+method               | Correlation
+source               | example_data
+output_table         | example_data_output
+column_names         | {temperature,humidity}
+mean_vector          | {70.188679245283,79.8679245283019}
+total_rows_processed | 53
+</pre>
+
+-# Correlation with grouping by day:
+<pre class="example">
+\\x off
 DROP TABLE IF EXISTS example_data_output, example_data_output_summary;
 SELECT madlib.correlation( 'example_data',
                            'example_data_output',
                            'temperature, humidity',
                            FALSE,
-                           'g'
+                           'day'
                          );
 </pre>
-
--# View the correlation matrix.
+View the correlation matrix by group:
 <pre class="example">
-SELECT * FROM example_data_output ORDER BY g, column_position;
+SELECT * FROM example_data_output ORDER BY day, column_position;
 </pre>
-Result:
 <pre class="result">
- g | column_position |  variable   |    temperature     | humidity
----+-----------------+-------------+--------------------+----------
- 1 |               1 | temperature |                  1 |
- 1 |               2 | humidity    |  0.616876934548786 |        1
- 2 |               1 | temperature |                  1 |
- 2 |               2 | humidity    |  0.616876934548786 |        1
- 3 |               1 | temperature |                  1 |
- 3 |               2 | humidity    | -0.120552853814947 |        1
-(2 rows)
+ column_position |  variable   | day  |    temperature    | humidity 
+-----------------+-------------+------+-------------------+----------
+               1 | temperature | Mon  |                 1 |         
+               2 | humidity    | Mon  | 0.616876934548786 |        1
+               1 | temperature | Tues |                 1 |         
+               2 | humidity    | Tues | 0.616876934548786 |        1
+               1 | temperature | Wed  |                 1 |         
+               2 | humidity    | Wed  | -0.28969669368457 |        1
+(6 rows)
+</pre>
+View the summary table:
+<pre class="example">
+\\x on
+SELECT * FROM example_data_output_summary ORDER BY day; 
+</pre>
+<pre class="result">
+-[ RECORD 1 ]--------+------------------------------------
+method               | Correlation
+source               | example_data
+output_table         | example_data_output
+column_names         | {temperature,humidity}
+day                  | Mon
+mean_vector          | {77.5,82.75}
+total_rows_processed | 16
+-[ RECORD 2 ]--------+------------------------------------
+method               | Correlation
+source               | example_data
+output_table         | example_data_output
+column_names         | {temperature,humidity}
+day                  | Tues
+mean_vector          | {77.5,82.75}
+total_rows_processed | 16
+-[ RECORD 3 ]--------+------------------------------------
+method               | Correlation
+source               | example_data
+output_table         | example_data_output
+column_names         | {temperature,humidity}
+day                  | Wed
+mean_vector          | {59.0476190476191,75.4761904761905}
+total_rows_processed | 21
 </pre>
 
--# Compute the covariance of features in the dataset.
+-# Get covariance between temperature and humidity:
 <pre class="example">
-DROP TABLE IF EXISTS cov_output, cov_output_summary;
-SELECT madlib.covariance( 'example_view',
-                          'cov_output',
-                           'temperature, humidity'
+\\x off
+DROP TABLE IF EXISTS example_data_output, example_data_output_summary;
+SELECT madlib.covariance( 'example_data',
+                          'example_data_output',
+                          'temperature, humidity'
                          );
 </pre>
-
--# View the covariance matrix.
+View the covariance matrix:
 <pre class="example">
-SELECT * FROM cov_output ORDER BY column_position;
+SELECT * FROM example_data_output ORDER BY column_position; 
 </pre>
-Result:
 <pre class="result">
- column_position |  variable   |    temperature    | humidity
------------------+-------------+-------------------+----------
-               1 | temperature |      146.25       |
-               2 | humidity    |      82.125       | 121.1875
+ column_position |  variable   |   temperature    |     humidity     
+-----------------+-------------+------------------+------------------
+               1 | temperature | 507.926664293343 |                 
+               2 | humidity    | 2.40227839088644 | 307.359914560342
 (2 rows)
+</pre>
+View the summary table:
+<pre class="example">
+\\x on
+SELECT * FROM example_data_output_summary; 
+</pre>
+<pre class="result">
+-[ RECORD 1 ]--------+-----------------------------------
+method               | Covariance
+source               | example_data
+output_table         | example_data_output
+column_names         | {temperature,humidity}
+mean_vector          | {70.188679245283,79.8679245283019}
+total_rows_processed | 53
 </pre>
 
 @par Notes
 
-Null values will be replaced by the mean of their respective columns (Mean
+Null values will be replaced by the mean of their respective columns (mean
 imputation/substitution). Mean imputation is a method in which the missing
 value on a certain variable is replaced by the mean of the available cases.
 This method maintains the sample size and is easy to use, but the variability

--- a/src/ports/postgres/modules/stats/correlation.sql_in
+++ b/src/ports/postgres/modules/stats/correlation.sql_in
@@ -47,7 +47,8 @@ The correlation function has the following syntax:
 correlation( source_table,
              output_table,
              target_cols,
-             verbose
+             verbose,
+             grouping_cols
            )
 </pre>
 
@@ -57,7 +58,8 @@ can be used to compute the covariance between features.
 covariance( source_table,
              output_table,
              target_cols,
-             verbose
+             verbose,
+             grouping_cols
            )
 </pre>
 
@@ -72,12 +74,16 @@ The output is a table with N+2 columns and N rows, where N is the number of
 target columns. It contains the following columns.
 <table class="output">
 <tr>
+<th>grouping_cols</th>
+<td>Contains the grouping columns if applicable.</td>
+</tr>
+<tr>
 <th>column_position</th>
-<td>The first column is a sequential counter indicating the position of the variable in the '<em>output_table</em>'.</td>
+<td>A sequential counter indicating the position of the variable in the '<em>output_table</em>' (for its group if applicable).</td>
 </tr>
 <tr>
 <th>variable</th>
-<td>The second column contains the row-header for the variables.</td>
+<td>Contains the row-header for the variables.</td>
 </tr>
 <tr>
 <th><...></th>
@@ -115,6 +121,8 @@ If NULL or <tt>'*'</tt>, results are produced for all numeric columns.</dd>
 <dt>verbose (optional)</dt>
 <dd>BOOLEAN, default: FALSE. Print verbose debugging information if TRUE.</dd>
 
+<dt>grouping_cols (optional)</dt>
+<dd>TEXT, default: NULL. A comma-separated list of the columns to group by.</dd>
 </dl>
 
 
@@ -126,53 +134,114 @@ If NULL or <tt>'*'</tt>, results are produced for all numeric columns.</dd>
 SELECT madlib.correlation();
 </pre>
 
--# Create an input data set.
+-# Create an input dataset.
 <pre class="example">
-DROP TABLE IF EXISTS example_data;
+DROP TABLE IF EXISTS example_data CASCADE;
 CREATE TABLE example_data(
     id SERIAL, outlook TEXT,
     temperature FLOAT8, humidity FLOAT8,
-    windy TEXT, class TEXT);
+    windy TEXT, class TEXT,
+    g TEXT);
 INSERT INTO example_data VALUES
-(1, 'sunny', 85, 85, 'false', 'Dont Play'),
-(2, 'sunny', 80, 90, 'true', 'Dont Play'),
-(3, 'overcast', 83, 78, 'false', 'Play'),
-(4, 'rain', 70, 96, 'false', 'Play'),
-(5, 'rain', 68, 80, 'false', 'Play'),
-(6, 'rain', 65, 70, 'true', 'Dont Play'),
-(7, 'overcast', 64, 65, 'true', 'Play'),
-(8, 'sunny', 72, 95, 'false', 'Dont Play'),
-(9, 'sunny', 69, 70, 'false', 'Play'),
-(10, 'rain', 75, 80, 'false', 'Play'),
-(11, 'sunny', 75, 70, 'true', 'Play'),
-(12, 'overcast', 72, 90, 'true', 'Play'),
-(13, 'overcast', 81, 75, 'false', 'Play'),
-(14, 'rain', 71, 80, 'true', 'Dont Play'),
-(15, NULL, 100, 100, 'true', NULL),
-(16, NULL, 110, 100, 'true', NULL);
+(1, 'sunny', 85, 85, 'false', 'Dont Play', 1),
+(2, 'sunny', 80, 90, 'true', 'Dont Play', 1),
+(3, 'overcast', 83, 78, 'false', 'Play', 1),
+(4, 'rain', 70, 96, 'false', 'Play', 1),
+(5, 'rain', 68, 80, 'false', 'Play', 1),
+(6, 'rain', 65, 70, 'true', 'Dont Play', 1),
+(7, 'overcast', 64, 65, 'true', 'Play', 1),
+(8, 'sunny', 72, 95, 'false', 'Dont Play', 1),
+(9, 'sunny', 69, 70, 'false', 'Play', 1),
+(10, 'rain', 75, 80, 'false', 'Play', 1),
+(11, 'sunny', 75, 70, 'true', 'Play', 1),
+(12, 'overcast', 72, 90, 'true', 'Play', 1),
+(13, 'overcast', 81, 75, 'false', 'Play', 1),
+(14, 'rain', 71, 80, 'true', 'Dont Play', 1),
+(15, NULL, 100, 100, 'true', NULL, 1),
+(16, NULL, 110, 100, 'true', NULL, 1);
+INSERT INTO example_data VALUES
+(1, 'sunny', 85, 85, 'false', 'Dont Play', 2),
+(2, 'sunny', 80, 90, 'true', 'Dont Play', 2),
+(3, 'overcast', 83, 78, 'false', 'Play', 2),
+(4, 'rain', 70, 96, 'false', 'Play', 2),
+(5, 'rain', 68, 80, 'false', 'Play', 2),
+(6, 'rain', 65, 70, 'true', 'Dont Play', 2),
+(7, 'overcast', 64, 65, 'true', 'Play', 2),
+(8, 'sunny', 72, 95, 'false', 'Dont Play', 2),
+(9, 'sunny', 69, 70, 'false', 'Play', 2),
+(10, 'rain', 75, 80, 'false', 'Play', 2),
+(11, 'sunny', 75, 70, 'true', 'Play', 2),
+(12, 'overcast', 72, 90, 'true', 'Play', 2),
+(13, 'overcast', 81, 75, 'false', 'Play', 2),
+(14, 'rain', 71, 80, 'true', 'Dont Play', 2),
+(15, NULL, 100, 100, 'true', NULL, 2),
+(16, NULL, 110, 100, 'true', NULL, 2);
+INSERT INTO example_data VALUES
+(1, 'sunny', 85, 85, 'false', 'Dont Play', 3),
+(2, 'sunny', 80, 90, 'true', 'Dont Play', 3),
+(3, 'overcast', 83, 78, 'false', 'Play', 3),
+(4, 'rain', 70, 96, 'false', 'Play', 3),
+(5, 'rain', 68, 80, 'false', 'Play', 3),
+(6, 'rain', 65, 70, 'true', 'Dont Play', 3),
+(7, 'overcast', 64, 65, 'true', 'Play', 3),
+(8, 'sunny', 7, 95, 'false', 'Dont Play', 3),
+(9, 'sunny', 6, 70, 'false', 'Play', 3),
+(10, 'rain', 7, 80, 'false', 'Play', 3),
+(11, 'sunny', 75, 70, 'true', 'Play', 3),
+(12, 'overcast', 72, 90, 'true', 'Play', 3),
+(13, 'overcast', 81, 75, 'false', 'Play', 3),
+(14, 'rain', 71, 80, 'true', 'Dont Play', 3),
+(15, NULL, 10, 100, 'true', NULL, 3),
+(16, NULL, 10, 100, 'true', NULL, 3),
+(21, 'sunny', 85, 85, 'false', 'Dont Play', 3),
+(22, 'sunny', 80, 9, 'true', 'Dont Play', 3),
+(23, 'overcast', 83, 78, 'false', 'Play', 3),
+(24, 'rain', 70, 9, 'false', 'Play', 3),
+(25, 'rain', 68, 80, 'false', 'Play', 3),
+(26, 'rain', 65, 7, 'true', 'Dont Play', 3),
+(27, 'overcast', 64, 65, 'true', 'Play', 3),
+(28, 'sunny', 72, 95, 'false', 'Dont Play', 3),
+(29, 'sunny', 69, 7, 'false', 'Play', 3),
+(210, 'rain', 75, 8, 'false', 'Play', 3),
+(211, 'sunny', 75, 70, 'true', 'Play', 3),
+(212, 'overcast', 72, 90, 'true', 'Play', 3),
+(213, 'overcast', 1, 75, 'false', 'Play', 3),
+(214, 'rain', 71, 80, 'true', 'Dont Play', 3),
+(215, NULL, 100, 100, 'true', NULL, 3),
+(216, NULL, 110, 100, 'true', NULL, 3);
 </pre>
 
--# Run the correlation() function on the data set.
+
+-# Create a view for a single group.
+<pre class="example">
+DROP VIEW IF EXISTS example_view;
+CREATE VIEW example_view AS SELECT * FROM example_data WHERE g = '1';
+</pre>
+
+-# Run the correlation() function on the dataset.
 <pre class="example">
 -- Correlate all numeric columns
-SELECT madlib.correlation( 'example_data',
-                           'example_data_output'
+DROP TABLE IF EXISTS example_view_output, example_view_output_summary;
+SELECT madlib.correlation( 'example_view',
+                           'example_view_output'
                          );
 -- Setting target_cols to NULL or '*' also correlates all numeric columns
-SELECT madlib.correlation( 'example_data',
-                           'example_data_output',
+DROP TABLE IF EXISTS example_view_output, example_view_output_summary;
+SELECT madlib.correlation( 'example_view',
+                           'example_view_output',
                            '*'
                          );
 -- Correlate only the temperature and humidity columns
-SELECT madlib.correlation( 'example_data',
-                           'example_data_output',
+DROP TABLE IF EXISTS example_view_output, example_view_output_summary;
+SELECT madlib.correlation( 'example_view',
+                           'example_view_output',
                            'temperature, humidity'
                          );
 </pre>
 
 -# View the correlation matrix.
 <pre class="example">
-SELECT * FROM example_data_output ORDER BY column_position;
+SELECT * FROM example_view_output ORDER BY column_position;
 </pre>
 Result:
 <pre class="result">
@@ -183,10 +252,40 @@ Result:
 (2 rows)
 </pre>
 
--# Compute the covariance of features in the data set.
+-# Compute the correlation for multiple groups
 <pre class="example">
-SELECT madlib.covariance( 'example_data',
-                          'cov_output'
+DROP TABLE IF EXISTS example_data_output, example_data_output_summary;
+SELECT madlib.correlation( 'example_data',
+                           'example_data_output',
+                           'temperature, humidity',
+                           FALSE,
+                           'g'
+                         );
+</pre>
+
+-# View the correlation matrix.
+<pre class="example">
+SELECT * FROM example_data_output ORDER BY g, column_position;
+</pre>
+Result:
+<pre class="result">
+ g | column_position |  variable   |    temperature     | humidity
+---+-----------------+-------------+--------------------+----------
+ 1 |               1 | temperature |                  1 |
+ 1 |               2 | humidity    |  0.616876934548786 |        1
+ 2 |               1 | temperature |                  1 |
+ 2 |               2 | humidity    |  0.616876934548786 |        1
+ 3 |               1 | temperature |                  1 |
+ 3 |               2 | humidity    | -0.120552853814947 |        1
+(2 rows)
+</pre>
+
+-# Compute the covariance of features in the dataset.
+<pre class="example">
+DROP TABLE IF EXISTS cov_output, cov_output_summary;
+SELECT madlib.covariance( 'example_view',
+                          'cov_output',
+                           'temperature, humidity'
                          );
 </pre>
 
@@ -307,10 +406,11 @@ CREATE AGGREGATE MADLIB_SCHEMA.covariance_agg(
    </pre>
 */
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.correlation(
-    source_table varchar, --  input table name
+    source_table varchar, -- input table name
     output_table varchar, -- output table name
     target_cols  varchar, -- comma separated list of output cols (default = '*')
-    verbose      boolean  -- flag to determine verbosity
+    verbose      boolean, -- flag to determine verbosity
+    grouping_cols varchar -- comma separated column names to be used for grouping
 ) RETURNS TEXT AS $$
     PythonFunction(stats, correlation, correlation)
 $$ LANGUAGE plpythonu VOLATILE
@@ -322,10 +422,21 @@ m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.correlation(
     source_table varchar, --  input table name
     output_table varchar, -- output table name
+    target_cols  varchar,  -- comma separated list of output cols (default = '*')
+    verbose      boolean  -- flag to determine verbosity
+)
+RETURNS TEXT AS $$
+    select MADLIB_SCHEMA.correlation($1, $2, $3, $4, NULL)
+$$ LANGUAGE sql VOLATILE
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.correlation(
+    source_table varchar, --  input table name
+    output_table varchar, -- output table name
     target_cols  varchar  -- comma separated list of output cols (default = '*')
 )
 RETURNS TEXT AS $$
-    select MADLIB_SCHEMA.correlation($1, $2, $3, FALSE)
+    select MADLIB_SCHEMA.correlation($1, $2, $3, FALSE, NULL)
 $$ LANGUAGE sql VOLATILE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -334,7 +445,7 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.correlation(
     source_table varchar, --  input table name
     output_table varchar  -- output table name
 ) RETURNS TEXT AS $$
-    select MADLIB_SCHEMA.correlation($1, $2, NULL)
+    select MADLIB_SCHEMA.correlation($1, $2, NULL, FALSE, NULL)
 $$ LANGUAGE sql VOLATILE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -380,11 +491,12 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.covariance(
     source_table varchar, --  input table name
     output_table varchar, -- output table name
     target_cols  varchar, -- comma separated list of output cols (default = '*')
-    verbose      boolean  -- flag to determine verbosity
+    verbose      boolean, -- flag to determine verbosity
+    grouping_cols varchar -- comma separated column names to be used for grouping
 ) RETURNS TEXT AS $$
     PythonFunctionBodyOnly(`stats', `correlation')
     return correlation.correlation(schema_madlib, source_table, output_table,
-                                   target_cols, True, verbose)
+                                   target_cols, grouping_cols, True, verbose)
 $$ LANGUAGE plpythonu VOLATILE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -394,10 +506,21 @@ m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.covariance(
     source_table varchar, --  input table name
     output_table varchar, -- output table name
+    target_cols  varchar, -- comma separated list of output cols (default = '*')
+    verbose BOOLEAN       -- flag to determine verbosity
+)
+RETURNS TEXT AS $$
+    select MADLIB_SCHEMA.covariance($1, $2, $3, $4, NULL)
+$$ LANGUAGE sql VOLATILE
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.covariance(
+    source_table varchar, --  input table name
+    output_table varchar, -- output table name
     target_cols  varchar  -- comma separated list of output cols (default = '*')
 )
 RETURNS TEXT AS $$
-    select MADLIB_SCHEMA.covariance($1, $2, $3, FALSE)
+    select MADLIB_SCHEMA.covariance($1, $2, $3, FALSE, NULL)
 $$ LANGUAGE sql VOLATILE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -406,7 +529,7 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.covariance(
     source_table varchar, --  input table name
     output_table varchar  -- output table name
 ) RETURNS TEXT AS $$
-    select MADLIB_SCHEMA.covariance($1, $2, NULL)
+    select MADLIB_SCHEMA.covariance($1, $2, NULL, NULL)
 $$ LANGUAGE sql VOLATILE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 

--- a/src/ports/postgres/modules/stats/correlation.sql_in
+++ b/src/ports/postgres/modules/stats/correlation.sql_in
@@ -18,19 +18,20 @@ m4_include(`SQLCommon.m4')
 
 <div class="toc"><b>Contents</b>
 <ul>
-<li><a href="#usage">Correlation Function</a></li>
+<li><a href="#usage">Covariance and Correlation Functions</a></li>
 <li><a href="#examples">Examples</a></li>
 <li><a href="#literature">Literature</a></li>
 <li><a href="#related">Related Topics</a></li>
 </ul>
 </div>
 
-@brief Generates a cross-correlation matrix for pairs of numeric columns in a table.
+@brief Generates a covariance or Pearson correlation matrix for pairs 
+of numeric columns in a table.
 
 A correlation function is the degree and direction of association of two
 variables&mdash;how well one random variable can be predicted from the other. 
 It is a normalized version of covariance.
-The Pearson correlation coefficient has a value between -1 and 1,
+The Pearson correlation coefficient is used here, which has a value between -1 and 1,
 where 1 implies total positive linear correlation, 0 means no linear correlation, 
 and -1 means total negative linear correlation.
 
@@ -44,7 +45,7 @@ We also provide a covariance function which is similar in nature to correlation,
 and is a measure of the joint variability of two random variables.
 
 @anchor usage
-@par Correlation Function
+@par Covariance and Correlation Functions
 
 The correlation function has the following syntax:
 <pre class="syntax">

--- a/src/ports/postgres/modules/stats/test/correlation.sql_in
+++ b/src/ports/postgres/modules/stats/test/correlation.sql_in
@@ -43,47 +43,94 @@ INSERT INTO example_data VALUES
 (12, 'overcast', 72, 90, 'true', 'Play', 11),
 (13, 'overcast', 81, 75, 'false', 'Play', 31),
 (14, 'rain', 71, 80, 'true', 'Dont Play', 21),
-(15, NULL, 100, 100, 'true', NULL, 11),
-(16, NULL, 110, 100, 'true', NULL, 13);
+(15, 'rain', NULL, 100, 'true', NULL, 11),
+(16, 'rain', 110, NULL, 'true', NULL, 13);
 
---- example_data_output will have correlations of only two columns which do
---- not include any null columns in another columns
-DROP TABLE IF EXISTS example_data_output, example_data_output_summary;
+DROP TABLE IF EXISTS example_data_output, example_data_output_summary, example_data_output_covariance, example_data_output_covariance_summary;
 SELECT correlation( 'example_data',
                     'example_data_output',
-                    'temperature, humidity, new_col',
+                    'temperature, humidity, id, new_col',
                     True);
-SELECT * FROM example_data_output;
-
-INSERT INTO example_data VALUES (17, NULL, 110, 100, 'true', NULL, NULL);
-
---- example_data_output will have correlations of only three columns which does
---- include any columns. Hence if this
-DROP TABLE IF EXISTS example_data_output_with_null_2column, example_data_output_with_null_2column_summary;
-SELECT correlation( 'example_data',
-                    'example_data_output_with_null_2column',
-                    'temperature, humidity',
+SELECT covariance( 'example_data',
+                    'example_data_output_covariance',
+                    'temperature, humidity, id, new_col',
                     True);
 
-SELECT * FROM example_data_output_with_null_2column;
+SELECT assert(relative_error(temperature, 0.1606) < 0.0001, 'calculated correlation value: '|| temperature ||' does not match expected: ' || 0.1606) FROM example_data_output WHERE variable ='humidity';
 
-DROP TABLE IF EXISTS example_data_output_with_null_3column, example_data_output_with_null_3column_summary;
-SELECT correlation( 'example_data',
-                    'example_data_output_with_null_3column',
-                    'temperature, humidity, new_col',
-                    True);
-SELECT * FROM example_data_output_with_null_3column;
+SELECT assert(relative_error(humidity, -0.3502) < 0.0001, 'calculated correlation value ' || humidity || 'does not match expected: ' || -0.3502) FROM example_data_output WHERE variable ='new_col';
 
-SELECT assert(ABS(a.temperature - b.temperature) < 0.000001,
-       'Rows with NULL values are ignored.')
-FROM
-  example_data_output_with_null_2column a,
-  example_data_output_with_null_3column b
-WHERE a.column_position = 2 and b.column_position = 2;
+SELECT assert(relative_error(id, 0.4122) < 0.0001, 'calculated correlation value ' || id || 'does not match expected: ' || 0.4122) FROM example_data_output WHERE variable ='new_col';
 
-SELECT assert(ABS(a.temperature - b.temperature) > 0.000001,
-       'New row with NULL values is ignored.')
-FROM
-  example_data_output a,
-  example_data_output_with_null_2column b
-WHERE a.column_position = 2 and b.column_position = 2;
+
+SELECT assert(relative_error(temperature, 17.1500) < 0.0001, 'calculated covariance value: '|| temperature ||' does not match expected: ' || 17.1500) FROM example_data_output_covariance WHERE variable ='humidity';
+
+SELECT assert(relative_error(humidity, -28.7000) < 0.0001, 'calculated covariance value ' || humidity || 'does not match expected: ' || -28.7000) FROM example_data_output_covariance WHERE variable ='new_col';
+
+SELECT assert(relative_error(id, 15.4688) < 0.0001, 'calculated covariance value ' || id || 'does not match expected: ' || 15.4688) FROM example_data_output_covariance WHERE variable ='new_col';
+
+
+DROP TABLE IF EXISTS example_data_gr2;
+CREATE TABLE example_data_gr2(
+    id SERIAL, outlook TEXT,
+    temperature FLOAT8, humidity FLOAT8,
+    windy TEXT, class TEXT, new_col FLOAT8, gr TEXT, gr2 TEXT);
+INSERT INTO example_data_gr2 VALUES
+(1, 'sunny', 85, 85, 'false', 'Dont Play', 1, 1, 1),
+(2, 'sunny', 80, 90, 'true', 'Dont Play', 12, 1, 1),
+(3, 'overcast', 83, 78, 'false', 'Play', 13, 1, 1),
+(4, 'rain', 70, 96, 'false', 'Play', 16, 1, 1),
+(5, 'rain', 68, 80, 'false', 'Play', 17, 1, 1),
+(6, 'rain', 65, 70, 'true', 'Dont Play', 12, 1, 1),
+(7, 'overcast', 64, 65, 'true', 'Play', 15, 1, 1),
+(8, 'sunny', 72, 95, 'false', 'Dont Play', 19, 1, 1),
+(9, 'sunny', 69, 70, 'false', 'Play', 20, 1, 1),
+(10, 'rain', 75, 80, 'false', 'Play', 32, 1, 1),
+(11, 'sunny', 75, 70, 'true', 'Play', 31, 1, 1),
+(12, 'overcast', 72, 90, 'true', 'Play', 11, 1, 1),
+(13, 'overcast', 81, 75, 'false', 'Play', 31, 1, 1),
+(14, 'rain', 71, 80, 'true', 'Dont Play', 21, 1, 1),
+(15, 'rain', NULL, 100, 'true', NULL, 11, 1, 1),
+(16, 'rain', 110, NULL, 'true', NULL, 13, 1, 1),
+(1, 'sunny', 78, 81, 'false', 'Dont Play', 1, 2, 2),
+(2, 'sunny', 80, 90, 'true', 'Dont Play', 12, 2, 2),
+(3, 'overcast', 82, 78, 'false', 'Play', 13, 2, 2),
+(4, 'rain', 70, 96, 'false', 'Play', 16, 2, 2),
+(5, 'rain', 68, 80, 'false', 'Play', 17, 2, 2),
+(6, 'rain', 69, 70, 'true', 'Dont Play', 12, 2, 2),
+(7, 'overcast', 66, 65, 'true', 'Play', 15, 2, 2),
+(8, 'sunny', 72, 101, 'false', 'Dont Play', 19, 2, 2),
+(9, 'sunny', 71, 68, 'false', 'Play', 20, 2, 2),
+(10, 'rain', 75, 80, 'false', 'Play', 32, 2, 3),
+(11, 'sunny', 75, 70, 'true', 'Play', 31, 2, 3),
+(12, 'overcast', 73, 93, 'true', 'Play', 11, 2, 3),
+(13, 'overcast', 83, 77, 'false', 'Play', 31, 2, 3),
+(14, 'rain', 69, 81, 'true', 'Dont Play', 21, 2, 3),
+(15, 'rain', NULL, 100, 'true', NULL, 11, 2, 3),
+(16, 'rain', 100, NULL, 'true', NULL, 13, 2, 3);
+
+DROP TABLE IF EXISTS example_data_gr2_output, example_data_gr2_output_summary;
+SELECT correlation( 'example_data_gr2',
+                    'example_data_gr2_output',
+                    'temperature, humidity, id, new_col',
+                    FALSE,
+                    'gr,gr2');
+
+SELECT assert(relative_error(temperature, 0.1606) < 0.0001, 'calculated correlation value: '|| temperature ||' does not match expected: ' || 0.1606) FROM example_data_gr2_output WHERE variable ='humidity' AND gr='1' AND gr2='1';
+
+SELECT assert(relative_error(humidity, -0.3502) < 0.0001, 'calculated correlation value ' || humidity || 'does not match expected: ' || -0.3502) FROM example_data_gr2_output WHERE variable ='new_col' AND gr='1' AND gr2='1';
+
+SELECT assert(relative_error(id, 0.4122) < 0.0001, 'calculated correlation value ' || id || 'does not match expected: ' || 0.4122) FROM example_data_gr2_output WHERE variable ='new_col' AND gr='1' AND gr2='1';
+
+DROP TABLE IF EXISTS example_data_gr2_output_covariance, example_data_gr2_output_covariance_summary;
+SELECT covariance( 'example_data_gr2',
+                    'example_data_gr2_output_covariance',
+                    'temperature, humidity, id, new_col',
+                    FALSE,
+                    'gr,gr2');
+
+SELECT assert(relative_error(temperature, 17.1500) < 0.0001, 'calculated covariance value: '|| temperature ||' does not match expected: ' || 17.1500) FROM example_data_gr2_output_covariance WHERE variable ='humidity' AND gr='1' AND gr2='1';
+
+SELECT assert(relative_error(humidity, -28.7000) < 0.0001, 'calculated covariance value ' || humidity || 'does not match expected: ' || -28.7000) FROM example_data_gr2_output_covariance WHERE variable ='new_col' AND gr='1' AND gr2='1';
+
+SELECT assert(relative_error(id, 15.4688) < 0.0001, 'calculated covariance value ' || id || 'does not match expected: ' || 15.4688) FROM example_data_gr2_output_covariance WHERE variable ='new_col' AND gr='1' AND gr2='1';

--- a/src/ports/postgres/modules/utilities/utilities.py_in
+++ b/src/ports/postgres/modules/utilities/utilities.py_in
@@ -800,26 +800,39 @@ def get_table_qualified_col_str(tbl_name, col_list):
                        for col in col_list])
 
 
+def validate_reserved_and_target_cols_intersection(source_table,
+                                                   target_cols_list,
+                                                   reserved_cols_list,
+                                                   module_name):
+    """
+        Function to check if any target column name is part of reserved column
+        names. Throw an error if it is.
+    """
+    cols_in_tbl_valid(source_table,
+                      target_cols_list,
+                      module_name)
+    intersect = frozenset(target_cols_list).intersection(
+                                                frozenset(reserved_cols_list))
+    _assert(len(intersect) == 0,
+            "{0} error: Conflicting column names.\n"
+            "Some predefined keyword(s) ({1}) are not allowed "
+            "for column names in module input params.".format(
+                module_name, ', '.join(intersect)))
+
 def get_grouping_col_str(schema_madlib, module_name, reserved_cols,
                          source_table, grouping_col):
     if grouping_col and grouping_col.lower() != 'null':
         grouping_col_array = _string_to_array_with_quotes(grouping_col)
-        cols_in_tbl_valid(source_table,
-                          grouping_col_array,
-                          module_name)
-        intersect = frozenset(
-            _string_to_array(grouping_col)).intersection(frozenset(reserved_cols))
-        _assert(len(intersect) == 0,
-                "{0} error: Conflicting grouping column name.\n"
-                "Some predefined keyword(s) ({1}) are not allowed "
-                "for grouping column names!".format(module_name, ', '.join(intersect)))
-
-        grouping_list = [i + "::text"
-                         for i in explicit_bool_to_text(
-                             source_table,
-                             grouping_col_array,
-                             schema_madlib)]
-        grouping_str = ','.join(grouping_list)
+        validate_reserved_and_target_cols_intersection(source_table,
+                                                       grouping_col_array,
+                                                       reserved_cols,
+                                                       module_name)
+        grouping_list_with_text = [i + "::text" for i in
+                                                    explicit_bool_to_text(
+                                                        source_table,
+                                                        grouping_col_array,
+                                                        schema_madlib)]
+        grouping_str = ','.join(grouping_list_with_text)
     else:
         grouping_str = "Null"
         grouping_col = None

--- a/src/ports/postgres/modules/utilities/utilities.py_in
+++ b/src/ports/postgres/modules/utilities/utilities.py_in
@@ -8,6 +8,7 @@ from distutils.util import strtobool
 from validate_args import _get_table_schema_names
 from validate_args import get_first_schema
 from validate_args import cols_in_tbl_valid
+from validate_args import does_exclude_reserved
 from validate_args import explicit_bool_to_text
 from validate_args import input_tbl_valid
 from validate_args import is_var_valid
@@ -798,41 +799,19 @@ def get_table_qualified_col_str(tbl_name, col_list):
     """
     return ' , '.join([" {tbl_name}.{col} ".format(**locals())
                        for col in col_list])
+# ------------------------------------------------------------------------------
 
-
-def validate_reserved_and_target_cols_intersection(source_table,
-                                                   target_cols_list,
-                                                   reserved_cols_list,
-                                                   module_name):
-    """
-        Function to check if any target column name is part of reserved column
-        names. Throw an error if it is.
-    """
-    cols_in_tbl_valid(source_table,
-                      target_cols_list,
-                      module_name)
-    intersect = frozenset(target_cols_list).intersection(
-                                                frozenset(reserved_cols_list))
-    _assert(len(intersect) == 0,
-            "{0} error: Conflicting column names.\n"
-            "Some predefined keyword(s) ({1}) are not allowed "
-            "for column names in module input params.".format(
-                module_name, ', '.join(intersect)))
 
 def get_grouping_col_str(schema_madlib, module_name, reserved_cols,
                          source_table, grouping_col):
     if grouping_col and grouping_col.lower() != 'null':
         grouping_col_array = _string_to_array_with_quotes(grouping_col)
-        validate_reserved_and_target_cols_intersection(source_table,
-                                                       grouping_col_array,
-                                                       reserved_cols,
-                                                       module_name)
-        grouping_list_with_text = [i + "::text" for i in
-                                                    explicit_bool_to_text(
-                                                        source_table,
-                                                        grouping_col_array,
-                                                        schema_madlib)]
-        grouping_str = ','.join(grouping_list_with_text)
+        cols_in_tbl_valid(source_table, grouping_col_array, module_name)
+        does_exclude_reserved(grouping_col_array, reserved_cols)
+        grp_array_w_cast = explicit_bool_to_text(source_table,
+                                                grouping_col_array,
+                                                schema_madlib)
+        grouping_str = ', '.join(i + "::text" for i in grp_array_w_cast)
     else:
         grouping_str = "Null"
         grouping_col = None

--- a/src/ports/postgres/modules/utilities/validate_args.py_in
+++ b/src/ports/postgres/modules/utilities/validate_args.py_in
@@ -666,6 +666,18 @@ def regproc_valid(qualified_name, args_str, module):
             """{module} error: Required function "{qualified_name}({args_str})" not found!""".format(**locals()))
 # -------------------------------------------------------------------------
 
+def does_exclude_reserved(targets, reserved):
+    """
+        Function to check if any target column name is part of reserved column
+        names. Throw an error if it is.
+    """
+    intersect = frozenset(targets).intersection(frozenset(reserved))
+    if len(intersect) != 0:
+        plpy.error( "Error: Conflicting column names.\n"
+                    "Some predefined keyword(s) ({0}) are not allowed "
+                    "for column names in module input params.".format(
+                    ', '.join(intersect)))
+# -------------------------------------------------------------------------
 
 import unittest
 


### PR DESCRIPTION
JIRA: MADLIB-1128

This commit adds grouping support to correlation and covariance
functions in MADlib stats. Changes include relevant queries to do the
same.
This commit also has refactor changes to a helper function in
utilities.py_in.

Co-authored-by: Jingyi Mei <jmei@pivotal.io>
Co-authored-by: Nikhil Kak <nkak@pivotal.io>
Co-authored-by: Nandish Jayaram <njayaram@apache.org>