### PR TITLE
SVM: Fix flaky dev-check failure

### DIFF
--- a/src/ports/postgres/modules/svm/test/svm.sql_in
+++ b/src/ports/postgres/modules/svm/test/svm.sql_in
@@ -214,7 +214,10 @@ SELECT * FROM svm_model_small_norm2;
 SELECT
     assert(
         norm2(l2.coef) < norm2(noreg.coef) OR
-        norm2(l2.coef)-norm2(noreg.coef) < 0.001,
+        (
+            (norm2(l2.coef)-norm2(noreg.coef))/norm2(noreg.coef) < 0.1 AND
+            l2.loss < noreg.loss
+        ),
         'l2 regularization should produce coef with smaller l2 norm!')
 FROM svm_model AS noreg, svm_model_small_norm2 AS l2;
 

--- a/src/ports/postgres/modules/svm/test/svm.sql_in
+++ b/src/ports/postgres/modules/svm/test/svm.sql_in
@@ -213,7 +213,8 @@ SELECT * FROM svm_model_small_norm2;
 
 SELECT
     assert(
-        norm2(l2.coef) < norm2(noreg.coef),
+        norm2(l2.coef) < norm2(noreg.coef) OR
+        norm2(l2.coef)-norm2(noreg.coef) < 0.001,
         'l2 regularization should produce coef with smaller l2 norm!')
 FROM svm_model AS noreg, svm_model_small_norm2 AS l2;
 


### PR DESCRIPTION
JIRA: MADLIB-1232

SVM has a dev-check query that is flaky on a large cluster. This commit
relaxes the assert condition for that query.

Closes #284