### PR TITLE
Minibatch Preprocessing: fix dependent var with special character

### DIFF
--- a/src/ports/postgres/modules/utilities/minibatch_preprocessing.py_in
+++ b/src/ports/postgres/modules/utilities/minibatch_preprocessing.py_in
@@ -60,8 +60,8 @@ class MiniBatchPreProcessor:
     """
     @MinWarning("error")
     def __init__(self, schema_madlib, source_table, output_table,
-                  dependent_varname, independent_varname, grouping_cols,
-                  buffer_size, one_hot_encode_int_dep_var=False, **kwargs):
+                 dependent_varname, independent_varname, grouping_cols,
+                 buffer_size, one_hot_encode_int_dep_var=False, **kwargs):
         self.schema_madlib = schema_madlib
         self.source_table = source_table
         self.output_table = output_table
@@ -81,7 +81,7 @@ class MiniBatchPreProcessor:
     def minibatch_preprocessor(self):
         # Get array expressions for both dep and indep variables from the
         # MiniBatchQueryFormatter class
-        qry_formatter = MiniBatchQueryFormatter(self.source_table)
+        qry_formatter = MiniBatchQueryFormatter(self.schema_madlib, self.source_table)
         dependent_var_dbtype = get_expr_type(self.dependent_varname,
                                              self.source_table)
 
@@ -90,7 +90,7 @@ class MiniBatchPreProcessor:
                                           dependent_var_dbtype,
                                           self.one_hot_encode_int_dep_var)
         indep_var_array_str = qry_formatter.get_indep_var_array_str(
-                                              self.independent_varname)
+            self.independent_varname)
 
         standardizer = MiniBatchStandardizer(self.schema_madlib,
                                              self.source_table,
@@ -236,9 +236,9 @@ class MiniBatchPreProcessor:
                                        if self.grouping_cols else '')
         result = plpy.execute(query)
 
-        ## SUM and AVG both return float, and we have to cast them into int fo
-        ## summary table. For avg_num_rows_processed we need to ceil first so
-        ## that the minimum won't be 0
+        # SUM and AVG both return float, and we have to cast them into int fo
+        # summary table. For avg_num_rows_processed we need to ceil first so
+        # that the minimum won't be 0
         source_table_row_count = int(result[0]['source_table_row_count'])
         total_num_rows_processed = int(result[0]['total_num_rows_processed'])
         avg_num_rows_processed = int(ceil(result[0]['avg_num_rows_processed']))
@@ -258,7 +258,8 @@ class MiniBatchQueryFormatter:
     variables into arrays so that they can be matrix agged by the preprocessor
     class.
     """
