### PR TITLE
Upgrade: add changelist file and bug fixes

### DIFF
--- a/src/madpack/changelist_1.12_1.13.yaml
+++ b/src/madpack/changelist_1.12_1.13.yaml
@@ -49,7 +49,7 @@ udf:
         rettype: void
         argument: character varying, character varying, character varying, character varying
     - mlp_igd_final:
-        rettype: mlp_step_result
+        rettype: schema_madlib.mlp_step_result
         argument: double precision[]
     - mlp_igd_transition:
         rettype: double precision[]

--- a/src/madpack/changelist_1.14_1.15-dev.yaml
+++ b/src/madpack/changelist_1.14_1.15-dev.yaml
@@ -1,0 +1,58 @@
+# ------------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ------------------------------------------------------------------------------
+
+# Changelist for MADlib version 1.14 to 1.15
+
+# This file contains all changes that were introduced in a new version of
+# MADlib. This changelist is used by the upgrade script to detect what objects
+# should be upgraded (while retaining all other objects from the previous version)
+
+# New modules (actually .sql_in files) added in upgrade version
+# For these files the sql_in code is retained as is with the functions in the
+# file installed on the upgrade version. All other files (that don't have
+# updates), are cleaned up to remove object replacements
+new module:
+    # ----------------- Changes from 1.14 to 1.15 --------
+
+
+# Changes in the types (UDT) including removal and modification
+udt:
+
+# List of the UDF changes that affect the user externally. This includes change
+# in function name, return type, argument order or types, or removal of
+# the function. In each case, the original function is as good as removed and a
+# new function is created. In such cases, we should abort the upgrade if there
+# are user views dependent on this function, since the original function will
+# not be present in the upgraded version.
+udf:
+    # ----------------- Changes from 1.14 to 1.15 ----------
+
+
+# Changes to aggregates (UDA) including removal and modification
+# Overloaded functions should be mentioned separately
+uda:
+
+# Casts (UDC) updated/removed
+udc:
+
+# Operators (UDO) removed/updated
+udo:
+
+# Operator Classes (UDOC) removed/updated
+udoc:

--- a/src/madpack/upgrade_util.py
+++ b/src/madpack/upgrade_util.py
@@ -406,7 +406,7 @@ class ChangeHandler(UpgradeBase):
             cascade_str = 'CASCADE' if udt in ('svec', 'bytea8') else ''
             # CASCADE DROP for svec and bytea8 because the recv/send
             # functions and the type depend on each other
-            _write_to_file("DROP TYPE IF EXISTS {0}.{1} {2};".
+            _write_to_file(self.output_filehandle, "DROP TYPE IF EXISTS {0}.{1} {2};".
                                 format(self._schema, udt, cascade_str))
 
     def drop_changed_udf(self):
@@ -420,7 +420,7 @@ class ChangeHandler(UpgradeBase):
                 # so dropping that function needs this extra check.
                 udf_arglist = item['argument'] if 'argument' in item else ''
 
-                _write_to_file("DROP FUNCTION IF EXISTS {schema}.{udf}({arg});".
+                _write_to_file(self.output_filehandle, "DROP FUNCTION IF EXISTS {schema}.{udf}({arg});".
                                     format(schema=self._schema,
                                            udf=udf,
                                            arg=udf_arglist))
@@ -431,7 +431,7 @@ class ChangeHandler(UpgradeBase):
         """
         for uda in self._uda:
             for item in self._uda[uda]:
-                _write_to_file("DROP AGGREGATE IF EXISTS {schema}.{uda}({arg});".
+                _write_to_file(self.output_filehandle, "DROP AGGREGATE IF EXISTS {schema}.{uda}({arg});".
                                     format(schema=self._schema,
                                            uda=uda,
                                            arg=item['argument']))
@@ -442,7 +442,7 @@ class ChangeHandler(UpgradeBase):
         @note We have special treatment for UDCs defined in the svec module
         """
         for udc in self._udc:
-            _write_to_file("DROP CAST IF EXISTS ({sourcetype} AS {targettype});".
+            _write_to_file(self.output_filehandle, "DROP CAST IF EXISTS ({sourcetype} AS {targettype});".
                                 format(sourcetype=self._udc[udc]['sourcetype'],
                                        targettype=self._udc[udc]['targettype']))
 
@@ -451,7 +451,7 @@ class ChangeHandler(UpgradeBase):
         @brief Drop the madlib.training_info table, which should no longer be used since
         the version 1.5
         """
-        _write_to_file("DROP TABLE IF EXISTS {schema}.training_info;".
+        _write_to_file(self.output_filehandle, "DROP TABLE IF EXISTS {schema}.training_info;".
                             format(schema=self._schema))
 
     def drop_changed_udo(self):
@@ -462,7 +462,7 @@ class ChangeHandler(UpgradeBase):
             for value in self._udo[op]:
                 leftarg = value['leftarg'].replace('schema_madlib', self._schema)
                 rightarg = value['rightarg'].replace('schema_madlib', self._schema)
-                _write_to_file("""
+                _write_to_file(self.output_filehandle, """
                     DROP OPERATOR IF EXISTS {schema}.{op} ({leftarg}, {rightarg});
                     """.format(schema=self._schema, **locals()))
 
@@ -473,7 +473,7 @@ class ChangeHandler(UpgradeBase):
         for op_cls in self._udoc:
             for value in self._udoc[op_cls]:
                 index = value['index']
-                _write_to_file("""
+                _write_to_file(self.output_filehandle, """
                     DROP OPERATOR CLASS IF EXISTS {schema}.{op_cls} USING {index};
                     """.format(schema=self._schema, **locals()))
 


### PR DESCRIPTION
This PR  adds a changelist file for testing 1.14 to 1.15 upgrade and addresses 2 bugs we found during upgrade testing.
1. Commit 8e34f68 added a new function called `_write_to_file` that takes 2 arguments.
Some of the calls to this function were not passing the first file handle argument.
2. Append schema_madlib to the mlp_igd_final return type. This caused the
upgrade to fail from 1.12 to 1.x if there was a dependency on
mlp_igd_final.

Co-authored-by : Orhan Kislal <okislal@pivotal.io>
