### PR TITLE
Build: Remove symlinks during rpm uninstall

### DIFF
--- a/deploy/CMakeLists.txt
+++ b/deploy/CMakeLists.txt
@@ -54,6 +54,7 @@ add_subdirectory(gppkg)
 # -- Finally do the packaging! -------------------------------------------------
 
 set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_CURRENT_SOURCE_DIR}/rpm_post.sh")
+set(CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE "${CMAKE_CURRENT_SOURCE_DIR}/rpm_post_uninstall.sh")
 set(CPACK_PREFLIGHT_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/preflight.sh)
 set(CPACK_POSTFLIGHT_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/postflight.sh)
 set(CPACK_MONOLITHIC_INSTALL 1)

--- a/deploy/rpm_post_uninstall.sh
+++ b/deploy/rpm_post_uninstall.sh
@@ -1,0 +1,7 @@
+# remove symlinks created during rpm install
+find $RPM_INSTALL_PREFIX/madlib/Current -depth -type l -exec rm {} \; 2>/dev/null
+find $RPM_INSTALL_PREFIX/madlib/bin -depth -type l -exec rm {} \; 2>/dev/null
+find $RPM_INSTALL_PREFIX/madlib/doc -depth -type l -exec rm {} \; 2>/dev/null
+
+# remove "Versions" directory if it's empty
+rmdir $RPM_INSTALL_PREFIX/madlib/Versions 2>/dev/null

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
               <exclude>deploy/preflight.sh</exclude>
               <exclude>deploy/RPM/CMakeLists.txt</exclude>
               <exclude>deploy/rpm_post.sh</exclude>
+              <exclude>deploy/rpm_post_uninstall.sh</exclude>
               <exclude>doc/bin/CMakeLists.txt</exclude>
               <exclude>doc/bin/doxypy.py</exclude>
               <exclude>doc/bin/py_filter.sh.in</exclude>


### PR DESCRIPTION
JIRA: MADLIB-1175

`rpm --install` creates three symlinks to `Versions/`, `.../bin`, and
`.../doc`. These symlinks should be deleted during `rpm --erase`.
Additionally, we also delete `Versions/` if it is empty after the erase.

Closes #286

Co-Authored-by: Arvind Sridhar <asridhar@pivotal.io>