-    def __init__(self, source_table):
+    def __init__(self, schema_madlib, source_table):
+        self.schema_madlib = schema_madlib
         self.source_table = source_table
 
     def get_dep_var_array_and_classes(self,
@@ -297,29 +298,34 @@ class MiniBatchQueryFormatter:
         if to_one_hot_encode:
             # for encoding, since dependent_varname can also be a logical
             # expression, there is a () around it
+            if is_psql_boolean_type(dependent_var_dbtype):
+                # GPDB 4.3 does not support bool to text cast
+                dep_var_bool_patched = "{0}.bool_to_text({1})".format(
+                    self.schema_madlib, dependent_varname)
+            else:
+                dep_var_bool_patched = dependent_varname
+
             dep_level_sql = """
-                SELECT DISTINCT (quote_literal({dependent_varname})) AS class
-                FROM {source_table}
+                SELECT DISTINCT quote_literal({dep_var_bool_patched}) AS class
+                FROM {self.source_table}
                 WHERE ({dependent_varname}) is NOT NULL
-                """.format(dependent_varname=dependent_varname,
-                           source_table=self.source_table)
+                """.format(**locals())
             dep_levels = plpy.execute(dep_level_sql)
+
             dep_var_classes = sorted(l["class"] for l in dep_levels)
-            dep_var_array_str = \
-                self._get_one_hot_encoded_str(dependent_varname,
-                                              dep_var_classes,
-                                              to_quote=not is_dep_var_int_type)
-            dep_var_class_value_str = \
-                py_list_to_sql_string(dep_var_classes,
-                                      array_type=dependent_var_dbtype,
-                                      long_format=True)
+            dep_var_array_str = self._get_one_hot_encoded_str(
+                dependent_varname, dep_var_classes,
+                to_quote=not is_dep_var_int_type)
+            dep_var_class_value_str = py_list_to_sql_string(
+                dep_var_classes, array_type=dependent_var_dbtype,
+                long_format=True)
         elif "[]" in dependent_var_dbtype:
             dep_var_array_str = dependent_varname
         elif is_psql_numeric_type(dependent_var_dbtype):
             dep_var_array_str = 'ARRAY[{0}]'.format(dependent_varname)
         else:
-            plpy.error("""Invalid dependent variable type. It should be character,
-                boolean, numeric, or array.""")
+            plpy.error("Invalid dependent variable type. It should be character,"
+                       "boolean, numeric, or array.")
 
         return dep_var_array_str, dep_var_class_value_str
 

--- a/src/ports/postgres/modules/utilities/minibatch_preprocessing.py_in
+++ b/src/ports/postgres/modules/utilities/minibatch_preprocessing.py_in
@@ -293,13 +293,12 @@ class MiniBatchQueryFormatter:
         is_dep_var_int_type = is_psql_int_type(dependent_var_dbtype)
         to_one_hot_encode = (is_psql_char_type(dependent_var_dbtype) or
                              is_psql_boolean_type(dependent_var_dbtype) or
-                                (to_one_hot_encode_int and
-                                    is_dep_var_int_type))
+                             (to_one_hot_encode_int and is_dep_var_int_type))
         if to_one_hot_encode:
             # for encoding, since dependent_varname can also be a logical
             # expression, there is a () around it
             dep_level_sql = """
-                SELECT DISTINCT ({dependent_varname}) AS class
+                SELECT DISTINCT (quote_literal({dependent_varname})) AS class
                 FROM {source_table}
                 WHERE ({dependent_varname}) is NOT NULL
                 """.format(dependent_varname=dependent_varname,
@@ -312,7 +311,8 @@ class MiniBatchQueryFormatter:
                                               to_quote=not is_dep_var_int_type)
             dep_var_class_value_str = \
                 py_list_to_sql_string(dep_var_classes,
-                                      array_type=dependent_var_dbtype)
+                                      array_type=dependent_var_dbtype,
+                                      long_format=True)
         elif "[]" in dependent_var_dbtype:
             dep_var_array_str = dependent_varname
         elif is_psql_numeric_type(dependent_var_dbtype):
@@ -324,10 +324,7 @@ class MiniBatchQueryFormatter:
         return dep_var_array_str, dep_var_class_value_str
 
     def _get_one_hot_encoded_str(self, var_name, var_classes, to_quote=True):
-        def add_quote(c):
-            return "$${0}$$".format(c) if to_quote else c
-
-        one_hot_list = ["({0}) = {1}".format(var_name, add_quote(c))
+        one_hot_list = ["({0}) = {1}".format(var_name, c)
                         for c in var_classes]
         return 'ARRAY[{0}]::INTEGER[]'.format(', '.join(one_hot_list))
 
@@ -432,9 +429,9 @@ class MiniBatchStandardizer:
             ) AS {ind_colname},
             {self.source_table}.{self.grouping_cols}
         FROM
-          {self.source_table} 
-          INNER JOIN 
-          {self.x_mean_table} AS __x__ 
+          {self.source_table}
+          INNER JOIN
+          {self.x_mean_table} AS __x__
           ON  {self.source_table}.{self.grouping_cols} = __x__.{self.grouping_cols}
         """.format(
             self=self,

--- a/src/ports/postgres/modules/utilities/minibatch_preprocessing.py_in
+++ b/src/ports/postgres/modules/utilities/minibatch_preprocessing.py_in
@@ -325,7 +325,7 @@ class MiniBatchQueryFormatter:
 
     def _get_one_hot_encoded_str(self, var_name, var_classes, to_quote=True):
         def add_quote(c):
-            return "'{0}'".format(c) if to_quote else c
+            return "$${0}$$".format(c) if to_quote else c
 
         one_hot_list = ["({0}) = {1}".format(var_name, add_quote(c))
                         for c in var_classes]

--- a/src/ports/postgres/modules/utilities/test/minibatch_preprocessing.sql_in
+++ b/src/ports/postgres/modules/utilities/test/minibatch_preprocessing.sql_in
@@ -292,27 +292,59 @@ SELECT assert
         || ind_var_rows
         ) from (select max(array_upper(o.dependent_varname, 1)) as dep_var_rows, max(array_upper(o.independent_varname, 1)) as ind_var_rows , s1.buffer_size from minibatch_preprocessing_out o, minibatch_preprocessing_out_summary s1 group by buffer_size) s;
 
--- Test special characters in independent_var, dependent_var and grouping_cols
+-- Test default buffer size calculator
 DROP TABLE IF EXISTS minibatch_preprocessing_input;
 CREATE TABLE minibatch_preprocessing_input(
-    "se''x" TEXT,
-    "len'%*()gth" DOUBLE PRECISION[],
-    "rin!#'gs" INTEGER);
+    sex TEXT,
+    length DOUBLE PRECISION[],
+    rings INTEGER);
 
 INSERT INTO minibatch_preprocessing_input VALUES
 ('F',ARRAY[0.66, 0.5],6);
 DROP TABLE IF EXISTS minibatch_preprocessing_out, minibatch_preprocessing_out_standardization, minibatch_preprocessing_out_summary;
