### PR TITLE
KNN: make install check asserts deterministic

### DIFF
--- a/src/ports/postgres/modules/knn/test/knn.sql_in
+++ b/src/ports/postgres/modules/knn/test/knn.sql_in
@@ -77,7 +77,7 @@ select assert(array_agg(prediction order by id)='{1,1,0,1,0,0}', 'Wrong output i
 
 drop table if exists madlib_knn_result_classification;
 select knn('knn_train_data','data','id','label','knn_test_data','data','id','madlib_knn_result_classification',3);
-select assert(array_agg(x)= '{1,2,3}','Wrong output in classification with k=3') from (select unnest(k_nearest_neighbours) as x from madlib_knn_result_classification where id = 1 order by x asc) y;
+select assert(array_agg(x order by id)= '{1,2,3}','Wrong output in classification with k=3') from (select unnest(k_nearest_neighbours) as x, id from madlib_knn_result_classification where id = 1 order by x asc) y;
 
 drop table if exists madlib_knn_result_regression;
 select knn('knn_train_data_reg','data','id','label','knn_test_data','data','id','madlib_knn_result_regression',4,False,'MADLIB_SCHEMA.squared_dist_norm2',False);
@@ -85,7 +85,7 @@ select assert(array_agg(prediction order by id)='{1,1,0.5,1,0.25,0.25}', 'Wrong 
 
 drop table if exists madlib_knn_result_regression;
 select knn('knn_train_data_reg','data','id','label','knn_test_data','data','id','madlib_knn_result_regression',3,True);
-select assert(array_agg(x)= '{1,2,3}' , 'Wrong output in regression with k=3') from (select unnest(k_nearest_neighbours) as x from madlib_knn_result_regression where id = 1 order by x asc) y;
+select assert(array_agg(x order by id)= '{1,2,3}' , 'Wrong output in regression with k=3') from (select unnest(k_nearest_neighbours) as x, id from madlib_knn_result_regression where id = 1 order by x asc) y;
 
 drop table if exists madlib_knn_result_classification;
 select knn('knn_train_data','data','id','label','knn_test_data','data','id','madlib_knn_result_classification',3,False,NULL,False);


### PR DESCRIPTION
knn install check had a couple of array_agg asserts which were not
deterministic. This commit adds order by to the array agg function to
make it deterministic.