-SELECT minibatch_preprocessor('minibatch_preprocessing_input', 'minibatch_preprocessing_out', '"se''''x"', '"len''%*()gth"', '"rin!#''gs"');
+SELECT minibatch_preprocessor('minibatch_preprocessing_input', 'minibatch_preprocessing_out', 'sex', 'length', 'rings');
+SELECT assert
+        (
+        source_table        = 'minibatch_preprocessing_input' AND
+        output_table        = 'minibatch_preprocessing_out' AND
+        dependent_varname   = 'sex' AND
+        independent_varname = 'length' AND
+        buffer_size         = 1 AND
+        class_values        = '{F}' AND -- we sort the class values in python
+        num_rows_processed  = 1 AND
+        num_missing_rows_skipped    = 0 AND
+        grouping_cols       = 'rings',
+        'Summary Validation failed for special chars. Actual:' || __to_char(summary)
+        ) from (select * from minibatch_preprocessing_out_summary) summary;
+
+
+-- Test special characters and unicode characters in independent_var, dependent_var and grouping_cols, both for column name and column value
+DROP TABLE IF EXISTS minibatch_preprocessing_input;
+CREATE TABLE minibatch_preprocessing_input(
+    "se''x" TEXT,
+    "len'%*()gth" DOUBLE PRECISION[],
+    "rinЖ!#'gs" INTEGER);
+
+INSERT INTO minibatch_preprocessing_input VALUES
+('M''M',ARRAY[0.66, 0.5],6),
+('M$M',ARRAY[0.66, 0.5],6),
+('M,M',ARRAY[0.66, 0.5],6),
+('M@[}(:*;M',ARRAY[0.66, 0.5],6),
+('M"M',ARRAY[0.66, 0.5],6),
+('MЖM',ARRAY[0.66, 0.5],6);
+DROP TABLE IF EXISTS minibatch_preprocessing_out, minibatch_preprocessing_out_standardization, minibatch_preprocessing_out_summary;
+SELECT minibatch_preprocessor('minibatch_preprocessing_input', 'minibatch_preprocessing_out', '"se''''x"', '"len''%*()gth"', '"rinЖ!#''gs"', 4);
 SELECT assert
         (
         source_table        = 'minibatch_preprocessing_input' AND
         output_table        = 'minibatch_preprocessing_out' AND
         dependent_varname   = '"se''''x"' AND
         independent_varname = '"len''%*()gth"' AND
-        buffer_size         = 1 AND
-        class_values        = '{F}' AND -- we sort the class values in python
-        num_rows_processed  = 1 AND
+        buffer_size         = 4 AND
+        array_to_string(class_values, ',,,') = $$M"M,,,M$M,,,M'M,,,M,M,,,M@[}(:*;M,,,MЖM$$ AND
+        -- we sort the class values in python
+        num_rows_processed  = 6 AND
         num_missing_rows_skipped    = 0 AND
-        grouping_cols       = '"rin!#''gs"',
+        grouping_cols       = '"rinЖ!#''gs"',
         'Summary Validation failed for special chars. Actual:' || __to_char(summary)
-        ) from (select * from minibatch_preprocessing_out_summary) summary;
+        ) from (select * from minibatch_preprocessing_out_summary order by class_values) summary;

--- a/src/ports/postgres/modules/utilities/test/minibatch_preprocessing.sql_in
+++ b/src/ports/postgres/modules/utilities/test/minibatch_preprocessing.sql_in
@@ -328,21 +328,20 @@ CREATE TABLE minibatch_preprocessing_input(
 INSERT INTO minibatch_preprocessing_input VALUES
 ('M''M',ARRAY[0.66, 0.5],6),
 ('''M''M''',ARRAY[0.66, 0.5],6),
-('M$M',ARRAY[0.66, 0.5],6),
+('M|$$M',ARRAY[0.66, 0.5],6),
 ('M,M',ARRAY[0.66, 0.5],6),
 ('M@[}(:*;M',ARRAY[0.66, 0.5],6),
 ('M"M',ARRAY[0.66, 0.5],6),
 ('MЖM',ARRAY[0.66, 0.5],6);
 DROP TABLE IF EXISTS minibatch_preprocessing_out, minibatch_preprocessing_out_standardization, minibatch_preprocessing_out_summary;
 SELECT minibatch_preprocessor('minibatch_preprocessing_input', 'minibatch_preprocessing_out', '"se''''x"', '"len''%*()gth"', '"rinЖ!#''gs"', 4);
-SELECT assert
-        (
+SELECT assert(
         source_table        = 'minibatch_preprocessing_input' AND
         output_table        = 'minibatch_preprocessing_out' AND
         dependent_varname   = '"se''''x"' AND
         independent_varname = '"len''%*()gth"' AND
         buffer_size         = 4 AND
-        array_to_string(class_values, ',,,') = $$'M'M',,,M"M,,,M$M,,,M'M,,,M,M,,,M@[}(:*;M,,,MЖM$$ AND
+        class_values        = $__madlib__${ 'M'M', M\"M, M'M, "M,M", "M@[}(:*;M", "M|$$M", MЖM }$__madlib__$ AND
         -- we sort the class values in python
         num_rows_processed  = 7 AND
         num_missing_rows_skipped    = 0 AND

--- a/src/ports/postgres/modules/utilities/test/minibatch_preprocessing.sql_in
+++ b/src/ports/postgres/modules/utilities/test/minibatch_preprocessing.sql_in
@@ -327,6 +327,7 @@ CREATE TABLE minibatch_preprocessing_input(
 
 INSERT INTO minibatch_preprocessing_input VALUES
 ('M''M',ARRAY[0.66, 0.5],6),
+('''M''M''',ARRAY[0.66, 0.5],6),
 ('M$M',ARRAY[0.66, 0.5],6),
 ('M,M',ARRAY[0.66, 0.5],6),
 ('M@[}(:*;M',ARRAY[0.66, 0.5],6),
@@ -341,9 +342,9 @@ SELECT assert
         dependent_varname   = '"se''''x"' AND
         independent_varname = '"len''%*()gth"' AND
         buffer_size         = 4 AND
-        array_to_string(class_values, ',,,') = $$M"M,,,M$M,,,M'M,,,M,M,,,M@[}(:*;M,,,MЖM$$ AND
+        array_to_string(class_values, ',,,') = $$'M'M',,,M"M,,,M$M,,,M'M,,,M,M,,,M@[}(:*;M,,,MЖM$$ AND
         -- we sort the class values in python
-        num_rows_processed  = 6 AND
+        num_rows_processed  = 7 AND
         num_missing_rows_skipped    = 0 AND
         grouping_cols       = '"rinЖ!#''gs"',
         'Summary Validation failed for special chars. Actual:' || __to_char(summary)

--- a/src/ports/postgres/modules/utilities/utilities.py_in
+++ b/src/ports/postgres/modules/utilities/utilities.py_in
@@ -278,7 +278,16 @@ def _string_to_array_with_quotes(s):
 
 
 def py_list_to_sql_string(array, array_type=None, long_format=None):
-    """Convert a list to SQL array string """
+    """Convert a list to SQL array string
+
+       Given a pyton list [ele1, ele2], return:
+       1. If the array is text or character, format it as
+          {'ele1','ele2'}::array_type[]
+       2. If the array is numeric, boolean or other, format it with explicit
+          ARRAY key word (long_format=True), like
+          ARRAY[ele1,ele2]::array_type[]
+    """
+
     if long_format is None:
         if (array_type is not None and
                 (any(array_type.startswith(i)
@@ -296,8 +305,23 @@ def py_list_to_sql_string(array, array_type=None, long_format=None):
     if not array:
         return "'{{ }}'::{0}".format(array_type)
     else:
-        array_str = "ARRAY[ {0} ]" if long_format else "'{{ {0} }}'"
-        return (array_str + "::{1}").format(','.join(map(str, array)), array_type)
+        # For non-character array types:
+        if long_format:
+            array_str = "ARRAY[ {0} ]";
+            return (array_str + "::{1}").format(
+                ','.join(map(str, array)), array_type)
+        else:
+        # For character array types, we have to deal with special characters in
+        # elements an array, i.e, {'ele''one', "ele,two", "ele$three"} :
+        # We firstly use ",,," to join elements in python list and then call
+        # postgres string_to_array with a delimiter ",,," to form the final
+        # psql array, because this sequence of characters will be very
+        # unlikely to show up in a real world use case and some special
+        # case (such as "M,M") will be handled.
+            array_str = "string_to_array($${0}$$, ',,,')"
+            return (array_str + "::{1}").format(
+                ',,,'.join(map(str, array)), array_type)
+
 # ------------------------------------------------------------------------
 
 

--- a/src/ports/postgres/modules/utilities/utilities.py_in
+++ b/src/ports/postgres/modules/utilities/utilities.py_in
@@ -278,7 +278,19 @@ def _string_to_array_with_quotes(s):
 
 
 def py_list_to_sql_string(array, array_type=None, long_format=None):
-    """Convert a list to SQL array string """
+    """Convert a list to SQL array string
+
+    @note: The long format is recommended with the input values quoted
+    appropriately by 'quote_literal'.
+
+    The short format (e.g. '{1,2,3}') does not take care of escaping the
+    string values in the array. Hence an input like '{ t$}t, test}' will fail due
+    to the unescaped '{'.
+    For eg. following is a valid input for short format:
+        array = ['M'M', M\"M, "M$M,M'M", M, M, M@[\}(:*;M, MM ]
+    Note the double quotes and curly brackets need to be escaped in the input if
+    used with the short format.
+    """
     if long_format is None:
         if (array_type is not None and
                 (any(array_type.startswith(i)
@@ -296,8 +308,15 @@ def py_list_to_sql_string(array, array_type=None, long_format=None):
     if not array:
         return "'{{ }}'::{0}".format(array_type)
     else:
-        array_str = "ARRAY[ {0} ]" if long_format else "$madlib${{ {0} }}$madlib$"
-        return (array_str + "::{1}").format(','.join(map(str, array)), array_type)
+        quote_delimiter = "$__madlib__$"
+        # This is a quote delimiter that can be used in lieu of
+        # single quotes and allows the use of single quotes in the
+        # string without escaping
+        array_str = "ARRAY[ {val} ]" if long_format else "{qd}{{ {val} }}{qd}"
+        return (array_str + "::{type}").format(
+            val=','.join(map(str, array)),
+            type=array_type,
+            qd=quote_delimiter)
 # ------------------------------------------------------------------------
 
 

--- a/src/ports/postgres/modules/utilities/utilities.py_in
+++ b/src/ports/postgres/modules/utilities/utilities.py_in
@@ -278,16 +278,7 @@ def _string_to_array_with_quotes(s):
 
 
 def py_list_to_sql_string(array, array_type=None, long_format=None):
-    """Convert a list to SQL array string
-
-       Given a pyton list [ele1, ele2], return:
-       1. If the array is text or character, format it as
-          {'ele1','ele2'}::array_type[]
-       2. If the array is numeric, boolean or other, format it with explicit
-          ARRAY key word (long_format=True), like
-          ARRAY[ele1,ele2]::array_type[]
-    """
-
+    """Convert a list to SQL array string """
     if long_format is None:
         if (array_type is not None and
                 (any(array_type.startswith(i)
@@ -305,23 +296,8 @@ def py_list_to_sql_string(array, array_type=None, long_format=None):
     if not array:
         return "'{{ }}'::{0}".format(array_type)
     else:
-        # For non-character array types:
-        if long_format:
-            array_str = "ARRAY[ {0} ]";
-            return (array_str + "::{1}").format(
-                ','.join(map(str, array)), array_type)
-        else:
-        # For character array types, we have to deal with special characters in
-        # elements an array, i.e, {'ele''one', "ele,two", "ele$three"} :
-        # We firstly use ",,," to join elements in python list and then call
-        # postgres string_to_array with a delimiter ",,," to form the final
-        # psql array, because this sequence of characters will be very
-        # unlikely to show up in a real world use case and some special
-        # case (such as "M,M") will be handled.
-            array_str = "string_to_array($${0}$$, ',,,')"
-            return (array_str + "::{1}").format(
-                ',,,'.join(map(str, array)), array_type)
-
+        array_str = "ARRAY[ {0} ]" if long_format else "$madlib${{ {0} }}$madlib$"
+        return (array_str + "::{1}").format(','.join(map(str, array)), array_type)
 # ------------------------------------------------------------------------
 
 


### PR DESCRIPTION
JIRA:MADLIB-1237

Previously, minibatch processing would error out when the specified
dependent variable has special characters within its values. We
fixed this in two places:
1. in the query with WHERE condition, we use $$ to queto string instead
   of ' ' to do string equals.
2. in the query with creating an array column, instead of using
   SELECT '{ele'with*special_char, 'M,M', 'M$M'}'::text[], 
   we call
   SELECT string_to_array(''ele'with*special_char', 'M"M', 'M$M'', ',')::text[]

Install check test cases also get updated.
Co-Authored-by: Jingyi Mei <jmei@pivotal.io>