### PR TITLE
RF: Add impurity variable importance

### DIFF
--- a/src/modules/recursive_partitioning/DT_impl.hpp
+++ b/src/modules/recursive_partitioning/DT_impl.hpp
@@ -1512,6 +1512,9 @@ DecisionTree<Container>::computeVariableImportance(
                     uint64_t maj_count = getMajorityCount(node_index);
                     uint64_t min_count =  node_count - maj_count;
 
+                    if (min_count == 0) {
+                        min_count = 1;
+                    }
                     double adj_agreement =
                         (surr_agreement(surr_lookup_index) - maj_count) / min_count;
                     Index surr_feat_index = surr_indices(surr_lookup_index);

--- a/src/modules/recursive_partitioning/DT_impl.hpp
+++ b/src/modules/recursive_partitioning/DT_impl.hpp
@@ -1511,10 +1511,8 @@ DecisionTree<Container>::computeVariableImportance(
                     uint64_t node_count = nodeCount(node_index);
                     uint64_t maj_count = getMajorityCount(node_index);
                     uint64_t min_count =  node_count - maj_count;
+                    assert(min_count > 0);
 
-                    if (min_count == 0) {
-                        min_count = 1;
-                    }
                     double adj_agreement =
                         (surr_agreement(surr_lookup_index) - maj_count) / min_count;
                     Index surr_feat_index = surr_indices(surr_lookup_index);

--- a/src/modules/recursive_partitioning/decision_tree.cpp
+++ b/src/modules/recursive_partitioning/decision_tree.cpp
@@ -502,10 +502,13 @@ get_variable_importance::run(AnyType &args){
    ColumnVector combined_var_imp(n_cat_features + n_con_features);
    combined_var_imp << cat_var_importance, con_var_importance;
 
-    // Avoid divide by zero by adding a small number.
+    // Avoid divide by zero by replacing with a small number if necessary
     double total_var_imp = combined_var_imp.sum();
     double VAR_IMP_EPSILON = 1e-6;
-    combined_var_imp *=  (100.0 / (total_var_imp + VAR_IMP_EPSILON));
+    if (total_var_imp < VAR_IMP_EPSILON){
+        total_var_imp = VAR_IMP_EPSILON;
+    }
+    combined_var_imp *=  (100.0 / total_var_imp);
 
     return combined_var_imp;
 }

--- a/src/modules/recursive_partitioning/decision_tree.cpp
+++ b/src/modules/recursive_partitioning/decision_tree.cpp
@@ -502,14 +502,10 @@ get_variable_importance::run(AnyType &args){
    ColumnVector combined_var_imp(n_cat_features + n_con_features);
    combined_var_imp << cat_var_importance, con_var_importance;
 
-    // Avoid divide by zero by replacing with a small number if necessary
+    // Avoid divide by zero by adding a small number
     double total_var_imp = combined_var_imp.sum();
     double VAR_IMP_EPSILON = 1e-6;
-    if (total_var_imp < VAR_IMP_EPSILON){
-        total_var_imp = VAR_IMP_EPSILON;
-    }
-    combined_var_imp *=  (100.0 / total_var_imp);
-
+    combined_var_imp *=  (100.0 / (total_var_imp + VAR_IMP_EPSILON));
     return combined_var_imp;
 }
 

--- a/src/ports/postgres/modules/recursive_partitioning/random_forest.py_in
+++ b/src/ports/postgres/modules/recursive_partitioning/random_forest.py_in
@@ -733,7 +733,7 @@ def forest_predict(schema_madlib, model, source, output,
 
     majority_pred_cast_str = majority_pred_cast_str.format(**locals())
     num_trees_grown = plpy.execute(
-        "SELECT count(DISTINCT sample_id) FROM {}".format(model))[0]['count']
+        "SELECT count(DISTINCT sample_id) FROM {0}".format(model))[0]['count']
 
     if pred_type == "response" or not is_classification:
         sql_prediction = """
@@ -1309,9 +1309,9 @@ def _create_group_table(
         oob_var_importance_str = (", array_cat(oob_cat_var_importance, "
                                   "oob_con_var_importance) AS oob_var_importance")
         impurity_var_importance_str = ", impurity_var_importance"
-        left_join_importance_table_str = ("LEFT OUTER JOIN {} USING (gid)".
+        left_join_importance_table_str = ("LEFT OUTER JOIN {0} USING (gid)".
                                           format(importance_table))
-        join_impurity_table_str = ("JOIN ({}) q USING (gid)".
+        join_impurity_table_str = ("JOIN ({0}) q USING (gid)".
                                    format(impurity_var_importance_query))
     else:
         oob_var_importance_str = ''
@@ -1392,12 +1392,12 @@ def _insert_into_result_table(schema_madlib, tree_states, output_table_name,
         importance_query = ''
 
     if grouping_cols:
-        grp_join_sql = """JOIN {} USING (grp_key)""".format(grp_key_to_grp_cols)
+        grp_join_sql = """JOIN {0} USING (grp_key)""".format(grp_key_to_grp_cols)
         gid_str = "gid"
         grp_key = py_list_to_sql_string([tree_state['grp_key']
                                          for tree_state in tree_states],
                                         'TEXT[]', False)
-        grp_key_sql = "unnest({}) AS grp_key, ".format(grp_key)
+        grp_key_sql = "unnest({0}) AS grp_key, ".format(grp_key)
     else:
         grp_join_sql = ''
         gid_str = "1 AS gid"

--- a/src/ports/postgres/modules/recursive_partitioning/random_forest.py_in
+++ b/src/ports/postgres/modules/recursive_partitioning/random_forest.py_in
@@ -452,9 +452,9 @@ def forest_train(
                     sql_cat_features_info, ['text[]', 'integer[]', 'integer', 'text[]'])
                 plpy.execute(plan_cat_features_info, [
                     bins['grp_key_cat'],
-                    bins['cat_n'],
-                    len(cat_features),
-                    bins['cat_origin']])
+                              bins['cat_n'],
+                              len(cat_features),
+                              bins['cat_origin']])
 
                 con_splits_table = unique_string()
                 _create_con_splits_table(schema_madlib, con_splits_table,
@@ -565,8 +565,7 @@ def forest_train(
                         dup_cnt: {dup_cnt}.
                         """.format(**locals()))
 
-#/*********************************************************************************
-                    if grouping_cols is None:
+                    if not grouping_cols:
                         tree_state = _tree_train_using_bins(
                             schema_madlib, bins, src_view, cat_features, con_features,
                             boolean_cats, num_bins, 'poisson_count', dep, min_split,
@@ -622,29 +621,19 @@ def forest_train(
                         num_bins, filter_null, null_proxy)
 
                 ###################################################################
-                # evaluating and summerizing random forest
+                # evaluating and summarizing random forest
 
                 oob_error_table = unique_string()
                 _calculate_oob_error(schema_madlib, oob_prediction_table,
                                      oob_error_table, id_col_name,
                                      is_classification)
-                importance_table = ''
                 if importance:
                     importance_table = unique_string()
-                    sql_create_empty_imp_tbl = """
-                            CREATE TEMP TABLE {importance_table}
-                            (
-                                gid integer,
-                                cat_var_importance float8[],
-                                con_var_importance float8[]
-                            );
-                            """.format(**locals())
-                    plpy.notice("sql_create_empty_imp_tbl:\n"+sql_create_empty_imp_tbl)
-                    plpy.execute(sql_create_empty_imp_tbl)
-
-                    _calculate_variable_importance(
+                    _calculate_oob_variable_importance(
                         schema_madlib, oob_prediction_table, is_classification,
                         importance_table, len(cat_features), len(con_features))
+                else:
+                    importance_table = ''
 
                 _create_group_table(schema_madlib, output_table_name,
                                     oob_error_table, importance_table,
@@ -670,8 +659,8 @@ def forest_train(
 # ------------------------------------------------------------
 
 
-def forest_predict(schema_madlib, model, source, output, pred_type='response',
-                   **kwargs):
+def forest_predict(schema_madlib, model, source, output,
+                   pred_type='response', **kwargs):
     """
     Args:
         @param schema_madlib: str, Name of MADlib schema
@@ -729,7 +718,7 @@ def forest_predict(schema_madlib, model, source, output, pred_type='response',
     using_str = "" if grouping_cols is None else "USING (" + grouping_cols + ")"
 
     if not is_classification:
-        majority_pred_expression = "avg(aggregated_prediction)"
+        majority_pred_expression = "AVG(aggregated_prediction)"
     else:
         majority_pred_expression = """($sql${{ {dep_levels} }}$sql$::varchar[])[
                                     {schema_madlib}.mode(aggregated_prediction + 1)]::TEXT
@@ -744,8 +733,7 @@ def forest_predict(schema_madlib, model, source, output, pred_type='response',
 
     majority_pred_cast_str = majority_pred_cast_str.format(**locals())
     num_trees_grown = plpy.execute(
-        "SELECT count(distinct sample_id) FROM {model}"
-        .format(**locals()))[0]['count']
+        "SELECT count(DISTINCT sample_id) FROM {}".format(model))[0]['count']
 
     if pred_type == "response" or not is_classification:
         sql_prediction = """
@@ -1112,9 +1100,18 @@ def _create_con_splits_table(schema_madlib, con_splits_table, grouping_cols,
 # ------------------------------------------------------------------------------
 
 
-def _calculate_variable_importance(
+def _calculate_oob_variable_importance(
         schema_madlib, oob_prediction_table, is_classification,
         importance_table, n_cat, n_con):
+    sql_create_empty_imp_tbl = """
+            CREATE TEMP TABLE {importance_table} (
+                gid integer,
+                oob_cat_var_importance float8[],
+                oob_con_var_importance float8[]
+            );
+            """.format(**locals())
+    plpy.notice("sql_create_empty_imp_tbl:\n" + sql_create_empty_imp_tbl)
+    plpy.execute(sql_create_empty_imp_tbl)
     if not is_classification:
         # squared error
         score_expression = "-((oob_prediction - dep)^2)".format(**locals())
@@ -1164,7 +1161,7 @@ def _calculate_variable_importance(
                )
             FROM (
                 -- Compute the average importance over the OOB data where,
-                -- importance = difference of original score and permuted score.
+                --      importance = original score - permuted score
                 -- Since permuted score is a vector and original score is a scalar,
                 -- the signs are inverted and then fixed by dividing with
                 -- negative of size.
@@ -1301,35 +1298,29 @@ def _create_group_table(
         importance_table, cat_features_info_table, grp_key_to_grp_cols,
         grouping_cols, tree_terminated):
     """ Create the group table for random forest"""
-
-    cat_var_importance_str = ''
-    con_var_importance_str = ''
-    impurity_var_importance_str = ''
-    left_join_importance_table_str = ''
-    join_impurity_table_str = ''
-
     if importance_table:
-        impurity_var_importance_table_name = unique_string(desp='impurity')
-        plpy.execute("""
-            CREATE TEMP TABLE {impurity_var_importance_table_name} AS
+        impurity_var_importance_query = """
             SELECT
                 gid,
                 {schema_madlib}.array_avg(impurity_var_importance, False) AS impurity_var_importance
             FROM {output_table_name}
             GROUP BY gid
-            """.format(**locals()))
+            """.format(**locals())
+        oob_var_importance_str = (", array_cat(oob_cat_var_importance, "
+                                  "oob_con_var_importance) AS oob_var_importance")
+        impurity_var_importance_str = ", impurity_var_importance"
+        left_join_importance_table_str = ("LEFT OUTER JOIN {} USING (gid)".
+                                          format(importance_table))
+        join_impurity_table_str = ("JOIN ({}) q USING (gid)".
+                                   format(impurity_var_importance_query))
+    else:
+        oob_var_importance_str = ''
+        impurity_var_importance_str = ''
+        left_join_importance_table_str = ''
+        join_impurity_table_str = ''
 
-        cat_var_importance_str = ", cat_var_importance AS oob_cat_var_importance,"
-        con_var_importance_str = "con_var_importance AS oob_con_var_importance,"
-        impurity_var_importance_str = "impurity_var_importance"
-        left_join_importance_table_str = """LEFT OUTER JOIN {importance_table}
-            USING (gid)""".format(importance_table=importance_table)
-        join_impurity_table_str = """JOIN {impurity_var_importance_table_name} USING (gid)""".format(impurity_var_importance_table_name=impurity_var_importance_table_name)
-
-    grouping_cols_str = ('' if grouping_cols is None
-                         else grouping_cols + ",")
+    grouping_cols_str = ('' if grouping_cols is None else grouping_cols + ",")
     group_table_name = add_postfix(output_table_name, "_group")
-
     sql_create_group_table = """
             CREATE TABLE {group_table_name} AS
             SELECT
@@ -1339,8 +1330,7 @@ def _create_group_table(
                 cat_n_levels,
                 cat_levels_in_text,
                 oob_error
-                {cat_var_importance_str}
-                {con_var_importance_str}
+                {oob_var_importance_str}
                 {impurity_var_importance_str}
             FROM
                 {oob_error_table}
@@ -1385,42 +1375,42 @@ def _create_empty_result_table(schema_madlib, output_table_name, importance):
 
 
 def _insert_into_result_table(schema_madlib, tree_states, output_table_name,
-                              grp_key_to_grp_cols, sample_id, importance, grouping_cols):
-    """Insert one tree to result table"""
-
-    impurity_var_imp_str = ''
-    importance_query = ''
-    importance_results = ''
-    if importance :
+                              grp_key_to_grp_cols, sample_id,
+                              importance, grouping_cols):
+    if importance:
         impurity_var_imp_str = ', impurity_var_importance'
-
         importance_results = [tree_state['impurity_var_importance']
-                                for tree_state in tree_states]
-        importance_results = py_list_to_sql_string(importance_results,'double precision[]',True)
-
-        importance_query = ', ({schema_madlib}.array_unnest_2d_to_1d({importance_results})).unnest_result AS impurity_var_importance'.format(**locals())
+                              for tree_state in tree_states]
+        importance_results = py_list_to_sql_string(importance_results,
+                                                   'DOUBLE PRECISION[]',
+                                                   True)
+        importance_query = """, ({schema_madlib}.array_unnest_2d_to_1d(
+                                    {importance_results})).unnest_result AS
+                                 impurity_var_importance""".format(**locals())
+    else:
+        impurity_var_imp_str = ''
+        importance_query = ''
 
     if grouping_cols:
-        grp_join_sql = """JOIN {grp_key_to_grp_cols} USING (grp_key)""".format(**locals())
-        gid_sql = "gid"
-
-        grp_key = [tree_state['grp_key'] for tree_state in tree_states]
-        grp_key = py_list_to_sql_string(grp_key,'text[]',False)
-        grp_key_sql = "unnest({grp_key}) AS grp_key, ".format(**locals())
+        grp_join_sql = """JOIN {} USING (grp_key)""".format(grp_key_to_grp_cols)
+        gid_str = "gid"
+        grp_key = py_list_to_sql_string([tree_state['grp_key']
+                                         for tree_state in tree_states],
+                                        'TEXT[]', False)
+        grp_key_sql = "unnest({}) AS grp_key, ".format(grp_key)
     else:
         grp_join_sql = ''
-        gid_sql = "1 AS gid"
+        gid_str = "1 AS gid"
         grp_key_sql = ''
 
     sql = """
         INSERT INTO {output_table_name}
         SELECT
-            {gid_sql},
+            {gid_str},
             {sample_id} AS sample_id,
             tree
             {impurity_var_imp_str}
-        FROM
-        (
+        FROM (
             SELECT
                 {grp_key_sql}
                 unnest($1) AS tree
@@ -1428,10 +1418,9 @@ def _insert_into_result_table(schema_madlib, tree_states, output_table_name,
         ) grp_key_to_tree
         {grp_join_sql}
         """.format(**locals())
-    sql_plan = plpy.prepare(sql,['{0}.bytea8[]'.format(schema_madlib)])
+    sql_plan = plpy.prepare(sql, ['{0}.bytea8[]'.format(schema_madlib)])
     plpy.execute(sql_plan, [[tree_state['tree_state'] for tree_state in tree_states]])
-
-# ------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 
 def _forest_validate_args(

--- a/src/ports/postgres/modules/recursive_partitioning/random_forest.py_in
+++ b/src/ports/postgres/modules/recursive_partitioning/random_forest.py_in
@@ -18,6 +18,7 @@ from utilities.utilities import unique_string
 from utilities.utilities import add_postfix
 from utilities.utilities import split_quoted_delimited_str
 from utilities.utilities import extract_keyvalue_params
+from utilities.utilities import py_list_to_sql_string
 from utilities.validate_args import get_cols_and_types
 from utilities.validate_args import is_var_valid
 from utilities.validate_args import input_tbl_valid
@@ -37,6 +38,7 @@ from decision_tree import _classify_features
 from decision_tree import _get_filter_str
 from decision_tree import _get_display_header
 from decision_tree import get_feature_str
+from decision_tree import _compute_var_importance
 # ------------------------------------------------------------
 
 
@@ -515,7 +517,8 @@ def forest_train(
                 plpy.notice("sql_create_oob_view:\n" + sql_create_oob_view)
                 plpy.execute(sql_create_oob_view)
 
-                _create_empty_result_table(schema_madlib, output_table_name)
+                _create_empty_result_table(schema_madlib, output_table_name,
+                    importance)
 
                 ##################################################################
                 # training random forest
@@ -562,13 +565,15 @@ def forest_train(
                         dup_cnt: {dup_cnt}.
                         """.format(**locals()))
 
-                    if grouping_cols is None:   # non-grouping case
+#/*********************************************************************************
+                    if grouping_cols is None:
                         tree_state = _tree_train_using_bins(
                             schema_madlib, bins, src_view, cat_features, con_features,
                             boolean_cats, num_bins, 'poisson_count', dep, min_split,
                             min_bucket, max_tree_depth, filter_null, dep_n_levels,
                             is_classification, split_criterion, True,
                             num_random_features, max_n_surr, null_proxy)
+
                         tree_states = [dict(tree_state=tree_state['tree_state'],
                                             grp_key='')]
 
@@ -597,9 +602,16 @@ def forest_train(
                                 elif item['finished'] == 2:
                                     tree_terminated[item['grp_key']] = 2
 
+                    if importance:
+                        for tree in tree_states:
+                            importance_vectors = _compute_var_importance(
+                                schema_madlib, tree,
+                                len(cat_features), len(con_features))
+                            tree.update(**importance_vectors)
+
                     _insert_into_result_table(
                         schema_madlib, tree_states, output_table_name,
-                        grp_key_to_grp_cols, sample_id)
+                        grp_key_to_grp_cols, sample_id, importance, grouping_cols)
 
                     _calculate_oob_prediction(
                         schema_madlib, output_table_name, cat_features_info_table,
@@ -616,23 +628,20 @@ def forest_train(
                 _calculate_oob_error(schema_madlib, oob_prediction_table,
                                      oob_error_table, id_col_name,
                                      is_classification)
-
-                importance_table = unique_string()
-                sql_create_empty_imp_tbl = """
-                        CREATE TEMP TABLE {importance_table}
-                        (
-                            gid integer,
-                            cat_var_importance float8[],
-                            con_var_importance float8[]
-                        );
-                        """.format(**locals())
-                plpy.notice("sql_create_empty_imp_tbl:\n"+sql_create_empty_imp_tbl)
-                plpy.execute(sql_create_empty_imp_tbl)
-
-                # we populate the importance_table only if variable importance is to be
-                # calculated, otherwise we use an empty table which will be used later
-                # for an outer join.
+                importance_table = ''
                 if importance:
+                    importance_table = unique_string()
+                    sql_create_empty_imp_tbl = """
+                            CREATE TEMP TABLE {importance_table}
+                            (
+                                gid integer,
+                                cat_var_importance float8[],
+                                con_var_importance float8[]
+                            );
+                            """.format(**locals())
+                    plpy.notice("sql_create_empty_imp_tbl:\n"+sql_create_empty_imp_tbl)
+                    plpy.execute(sql_create_empty_imp_tbl)
+
                     _calculate_variable_importance(
                         schema_madlib, oob_prediction_table, is_classification,
                         importance_table, len(cat_features), len(con_features))
@@ -646,13 +655,13 @@ def forest_train(
                 _create_summary_table(**locals())
 
                 sql_cleanup = """
-                        DROP TABLE {training_pois_cnt_table} CASCADE;
-                        DROP TABLE {oob_prediction_table} CASCADE;
-                        DROP TABLE {importance_table} CASCADE;
-                        DROP TABLE {oob_error_table} CASCADE;
-                        DROP TABLE {cat_features_info_table} CASCADE;
-                        DROP TABLE {con_splits_table} CASCADE;
-                        DROP TABLE {grp_key_to_grp_cols} CASCADE;
+                        DROP TABLE IF EXISTS {training_pois_cnt_table} CASCADE;
+                        DROP TABLE IF EXISTS {oob_prediction_table} CASCADE;
+                        DROP TABLE IF EXISTS {importance_table} CASCADE;
+                        DROP TABLE IF EXISTS {oob_error_table} CASCADE;
+                        DROP TABLE IF EXISTS {cat_features_info_table} CASCADE;
+                        DROP TABLE IF EXISTS {con_splits_table} CASCADE;
+                        DROP TABLE IF EXISTS {grp_key_to_grp_cols} CASCADE;
                         """.format(**locals())
                 plpy.notice("sql_cleanup:\n" + sql_cleanup)
                 plpy.execute(sql_cleanup)
@@ -1291,21 +1300,48 @@ def _create_group_table(
         schema_madlib, output_table_name, oob_error_table,
         importance_table, cat_features_info_table, grp_key_to_grp_cols,
         grouping_cols, tree_terminated):
-    """ Ceate the group table for random forest"""
+    """ Create the group table for random forest"""
+
+    cat_var_importance_str = ''
+    con_var_importance_str = ''
+    impurity_var_importance_str = ''
+    left_join_importance_table_str = ''
+    join_impurity_table_str = ''
+
+    if importance_table:
+        impurity_var_importance_table_name = unique_string(desp='impurity')
+        plpy.execute("""
+            CREATE TEMP TABLE {impurity_var_importance_table_name} AS
+            SELECT
+                gid,
+                {schema_madlib}.array_avg(impurity_var_importance, False) AS impurity_var_importance
+            FROM {output_table_name}
+            GROUP BY gid
+            """.format(**locals()))
+
+        cat_var_importance_str = ", cat_var_importance AS oob_cat_var_importance,"
+        con_var_importance_str = "con_var_importance AS oob_con_var_importance,"
+        impurity_var_importance_str = "impurity_var_importance"
+        left_join_importance_table_str = """LEFT OUTER JOIN {importance_table}
+            USING (gid)""".format(importance_table=importance_table)
+        join_impurity_table_str = """JOIN {impurity_var_importance_table_name} USING (gid)""".format(impurity_var_importance_table_name=impurity_var_importance_table_name)
+
     grouping_cols_str = ('' if grouping_cols is None
                          else grouping_cols + ",")
     group_table_name = add_postfix(output_table_name, "_group")
+
     sql_create_group_table = """
             CREATE TABLE {group_table_name} AS
             SELECT
                 gid,
                 {grouping_cols_str}
-                grp_finished as success,
+                grp_finished AS success,
                 cat_n_levels,
                 cat_levels_in_text,
-                oob_error,
-                cat_var_importance,
-                con_var_importance
+                oob_error
+                {cat_var_importance_str}
+                {con_var_importance_str}
+                {impurity_var_importance_str}
             FROM
                 {oob_error_table}
             JOIN
@@ -1313,16 +1349,15 @@ def _create_group_table(
             USING (gid)
             JOIN (
                 SELECT
-                    unnest($1) as grp_key,
-                    unnest($2) as grp_finished
+                    unnest($1) AS grp_key,
+                    unnest($2) AS grp_finished
             ) tree_terminated
             USING (grp_key)
             JOIN
                 {cat_features_info_table}
             USING (gid)
-            LEFT OUTER JOIN
-                {importance_table}
-            USING (gid)
+            {left_join_importance_table_str}
+            {join_impurity_table_str}
             """.format(**locals())
     plpy.notice("sql_create_group_table:\n" + sql_create_group_table)
     plan_create_group_table = plpy.prepare(sql_create_group_table,
@@ -1333,13 +1368,16 @@ def _create_group_table(
 # -------------------------------------------------------------------------
 
 
-def _create_empty_result_table(schema_madlib, output_table_name):
+def _create_empty_result_table(schema_madlib, output_table_name, importance):
     """Create the result table for all trees in the forest"""
+    impurity_var_imp_str = """, impurity_var_importance double precision[]);""" if importance else ");"
+
     sql_create_empty_result_table = """
             CREATE TABLE {output_table_name} (
                 gid         integer,
                 sample_id   integer,
-                tree        {schema_madlib}.bytea8);
+                tree        {schema_madlib}.bytea8
+                {impurity_var_imp_str}
             """.format(**locals())
     plpy.notice("sql_create_empty_result_table:\n" + sql_create_empty_result_table)
     plpy.execute(sql_create_empty_result_table)
@@ -1347,28 +1385,52 @@ def _create_empty_result_table(schema_madlib, output_table_name):
 
 
 def _insert_into_result_table(schema_madlib, tree_states, output_table_name,
-                              grp_key_to_grp_cols, sample_id):
+                              grp_key_to_grp_cols, sample_id, importance, grouping_cols):
     """Insert one tree to result table"""
+
+    impurity_var_imp_str = ''
+    importance_query = ''
+    importance_results = ''
+    if importance :
+        impurity_var_imp_str = ', impurity_var_importance'
+
+        importance_results = [tree_state['impurity_var_importance']
+                                for tree_state in tree_states]
+        importance_results = py_list_to_sql_string(importance_results,'double precision[]',True)
+
+        importance_query = ', ({schema_madlib}.array_unnest_2d_to_1d({importance_results})).unnest_result AS impurity_var_importance'.format(**locals())
+
+    if grouping_cols:
+        grp_join_sql = """JOIN {grp_key_to_grp_cols} USING (grp_key)""".format(**locals())
+        gid_sql = "gid"
+
+        grp_key = [tree_state['grp_key'] for tree_state in tree_states]
+        grp_key = py_list_to_sql_string(grp_key,'text[]',False)
+        grp_key_sql = "unnest({grp_key}) AS grp_key, ".format(**locals())
+    else:
+        grp_join_sql = ''
+        gid_sql = "1 AS gid"
+        grp_key_sql = ''
+
     sql = """
         INSERT INTO {output_table_name}
         SELECT
-            gid,
+            {gid_sql},
             {sample_id} AS sample_id,
             tree
+            {impurity_var_imp_str}
         FROM
         (
             SELECT
-                unnest($1) AS grp_key,
-                unnest($2) AS tree
+                {grp_key_sql}
+                unnest($1) AS tree
+                {importance_query}
         ) grp_key_to_tree
-        JOIN
-            {grp_key_to_grp_cols}
-        USING (grp_key)
+        {grp_join_sql}
         """.format(**locals())
-    sql_plan = plpy.prepare(sql, ['text[]', '{0}.bytea8[]'.format(schema_madlib)])
-    plpy.execute(sql_plan, [
-        [tree_state['grp_key'] for tree_state in tree_states],
-        [tree_state['tree_state'] for tree_state in tree_states]])
+    sql_plan = plpy.prepare(sql,['{0}.bytea8[]'.format(schema_madlib)])
+    plpy.execute(sql_plan, [[tree_state['tree_state'] for tree_state in tree_states]])
+
 # ------------------------------------------------------------
 
 

--- a/src/ports/postgres/modules/recursive_partitioning/random_forest.py_in
+++ b/src/ports/postgres/modules/recursive_partitioning/random_forest.py_in
@@ -516,9 +516,11 @@ def forest_train(
                         """.format(**locals())
                 plpy.notice("sql_create_oob_view:\n" + sql_create_oob_view)
                 plpy.execute(sql_create_oob_view)
-
+                temp_output_table = ''
+                if importance:
+                    temp_output_table = unique_string(desp='temp_out')
                 _create_empty_result_table(schema_madlib, output_table_name,
-                    importance)
+                    temp_output_table, importance)
 
                 ##################################################################
                 # training random forest
@@ -600,7 +602,6 @@ def forest_train(
                                     tree_terminated[item['grp_key']] = item['finished']
                                 elif item['finished'] == 2:
                                     tree_terminated[item['grp_key']] = 2
-
                     if importance:
                         for tree in tree_states:
                             importance_vectors = _compute_var_importance(
@@ -609,7 +610,7 @@ def forest_train(
                             tree.update(**importance_vectors)
 
                     _insert_into_result_table(
-                        schema_madlib, tree_states, output_table_name,
+                        schema_madlib, tree_states, output_table_name, temp_output_table,
                         grp_key_to_grp_cols, sample_id, importance, grouping_cols)
 
                     _calculate_oob_prediction(
@@ -635,10 +636,15 @@ def forest_train(
                 else:
                     importance_table = ''
 
-                _create_group_table(schema_madlib, output_table_name,
-                                    oob_error_table, importance_table,
-                                    cat_features_info_table, grp_key_to_grp_cols,
-                                    grouping_cols, tree_terminated)
+                _create_group_table(schema_madlib,
+                                    output_table_name,
+                                    temp_output_table,
+                                    oob_error_table,
+                                    importance_table,
+                                    cat_features_info_table,
+                                    grp_key_to_grp_cols,
+                                    grouping_cols,
+                                    tree_terminated)
 
                 num_failed_groups = sum(1 for v in tree_terminated.values() if v != 1)
                 _create_summary_table(**locals())
@@ -647,6 +653,7 @@ def forest_train(
                         DROP TABLE IF EXISTS {training_pois_cnt_table} CASCADE;
                         DROP TABLE IF EXISTS {oob_prediction_table} CASCADE;
                         DROP TABLE IF EXISTS {importance_table} CASCADE;
+                        DROP TABLE IF EXISTS {temp_output_table} CASCADE;
                         DROP TABLE IF EXISTS {oob_error_table} CASCADE;
                         DROP TABLE IF EXISTS {cat_features_info_table} CASCADE;
                         DROP TABLE IF EXISTS {con_splits_table} CASCADE;
@@ -1294,7 +1301,7 @@ def _create_summary_table(**kwargs):
 
 
 def _create_group_table(
-        schema_madlib, output_table_name, oob_error_table,
+        schema_madlib, output_table_name, temp_output_table, oob_error_table,
         importance_table, cat_features_info_table, grp_key_to_grp_cols,
         grouping_cols, tree_terminated):
     """ Create the group table for random forest"""
@@ -1303,7 +1310,7 @@ def _create_group_table(
             SELECT
                 gid,
                 {schema_madlib}.array_avg(impurity_var_importance, False) AS impurity_var_importance
-            FROM {output_table_name}
+            FROM {temp_output_table}
             GROUP BY gid
             """.format(**locals())
         oob_var_importance_str = (", array_cat(oob_cat_var_importance, "
@@ -1358,39 +1365,30 @@ def _create_group_table(
 # -------------------------------------------------------------------------
 
 
-def _create_empty_result_table(schema_madlib, output_table_name, importance):
+def _create_empty_result_table(schema_madlib, output_table_name,
+                               temp_output_table, importance):
     """Create the result table for all trees in the forest"""
-    impurity_var_imp_str = """, impurity_var_importance double precision[]);""" if importance else ");"
-
     sql_create_empty_result_table = """
             CREATE TABLE {output_table_name} (
                 gid         integer,
                 sample_id   integer,
-                tree        {schema_madlib}.bytea8
-                {impurity_var_imp_str}
+                tree        {schema_madlib}.bytea8)
             """.format(**locals())
     plpy.notice("sql_create_empty_result_table:\n" + sql_create_empty_result_table)
     plpy.execute(sql_create_empty_result_table)
+    if importance:
+        plpy.execute("""
+                CREATE TABLE {temp_output_table} (
+                gid         integer,
+                sample_id   integer,
+                impurity_var_importance double precision[])
+            """.format(**locals()))
 # ------------------------------------------------------------
 
 
 def _insert_into_result_table(schema_madlib, tree_states, output_table_name,
-                              grp_key_to_grp_cols, sample_id,
-                              importance, grouping_cols):
-    if importance:
-        impurity_var_imp_str = ', impurity_var_importance'
-        importance_results = [tree_state['impurity_var_importance']
-                              for tree_state in tree_states]
-        importance_results = py_list_to_sql_string(importance_results,
-                                                   'DOUBLE PRECISION[]',
-                                                   True)
-        importance_query = """, ({schema_madlib}.array_unnest_2d_to_1d(
-                                    {importance_results})).unnest_result AS
-                                 impurity_var_importance""".format(**locals())
-    else:
-        impurity_var_imp_str = ''
-        importance_query = ''
-
+                              temp_output_table, grp_key_to_grp_cols,
+                              sample_id, importance, grouping_cols):
     if grouping_cols:
         grp_join_sql = """JOIN {0} USING (grp_key)""".format(grp_key_to_grp_cols)
         gid_str = "gid"
@@ -1409,17 +1407,38 @@ def _insert_into_result_table(schema_madlib, tree_states, output_table_name,
             {gid_str},
             {sample_id} AS sample_id,
             tree
-            {impurity_var_imp_str}
         FROM (
             SELECT
                 {grp_key_sql}
                 unnest($1) AS tree
-                {importance_query}
         ) grp_key_to_tree
         {grp_join_sql}
         """.format(**locals())
     sql_plan = plpy.prepare(sql, ['{0}.bytea8[]'.format(schema_madlib)])
     plpy.execute(sql_plan, [[tree_state['tree_state'] for tree_state in tree_states]])
+    if importance:
+        importance_results = [tree_state['impurity_var_importance']
+                              for tree_state in tree_states]
+        importance_results = py_list_to_sql_string(importance_results,
+                                                   'DOUBLE PRECISION[]',
+                                                   True)
+        importance_query = """({schema_madlib}.array_unnest_2d_to_1d(
+                                    {importance_results})).unnest_result AS
+                                 impurity_var_importance""".format(**locals())
+        plpy.execute("""
+        INSERT INTO {temp_output_table}
+        SELECT
+            {gid_str},
+            {sample_id} AS sample_id,
+            impurity_var_importance
+        FROM (
+            SELECT
+                {grp_key_sql}
+                {importance_query}
+        ) grp_key_to_tree
+        {grp_join_sql}
+        """.format(**locals()))
+
 # ------------------------------------------------------------------------------
 
 

--- a/src/ports/postgres/modules/recursive_partitioning/random_forest.sql_in
+++ b/src/ports/postgres/modules/recursive_partitioning/random_forest.sql_in
@@ -144,14 +144,14 @@ forest_train(training_table_name,
   <DT>importance (optional)</DT>
   <DD>BOOLEAN, default: true. Whether or not to calculate variable importance.
   If set to true, variable out-of-bag importance for categorical and continuous
-  features as well as the gini impurity importance will be output in the group
-  table <em>\<model_table\>_group</em>.
-  Note that total runtime will increase when variable
-  importance is turned on. </DD>
+  features as well as the impurity importance will be output in the group
+  table <em>\<model_table\>_group</em>. Note that total runtime will increase
+  when variable importance is turned on.
+  </DD>
 
   <DT>num_permutations (optional)</DT>
   <DD>INTEGER, default: 1. Number of times to permute each feature value while
-      calculating variable importance.
+      calculating the out-of-bag variable importance.
 
     @note Variable importance for a feature is determined by permuting the variable
     and computing the drop in predictive accuracy using out-of-bag samples [1].
@@ -457,27 +457,20 @@ forest_train(training_table_name,
       </tr>
 
       <tr>
-        <th>oob_cat_var_importance</th>
-        <td>DOUBLE PRECISION[]. Variable out-of-bag importance for categorical features.
+        <th>oob_var_importance</th>
+        <td>DOUBLE PRECISION[]. Variable out-of-bag importance for both
+        categorical and continuous features.
         The order corresponds to the order of the variables as found in
-        'cat_features' in <em> \<model_table\>_summary</em>.</td>
-      </tr>
-
-      <tr>
-        <th>oob_con_var_importance</th>
-        <td>DOUBLE PRECISION[]. Variable out-of-bag importance for continuous features.
-        The order corresponds to the order of the variables as found in
-        'con_features' in  <em> \<model_table\>_summary</em>.</td>
+        'independent_varnames' in <em> \<model_table\>_summary</em>.</td>
       </tr>
 
       <tr>
         <th>impurity_var_importance</th>
-        <td>DOUBLE PRECISION[]. Variable gini impurity importance for both categorial
-        and continuous features. The order corresponds to the order of the variables as found in
-        'cat_features' followed by the order of the 'con_features' in
-         <em> \<model_table\>_summary</em>.</td>
+        <td>DOUBLE PRECISION[]. Variable gini impurity importance for both
+        categorial and continuous features. The order corresponds to the order
+         of the variables as found in 'independent_varnames' in
+        <em> \<model_table\>_summary</em>.</td>
       </tr>
-
 
    </table>
   </DD>
@@ -693,7 +686,7 @@ SELECT madlib.forest_train('rf_golf',         -- source table
 SELECT * FROM train_output_summary;
 </pre>
 <pre class="result">
--[ RECORD 1 ]---------+--------------------------------------------------
+--[ RECORD 1 ]---------+--------------------------------------------------
 method                | forest_train
 is_classification     | t
 source_table          | rf_golf
@@ -732,10 +725,9 @@ gid                     | 1
 success                 | t
 cat_n_levels            | {3,2}
 cat_levels_in_text      | {overcast,rain,sunny,False,True}
-oob_error               | 0.50000000000000000000
-oob_cat_var_importance  | {0.0595833333333333,0.00583333333333333}
-oob_con_var_importance  | {0,0.0491666666666667}
-impurity_var_importance | {37.5653240671247,9.73195751327106,27.7699636145019,24.9327548051023}
+oob_error               | 0.42857142857142857143
+oob_var_importance      | {0.0771428571428571,0.0129761904761904,0,0.0296428571428572}
+impurity_var_importance | {24.8796347659136,14.1455342814326,36.2830708609594,24.6916215180187}
 </pre>
 The 'cat_levels_in_text' array shows the ordering of the
 levels of the categorical variables "OUTLOOK" and windy,
@@ -791,20 +783,20 @@ FROM prediction_results p, rf_golf g WHERE p.id = g.id ORDER BY g.id;
 <pre class="result">
  id |   class    | estimated_prob_Don't Play | estimated_prob_Play
 ----+------------+---------------------------+---------------------
-  1 | Don't Play |                      0.85 |                0.15
-  2 | Don't Play |                      0.95 |                0.05
-  3 | Play       |                       0.2 |                 0.8
-  4 | Play       |                       0.3 |                 0.7
-  5 | Play       |                       0.1 |                 0.9
-  6 | Don't Play |                       0.7 |                 0.3
-  7 | Play       |                       0.2 |                 0.8
-  8 | Don't Play |                      0.75 |                0.25
+  1 | Don't Play |                       0.9 |                 0.1
+  2 | Don't Play |                      0.85 |                0.15
+  3 | Play       |                         0 |                   1
+  4 | Play       |                      0.35 |                0.65
+  5 | Play       |                      0.05 |                0.95
+  6 | Don't Play |                      0.85 |                0.15
+  7 | Play       |                      0.25 |                0.75
+  8 | Don't Play |                      0.85 |                0.15
   9 | Play       |                      0.15 |                0.85
- 10 | Play       |                       0.2 |                 0.8
- 11 | Play       |                      0.25 |                0.75
- 12 | Play       |                       0.3 |                 0.7
+ 10 | Play       |                      0.15 |                0.85
+ 11 | Play       |                      0.35 |                0.65
+ 12 | Play       |                       0.1 |                 0.9
  13 | Play       |                         0 |                   1
- 14 | Don't Play |                       0.6 |                 0.4
+ 14 | Don't Play |                       0.8 |                 0.2
 (14 rows)
 </pre>
 
@@ -929,16 +921,16 @@ SELECT madlib.forest_train('rf_golf',         -- source table
 SELECT * FROM train_output_summary;
 </pre>
 <pre class="result">
--[ RECORD 1 ]---------+--------------------------------------------------------------------------------
+-[ RECORD 1 ]---------+----------------------------------------------------------------------------------------
 method                | forest_train
 is_classification     | t
 source_table          | rf_golf
 model_table           | train_output
 id_col_name           | id
 dependent_varname     | class
-independent_varnames  | clouds_airquality[1],clouds_airquality[2],"Temp_Humidity"[1],"Temp_Humidity"[2]
-cat_features          | clouds_airquality[1],clouds_airquality[2]
-con_features          | "Temp_Humidity"[1],"Temp_Humidity"[2]
+independent_varnames  | (clouds_airquality)[1],(clouds_airquality)[2],("Temp_Humidity")[1],("Temp_Humidity")[2]
+cat_features          | (clouds_airquality)[1],(clouds_airquality)[2]
+con_features          | ("Temp_Humidity")[1],("Temp_Humidity")[2]
 grouping_cols         |
 num_trees             | 20
 num_random_features   | 2
@@ -985,15 +977,14 @@ SELECT madlib.forest_train('rf_golf',         -- source table
 SELECT * FROM train_output_group;
 </pre>
 <pre class="result">
--[ RECORD 1 ]-----------+---------------------------------------------------------------------
+-[ RECORD 1 ]-----------+--------------------------------------------------------------------
 gid                     | 1
 success                 | t
 cat_n_levels            | {3,2}
 cat_levels_in_text      | {overcast,rain,sunny,False,True}
-oob_error               | 0.61538461538461538462
-oob_cat_var_importance  | {0.025,0.025}
-oob_con_var_importance  | {0,0.035}
-impurity_var_importance | {22.2412816041848,14.4007056451613,30.9384504460131,7.4195623046408}
+oob_error               | 0.57142857142857142857
+oob_var_importance      | {0.0666666666666667,0.0333333333333333,0.05,0}
+impurity_var_importance | {14.4447296351495,16.1522023965976,22.8299129333055,31.57293033484}
 </pre>
 
 <b>Random Forest Regression Example</b>
@@ -1113,26 +1104,24 @@ Review the group table to see variable importance by group:
 SELECT * FROM mt_cars_output_group ORDER BY gid;
 </pre>
 <pre class="result">
--[ RECORD 1 ]-----------+--------------------------------------------------------------------------------------
+-[ RECORD 1 ]-----------+-----------------------------------------------------------------------------------------
 gid                     | 1
 am                      | 0
 success                 | t
 cat_n_levels            | {2,3}
 cat_levels_in_text      | {0,1,4,6,8}
-oob_error               | 7.89937404385343
-oob_cat_var_importance  | {7.87991809689153,0.617942222222223}
-oob_con_var_importance  | {1.84637058464259,0.883091796875,3.84846682043232}
-impurity_var_importance | {22.4124027853243,20,35.1569822119963,2.92362864369191,19.5069863589875}
--[ RECORD 2 ]-----------+--------------------------------------------------------------------------------------
+oob_error               | 8.62571889723009
+oob_var_importance      | {2.95162395813838,3.23089290134035,0.994241413118334,0.342690329218107,3.25006268518519}
+impurity_var_importance | {10.9386265747945,23.3057168169563,32.3513539280067,6.92963084493898,26.4746628051816}
+-[ RECORD 2 ]-----------+-----------------------------------------------------------------------------------------
 gid                     | 2
 am                      | 1
 success                 | t
 cat_n_levels            | {2,3}
 cat_levels_in_text      | {0,1,4,6,8}
-oob_error               | 25.4844331490554
-oob_cat_var_importance  | {4.8832,0.4919125}
-oob_con_var_importance  | {0.4919125,0,14.4849705555556}
-impurity_var_importance | {3.94164236675192,5.08316677853507,22.4710638947646,1.20369378537446,37.300433174574}
+oob_error               | 14.9083301827798
+oob_var_importance      | {0,11.9946222222222,2.737238,0,8.41890541666667}
+impurity_var_importance | {12.8401241270327,21.7441641446627,25.8468000245574,15.5707059756254,23.9982033921735}
 </pre>
 
 -# Predict regression output for the same data and compare with original:
@@ -1147,40 +1136,40 @@ SELECT s.am, s.id, mpg, estimated_mpg, mpg-estimated_mpg as delta
 FROM prediction_results p, mt_cars s WHERE s.id = p.id ORDER BY s.am, s.id;
 </pre>
 <pre class="result">
- am | id | mpg  |  estimated_mpg   |       delta
-----+----+------+------------------+--------------------
-  0 |  1 | 18.7 | 16.1644030112045 |   2.53559698879552
-  0 |  3 | 24.4 | 20.1780892857143 |   4.22191071428571
-  0 |  5 | 17.8 | 18.3336448412698 |  -0.53364484126984
-  0 |  6 | 16.4 |  16.073216503268 |  0.326783496732023
-  0 |  8 | 17.3 |  16.073216503268 |   1.22678349673203
-  0 |  9 | 21.4 | 19.1757281746032 |   2.22427182539683
-  0 | 10 | 15.2 | 15.4498831699346 | -0.249883169934643
-  0 | 11 | 18.1 | 18.3336448412698 | -0.233644841269843
-  0 | 13 | 14.3 | 15.3339109477124 |  -1.03391094771242
-  0 | 14 | 22.8 | 20.1780892857143 |   2.62191071428571
-  0 | 16 | 19.2 | 18.3336448412698 |  0.866355158730158
-  0 | 18 | 15.2 | 16.1644030112045 | -0.964403011204485
-  0 | 19 | 10.4 | 14.8702998366013 |  -4.47029983660131
-  0 | 21 | 10.4 | 14.8702998366013 |  -4.47029983660131
-  0 | 23 | 14.7 | 15.4936331699346 |  -0.79363316993464
-  0 | 25 | 21.5 | 20.1780892857143 |   1.32191071428571
-  0 | 27 | 15.5 | 15.3339109477124 |   0.16608905228758
-  0 | 29 | 13.3 | 15.3339109477124 |  -2.03391094771242
-  0 | 30 | 19.2 | 15.3614109477124 |   3.83858905228758
-  1 |  2 |   21 | 22.2740158730159 |  -1.27401587301587
-  1 |  4 |   21 | 21.9821825396825 |  -0.98218253968254
-  1 |  7 | 22.8 | 26.1888286435786 |  -3.38882864357864
-  1 | 12 | 32.4 | 28.0211143578644 |   4.37888564213564
-  1 | 15 | 30.4 | 28.5405588023088 |    1.8594411976912
-  1 | 17 | 33.9 | 28.5405588023088 |    5.3594411976912
-  1 | 20 | 27.3 | 27.6688921356421 | -0.368892135642131
-  1 | 22 |   26 | 23.3459603174603 |   2.65403968253968
-  1 | 24 | 30.4 | 26.8774516594517 |   3.52254834054834
-  1 | 26 | 15.8 | 19.9121825396825 |  -4.11218253968254
-  1 | 28 |   15 | 19.9121825396825 |  -4.91218253968254
-  1 | 31 | 19.7 | 20.7306825396825 |  -1.03068253968254
-  1 | 32 | 21.4 | 24.6353286435786 |  -3.23532864357864
+  am | id | mpg  |  estimated_mpg   |        delta
+----+----+------+------------------+----------------------
+  0 |  1 | 18.7 | 16.5055222816399 |     2.19447771836007
+  0 |  3 | 24.4 | 21.8437857142857 |     2.55621428571428
+  0 |  5 | 17.8 | 19.2085504201681 |    -1.40855042016807
+  0 |  6 | 16.4 | 15.7340778371955 |    0.665922162804513
+  0 |  8 | 17.3 | 15.7340778371955 |     1.56592216280452
+  0 |  9 | 21.4 | 18.2305980392157 |     3.16940196078431
+  0 | 10 | 15.2 | 15.2640778371955 |  -0.0640778371954838
+  0 | 11 | 18.1 | 18.9192647058824 |    -0.81926470588235
+  0 | 13 | 14.3 | 15.0690909090909 |   -0.769090909090908
+  0 | 14 | 22.8 | 21.8437857142857 |    0.956214285714289
+  0 | 16 | 19.2 | 19.2085504201681 | -0.00855042016807062
+  0 | 18 | 15.2 | 16.0805222816399 |    -0.88052228163993
+  0 | 19 | 10.4 | 14.7914111705288 |    -4.39141117052882
+  0 | 21 | 10.4 | 14.7914111705288 |    -4.39141117052882
+  0 | 23 | 14.7 | 15.0525222816399 |    -0.35252228163993
+  0 | 25 | 21.5 | 21.8437857142857 |   -0.343785714285712
+  0 | 27 | 15.5 | 15.4775222816399 |   0.0224777183600704
+  0 | 29 | 13.3 | 15.0690909090909 |    -1.76909090909091
+  0 | 30 | 19.2 | 15.4775222816399 |     3.72247771836007
+  1 |  2 |   21 |         19.53275 |              1.46725
+  1 |  4 |   21 | 20.3594166666667 |    0.640583333333332
+  1 |  7 | 22.8 | 23.0550833333333 |   -0.255083333333335
+  1 | 12 | 32.4 | 27.1501666666667 |     5.24983333333333
+  1 | 15 | 30.4 | 28.9628333333333 |     1.43716666666667
+  1 | 17 | 33.9 | 28.0211666666667 |     5.87883333333333
+  1 | 20 | 27.3 | 27.7138333333333 |   -0.413833333333333
+  1 | 22 |   26 | 26.8808333333333 |   -0.880833333333335
+  1 | 24 | 30.4 |          27.8225 |               2.5775
+  1 | 26 | 15.8 | 17.2924166666667 |    -1.49241666666666
+  1 | 28 |   15 | 17.2924166666667 |    -2.29241666666667
+  1 | 31 | 19.7 |         19.53275 |    0.167249999999999
+  1 | 32 | 21.4 | 23.0550833333333 |    -1.65508333333334
 (32 rows)
 </pre>
 
@@ -1306,9 +1295,8 @@ success                 | t
 cat_n_levels            | {2,2,2}
 cat_levels_in_text      | {US,__NULL__,rainy,__NULL__,NY,__NULL__}
 oob_error               | 1.00000000000000000000
-oob_cat_var_importance  | {0.0555555555555556,0.0555555555555556,0}
-oob_con_var_importance  |
-impurity_var_importance | {39.4412331406551,22.2612425927946,28.2975242665503}
+oob_var_importance      | {0,0,0}
+impurity_var_importance | {32.1752184623349,25.2686155402256,22.5560374792348}
 </pre>
 
 -# Predict for data not previously seen by assuming NULL

--- a/src/ports/postgres/modules/recursive_partitioning/random_forest.sql_in
+++ b/src/ports/postgres/modules/recursive_partitioning/random_forest.sql_in
@@ -38,9 +38,9 @@ expense of some loss in interpretation, can be highly accurate.
 Refer to Breiman and Cutler [1][2] for details on the implementation
 used here.
 
-Also refer to  
+Also refer to
 the <a href="group__grp__decision__tree.html">decision tree user documentation</a>
-since many parameters and examples are similar to 
+since many parameters and examples are similar to
 random forest.
 
 @anchor train
@@ -76,16 +76,16 @@ forest_train(training_table_name,
   <dt>output_table_name</dt>
   <dd>TEXT. Name of the generated table containing the model.
   If a table with the same name already exists, an
-  error will be returned. A summary table 
-  named <em>\<output_table_name\>_summary</em> and a grouping 
+  error will be returned. A summary table
+  named <em>\<output_table_name\>_summary</em> and a grouping
   table named <em>\<output_table_name\>_group</em>
   are also created.  These are described later on this page.
   </DD>
 
   <DT>id_col_name</DT>
-  <DD>TEXT. Name of the column containing id information 
-  in the training data.  This is a mandatory argument 
-  and is used for prediction and other purposes. The values 
+  <DD>TEXT. Name of the column containing id information
+  in the training data.  This is a mandatory argument
+  and is used for prediction and other purposes. The values
   are expected to be unique for each row.</DD>
 
   <DT>dependent_variable</DT>
@@ -107,7 +107,7 @@ forest_train(training_table_name,
 
   Array columns can also be included in the list, where the array is expanded
   to treat each element of the array as a feature.
-  
+
   Note that not every combination of the levels of a
   categorical variable is checked when evaluating a split. The levels of the
   non-integer categorical variable are ordered by the entropy of the variable in
@@ -121,7 +121,7 @@ forest_train(training_table_name,
       list. If the <em>dependent_variable</em> is an expression (including cast of a column name),
       then this list should include the columns present in the
       <em>dependent_variable</em> expression,
-      otherwise those columns will be included in the 
+      otherwise those columns will be included in the
       features (resulting in meaningless trees).
       The names in this parameter should be identical to the names used in the table and
       quoted appropriately. </DD>
@@ -137,15 +137,16 @@ forest_train(training_table_name,
       on the data.</DD>
 
   <DT>num_random_features (optional)</DT>
-  <DD>INTEGER, default: sqrt(n) for classification, n/3 
-  for regression. This is the number of features to randomly 
+  <DD>INTEGER, default: sqrt(n) for classification, n/3
+  for regression. This is the number of features to randomly
   select at each split.</DD>
 
   <DT>importance (optional)</DT>
   <DD>BOOLEAN, default: true. Whether or not to calculate variable importance.
-  If set to true, variable importance for categorical and continuous features
-  will be output in the group table <em>\<model_table\>_group</em>.
-  Note that total runtime will increase when variable 
+  If set to true, variable out-of-bag importance for categorical and continuous
+  features as well as the gini impurity importance will be output in the group
+  table <em>\<model_table\>_group</em>.
+  Note that total runtime will increase when variable
   importance is turned on. </DD>
 
   <DT>num_permutations (optional)</DT>
@@ -195,23 +196,23 @@ forest_train(training_table_name,
       <th>max_surrogates</th>
       <td>Default: 0. Number of surrogates to store for each node.</td>
       One approach to handling NULLs is to use surrogate splits for each
-      node. A surrogate variable enables you to make better use of 
+      node. A surrogate variable enables you to make better use of
       the data by using another predictor variable that is associated
       (correlated) with the primary split variable.  The surrogate
       variable comes into use when the primary predictior value is NULL.
-      Surrogate rules implemented here are based on reference [1]. 
+      Surrogate rules implemented here are based on reference [1].
     </tr>
     <tr>
     <th>null_as_category</th>
-    <td>Default: FALSE. Whether to treat NULL as a valid level 
+    <td>Default: FALSE. Whether to treat NULL as a valid level
     for categorical features.  FALSE means that NULL is not a
-    valid level, which is probably the most common sitation. 
-    
+    valid level, which is probably the most common sitation.
+
     If set to TRUE, NULL values are considered a categorical value and
     placed at the end of the ordering of categorical levels. Placing at the
     end ensures that NULL is never used as a value to split a node on.
-    One reason to make NULL a category is that it allows you to 
-    predict on categorical levels that were not in the training 
+    One reason to make NULL a category is that it allows you to
+    predict on categorical levels that were not in the training
     data by lumping them into an "other bucket."
 
     This parameter is ignored for continuous-valued features.
@@ -228,8 +229,8 @@ forest_train(training_table_name,
     If 'sample_ratio' is less than 1, a bootstrap sample size smaller than the data
     table is used for training each tree in the forest. A ratio that
     is close to 0 may result in trees with only the root node.
-    This sample parameter allows users to quickly experiment with the 
-    random forest function since it reduces run time by 
+    This sample parameter allows users to quickly experiment with the
+    random forest function since it reduces run time by
     using only some of the data.</DD>
 </DL>
 
@@ -249,8 +250,12 @@ forest_train(training_table_name,
       </tr>
       <tr>
         <th>tree</th>
-        <td>BYTEA8. Trained tree model stored in binary 
+        <td>BYTEA8. Trained tree model stored in binary
         format (not human readable).</td>
+      </tr>
+      <tr>
+        <th>impurity_var_importance</th>
+        <td>DOUBLE PRECISION[]. The gini impurity importance score for the tree.</td>
       </tr>
     </table>
 
@@ -295,7 +300,7 @@ forest_train(training_table_name,
 
     <tr>
       <th>cat_features</th>
-      <td>TEXT. List of categorical features 
+      <td>TEXT. List of categorical features
       as a comma-separated string.</td>
     </tr>
 
@@ -373,7 +378,7 @@ forest_train(training_table_name,
 
     <tr>
       <th>total_rows_skipped</th>
-      <td>BIGINT. Total numbers of rows skipped in all 
+      <td>BIGINT. Total numbers of rows skipped in all
       groups due to missing values or failures.</td>
     </tr>
 
@@ -394,9 +399,9 @@ forest_train(training_table_name,
 
     <tr>
     <th>null_proxy</th>
-    <td>TEXT. Describes how NULLs are handled.  If NULL is not 
+    <td>TEXT. Describes how NULLs are handled.  If NULL is not
     treated as a separate categorical variable, this will be NULL.
-    If NULL is treated as a separate categorical value, this will be 
+    If NULL is treated as a separate categorical value, this will be
     set to "__NULL__"</td>
     </tr>
     </table>
@@ -408,7 +413,7 @@ forest_train(training_table_name,
 
       <tr>
         <th>gid</th>
-        <td>integer. Group id that uniquely identifies 
+        <td>integer. Group id that uniquely identifies
         a set of grouping column values.  If grouping is not
         used, this will always be 1.</td>
       </tr>
@@ -416,7 +421,7 @@ forest_train(training_table_name,
       <tr>
         <th>&lt;...&gt;</th>
         <td>Same type as in the training data table 'grouping_cols'.
-        This could be multiple columns depending on 
+        This could be multiple columns depending on
         the 'grouping_cols' input.</td>
       </tr>
 
@@ -427,12 +432,12 @@ forest_train(training_table_name,
 
       <tr>
         <th>cat_levels_in_text</th>
-        <td>TEXT[]. Ordered levels (values) of categorical variables 
-        corresponding to the categorical features in 
+        <td>TEXT[]. Ordered levels (values) of categorical variables
+        corresponding to the categorical features in
         the 'list_of_features' argument above.  Used to help
-        interpret the trained tree.  For example, if the 
+        interpret the trained tree.  For example, if the
         categorical features specified are <em>weather_outlook</em>
-        and <em>windy</em> in that order, then 'cat_levels_in_text' 
+        and <em>windy</em> in that order, then 'cat_levels_in_text'
         might be <em>[overcast, rain, sunny, False, True]</em>.</td>
       </tr>
 
@@ -440,9 +445,9 @@ forest_train(training_table_name,
         <th>cat_n_levels</th>
         <td>INTEGER[]. Number of levels for each categorical variable.
         Used to help interpret the trained tree. In the example
-        from above, 'cat_n_levels' would 
-        be <em>[3, 2]</em> since there are 3 levels 
-        for <em>weather_outlook</em> and 2 levels 
+        from above, 'cat_n_levels' would
+        be <em>[3, 2]</em> since there are 3 levels
+        for <em>weather_outlook</em> and 2 levels
         <em>windy</em>.</td>
       </tr>
 
@@ -452,18 +457,27 @@ forest_train(training_table_name,
       </tr>
 
       <tr>
-        <th>cat_var_importance</th>
-        <td>DOUBLE PRECISION[]. Variable importance for categorical features.
+        <th>oob_cat_var_importance</th>
+        <td>DOUBLE PRECISION[]. Variable out-of-bag importance for categorical features.
         The order corresponds to the order of the variables as found in
         'cat_features' in <em> \<model_table\>_summary</em>.</td>
       </tr>
 
       <tr>
-        <th>con_var_importance</th>
-        <td>DOUBLE PRECISION[]. Variable importance for continuous features.
+        <th>oob_con_var_importance</th>
+        <td>DOUBLE PRECISION[]. Variable out-of-bag importance for continuous features.
         The order corresponds to the order of the variables as found in
         'con_features' in  <em> \<model_table\>_summary</em>.</td>
       </tr>
+
+      <tr>
+        <th>impurity_var_importance</th>
+        <td>DOUBLE PRECISION[]. Variable gini impurity importance for both categorial
+        and continuous features. The order corresponds to the order of the variables as found in
+        'cat_features' followed by the order of the 'con_features' in
+         <em> \<model_table\>_summary</em>.</td>
+      </tr>
+
 
    </table>
   </DD>
@@ -525,9 +539,9 @@ forest_predict(random_forest_model,
 @anchor get_tree
 @par Tree Display
 The display function outputs a graph representation of a
-single tree of the random forest. The output can either be in the popular 
-'dot' format that can be visualized using various programs including those 
-in the GraphViz package, or in a simple text format. The details of the 
+single tree of the random forest. The output can either be in the popular
+'dot' format that can be visualized using various programs including those
+in the GraphViz package, or in a simple text format. The details of the
 text format are output with the tree.
 <pre class="syntax">
 get_tree(forest_model_table,
@@ -585,7 +599,7 @@ programs.
 
 To export the dot format result to an external file,
 use the method below. Please note that you should use unaligned
-table output mode for psql with '-A' flag, or else you may get an 
+table output mode for psql with '-A' flag, or else you may get an
 error when you try to convert the dot file to another format
 for viewing (e.g., PDF). And inside the psql client,
 both '\\t' and '\\o' should be used:
@@ -617,11 +631,11 @@ for more details on working with tree output formats.
 @examp
 
 @note
- - Not all random forest parameters are demonstrated in 
- the examples below.  Some are shown in 
+ - Not all random forest parameters are demonstrated in
+ the examples below.  Some are shown in
  the <a href="group__grp__decision__tree.html">decision tree user documentation</a>
  since usage is similar.
- - Your results may look different than those below 
+ - Your results may look different than those below
 due the random nature of random forests.
 
 <b>Random Forest Classification Example</b>
@@ -689,7 +703,7 @@ dependent_varname     | class
 independent_varnames  | "OUTLOOK",windy,temperature,humidity
 cat_features          | "OUTLOOK",windy
 con_features          | temperature,humidity
-grouping_cols         | 
+grouping_cols         |
 num_trees             | 20
 num_random_features   | 2
 max_tree_depth        | 8
@@ -713,37 +727,38 @@ View the group table output:
 SELECT * FROM train_output_group;
 </pre>
 <pre class="result">
--[ RECORD 1 ]------+---------------------------------
-gid                | 1
-success            | t
-cat_n_levels       | {3,2}
-cat_levels_in_text | {overcast,sunny,rain,False,True}
-oob_error          | 0.42857142857142857143
-cat_var_importance | {0.0692857142857143,0.02}
-con_var_importance | {0,5.55111512312578e-17}
+-[ RECORD 1 ]-----------+----------------------------------------------------------------------
+gid                     | 1
+success                 | t
+cat_n_levels            | {3,2}
+cat_levels_in_text      | {overcast,rain,sunny,False,True}
+oob_error               | 0.50000000000000000000
+oob_cat_var_importance  | {0.0595833333333333,0.00583333333333333}
+oob_con_var_importance  | {0,0.0491666666666667}
+impurity_var_importance | {37.5653240671247,9.73195751327106,27.7699636145019,24.9327548051023}
 </pre>
-The 'cat_levels_in_text' array shows the ordering of the 
-levels of the categorical variables "OUTLOOK" and windy, 
-which have 3 and 2 levels respectively.  Variable importance 
+The 'cat_levels_in_text' array shows the ordering of the
+levels of the categorical variables "OUTLOOK" and windy,
+which have 3 and 2 levels respectively.  Variable importance
 for categorical variables is shown in 'cat_var_importance'.
-Variable importance for continuous variables is 
-shown in 'con_var_importance'. 
+Variable importance for continuous variables is
+shown in 'con_var_importance'.
 A higher value means higher importance for the variable.
 
--# Predict output categories. For the purpose of this 
+-# Predict output categories. For the purpose of this
 example, we use the same data that was used for training:
 <pre class="example">
 \\x off
 DROP TABLE IF EXISTS prediction_results;
-SELECT madlib.forest_predict('train_output',        -- tree model    
+SELECT madlib.forest_predict('train_output',        -- tree model
                              'rf_golf',             -- new data table
                              'prediction_results',  -- output table
                              'response');           -- show response
-SELECT g.id, class, estimated_class FROM prediction_results p, 
+SELECT g.id, class, estimated_class FROM prediction_results p,
 rf_golf g WHERE p.id = g.id ORDER BY g.id;
 </pre>
 <pre class="result">
- id |   class    | estimated_class 
+ id |   class    | estimated_class
 ----+------------+-----------------
   1 | Don't Play | Don't Play
   2 | Don't Play | Don't Play
@@ -761,20 +776,20 @@ rf_golf g WHERE p.id = g.id ORDER BY g.id;
  14 | Don't Play | Don't Play
 (14 rows)
 </pre>
-To display the probabilities associated with each 
-value of the dependent variable, set the 'type' 
+To display the probabilities associated with each
+value of the dependent variable, set the 'type'
 parameter to 'prob':
 <pre class="example">
 DROP TABLE IF EXISTS prediction_results;
-SELECT madlib.forest_predict('train_output',        -- tree model    
+SELECT madlib.forest_predict('train_output',        -- tree model
                              'rf_golf',             -- new data table
                              'prediction_results',  -- output table
                              'prob');               -- show probability
-SELECT g.id, class, "estimated_prob_Don't Play",  "estimated_prob_Play" 
+SELECT g.id, class, "estimated_prob_Don't Play",  "estimated_prob_Play"
 FROM prediction_results p, rf_golf g WHERE p.id = g.id ORDER BY g.id;
 </pre>
 <pre class="result">
- id |   class    | estimated_prob_Don't Play | estimated_prob_Play 
+ id |   class    | estimated_prob_Don't Play | estimated_prob_Play
 ----+------------+---------------------------+---------------------
   1 | Don't Play |                      0.85 |                0.15
   2 | Don't Play |                      0.95 |                0.05
@@ -793,8 +808,8 @@ FROM prediction_results p, rf_golf g WHERE p.id = g.id ORDER BY g.id;
 (14 rows)
 </pre>
 
--# View a single tree in text format within the forest 
-identified by 'gid' and 'sample_id', out of 
+-# View a single tree in text format within the forest
+identified by 'gid' and 'sample_id', out of
 the several that were created:
 <pre class="example">
 SELECT madlib.get_tree('train_output',1,7, FALSE);
@@ -822,8 +837,8 @@ second indented child (2i+2) is the 'False' node.
        (6)[2 0]  * --> "Don't Play"
 &nbsp;-------------------------------------
 </pre>
-Please see 
-the <a href="group__grp__decision__tree.html">decision tree user documentation</a> 
+Please see
+the <a href="group__grp__decision__tree.html">decision tree user documentation</a>
 for an explanation on how to interpret the tree display above.
 
 -# View tree in dot format:
@@ -854,7 +869,7 @@ SELECT madlib.get_tree('train_output',1,7);
  "11" [label="\"Don't Play\"",shape=box];
  "5" -> "12"[label="no"];
  "12" [label="\"Play\"",shape=box];
- } //---end of digraph--------- 
+ } //---end of digraph---------
 </pre>
 
 -# View tree in dot format with additional information:
@@ -885,12 +900,12 @@ SELECT madlib.get_tree('train_output',1,7, TRUE, TRUE);
  "11" [label="\"Don't Play\"\\n impurity = 0.5\\n samples = 2\\n value = [1 1]",shape=box];
  "5" -> "12"[label="no"];
  "12" [label="\"Play\"\\n impurity = 0\\n samples = 1\\n value = [0 1]",shape=box];
- } //---end of digraph--------- 
+ } //---end of digraph---------
 </pre>
 
--# Arrays of features. Categorical and continuous 
-features can be array columns, in which case the 
-array is expanded to treat each element of the 
+-# Arrays of features. Categorical and continuous
+features can be array columns, in which case the
+array is expanded to treat each element of the
 array as a feature:
 <pre class="example">
 DROP TABLE IF EXISTS train_output, train_output_group, train_output_summary;
@@ -924,7 +939,7 @@ dependent_varname     | class
 independent_varnames  | clouds_airquality[1],clouds_airquality[2],"Temp_Humidity"[1],"Temp_Humidity"[2]
 cat_features          | clouds_airquality[1],clouds_airquality[2]
 con_features          | "Temp_Humidity"[1],"Temp_Humidity"[2]
-grouping_cols         | 
+grouping_cols         |
 num_trees             | 20
 num_random_features   | 2
 max_tree_depth        | 8
@@ -944,7 +959,7 @@ independent_var_types | text, text, double precision, double precision
 null_proxy            | None
 </pre>
 
--# Sample ratio. Use the sample ratio parameter to 
+-# Sample ratio. Use the sample ratio parameter to
 train on a subset of the data:
 <pre class="example">
 DROP TABLE IF EXISTS train_output, train_output_group, train_output_summary;
@@ -970,21 +985,22 @@ SELECT madlib.forest_train('rf_golf',         -- source table
 SELECT * FROM train_output_group;
 </pre>
 <pre class="result">
--[ RECORD 1 ]------+---------------------------------
-gid                | 1
-success            | t
-cat_n_levels       | {3,2}
-cat_levels_in_text | {overcast,sunny,rain,False,True}
-oob_error          | 0.42857142857142857143
-cat_var_importance | {0.0416666666666667,0}
-con_var_importance | {0.0291666666666667,0.025}
+-[ RECORD 1 ]-----------+---------------------------------------------------------------------
+gid                     | 1
+success                 | t
+cat_n_levels            | {3,2}
+cat_levels_in_text      | {overcast,rain,sunny,False,True}
+oob_error               | 0.61538461538461538462
+oob_cat_var_importance  | {0.025,0.025}
+oob_con_var_importance  | {0,0.035}
+impurity_var_importance | {22.2412816041848,14.4007056451613,30.9384504460131,7.4195623046408}
 </pre>
 
 <b>Random Forest Regression Example</b>
 
--# Load input data related to fuel consumption and 10 
-aspects of automobile design and performance for 32 
-automobiles (1973–74 models). Data was extracted from 
+-# Load input data related to fuel consumption and 10
+aspects of automobile design and performance for 32
+automobiles (1973–74 models). Data was extracted from
 the 1974 Motor Trend US magazine.
 <pre class="example">
 DROP TABLE IF EXISTS mt_cars;
@@ -1037,8 +1053,8 @@ INSERT INTO mt_cars VALUES
 (32,21.4,4,121,109,4.11,2.78,18.6,1,1,4,2);
 </pre>
 
--# We train a regression random forest tree with 
-grouping on transmission type (0 = automatic, 1 = manual) 
+-# We train a regression random forest tree with
+grouping on transmission type (0 = automatic, 1 = manual)
 and use surrogates for NULL handling:
 <pre class="example">
 DROP TABLE IF EXISTS mt_cars_output, mt_cars_output_group, mt_cars_output_summary;
@@ -1087,7 +1103,7 @@ num_all_groups        | 2
 num_failed_groups     | 0
 total_rows_processed  | 32
 total_rows_skipped    | 0
-dependent_var_levels  | 
+dependent_var_levels  |
 dependent_var_type    | double precision
 independent_var_types | integer, integer, double precision, double precision, double precision
 null_proxy            | None
@@ -1097,24 +1113,26 @@ Review the group table to see variable importance by group:
 SELECT * FROM mt_cars_output_group ORDER BY gid;
 </pre>
 <pre class="result">
--[ RECORD 1 ]------+------------------------------------------------------
-gid                | 1
-am                 | 0
-success            | t
-cat_n_levels       | {2,3}
-cat_levels_in_text | {0,1,4,6,8}
-oob_error          | 7.61453121176269
-cat_var_importance | {1.67195685185185,1.78292533068783}
-con_var_importance | {4.74889044753087,3.00387950664048,0.730074734848485}
--[ RECORD 2 ]------+------------------------------------------------------
-gid                | 2
-am                 | 1
-success            | t
-cat_n_levels       | {2,3}
-cat_levels_in_text | {0,1,4,6,8}
-oob_error          | 14.8126620718319
-cat_var_importance | {0.631733333333333,13.4535567708333}
-con_var_importance | {14.6258526998299,0.631733333333333,0}
+-[ RECORD 1 ]-----------+--------------------------------------------------------------------------------------
+gid                     | 1
+am                      | 0
+success                 | t
+cat_n_levels            | {2,3}
+cat_levels_in_text      | {0,1,4,6,8}
+oob_error               | 7.89937404385343
+oob_cat_var_importance  | {7.87991809689153,0.617942222222223}
+oob_con_var_importance  | {1.84637058464259,0.883091796875,3.84846682043232}
+impurity_var_importance | {22.4124027853243,20,35.1569822119963,2.92362864369191,19.5069863589875}
+-[ RECORD 2 ]-----------+--------------------------------------------------------------------------------------
+gid                     | 2
+am                      | 1
+success                 | t
+cat_n_levels            | {2,3}
+cat_levels_in_text      | {0,1,4,6,8}
+oob_error               | 25.4844331490554
+oob_cat_var_importance  | {4.8832,0.4919125}
+oob_con_var_importance  | {0.4919125,0,14.4849705555556}
+impurity_var_importance | {3.94164236675192,5.08316677853507,22.4710638947646,1.20369378537446,37.300433174574}
 </pre>
 
 -# Predict regression output for the same data and compare with original:
@@ -1125,11 +1143,11 @@ SELECT madlib.forest_predict('mt_cars_output',
                              'mt_cars',
                              'prediction_results',
                              'response');
-SELECT s.am, s.id, mpg, estimated_mpg, mpg-estimated_mpg as delta 
+SELECT s.am, s.id, mpg, estimated_mpg, mpg-estimated_mpg as delta
 FROM prediction_results p, mt_cars s WHERE s.id = p.id ORDER BY s.am, s.id;
 </pre>
 <pre class="result">
- am | id | mpg  |  estimated_mpg   |       delta        
+ am | id | mpg  |  estimated_mpg   |       delta
 ----+----+------+------------------+--------------------
   0 |  1 | 18.7 | 16.1644030112045 |   2.53559698879552
   0 |  3 | 24.4 | 20.1780892857143 |   4.22191071428571
@@ -1181,10 +1199,10 @@ SELECT madlib.get_tree('mt_cars_output',1,7);
  "5" [label="15.8",shape=box];
  "2" -> "6"[label="no"];
  "6" [label="12.8",shape=box];
- } //---end of digraph--------- 
+ } //---end of digraph---------
 </pre>
-Display the surrogate variables that are 
-used to compute the split for each node when 
+Display the surrogate variables that are
+used to compute the split for each node when
 the primary variable is NULL:
 <pre class="example">
 SELECT madlib.get_tree_surr('mt_cars_output',1,7);
@@ -1205,7 +1223,7 @@ SELECT madlib.get_tree_surr('mt_cars_output',1,7);
 
 <h4>NULL Handling Example</h4>
 
--# Create toy example to illustrate 'null-as-category' handling 
+-# Create toy example to illustrate 'null-as-category' handling
 for categorical features:
 <pre class='example'>
 DROP TABLE IF EXISTS null_handling_example;
@@ -1223,7 +1241,7 @@ INSERT INTO null_handling_example VALUES
 (4,'US','NY','rainy','d');
 </pre>
 
--# Train random forest tree.  Note that 'NULL' is set as a 
+-# Train random forest tree.  Note that 'NULL' is set as a
 valid level for the categorical features country, weather and city:
 <pre class='example'>
 DROP TABLE IF EXISTS train_output, train_output_group, train_output_summary;
@@ -1257,8 +1275,8 @@ id_col_name           | id
 dependent_varname     | response
 independent_varnames  | country,weather,city
 cat_features          | country,weather,city
-con_features          | 
-grouping_cols         | 
+con_features          |
+grouping_cols         |
 num_trees             | 10
 num_random_features   | 2
 max_tree_depth        | 3
@@ -1282,17 +1300,18 @@ View the summary table:
 SELECT * FROM train_output_group;
 </pre>
 <pre class='result'>
--[ RECORD 1 ]------+------------------------------------------
-gid                | 1
-success            | t
-cat_n_levels       | {2,2,2}
-cat_levels_in_text | {US,__NULL__,rainy,__NULL__,NY,__NULL__}
-oob_error          | 1.00000000000000000000
-cat_var_importance | {0.0714285714285714,0.0714285714285714,0}
-con_var_importance | 
+-[ RECORD 1 ]-----------+-----------------------------------------------------
+gid                     | 1
+success                 | t
+cat_n_levels            | {2,2,2}
+cat_levels_in_text      | {US,__NULL__,rainy,__NULL__,NY,__NULL__}
+oob_error               | 1.00000000000000000000
+oob_cat_var_importance  | {0.0555555555555556,0.0555555555555556,0}
+oob_con_var_importance  |
+impurity_var_importance | {39.4412331406551,22.2612425927946,28.2975242665503}
 </pre>
 
--# Predict for data not previously seen by assuming NULL 
+-# Predict for data not previously seen by assuming NULL
 value as the default:
 <pre class='example'>
 \\x off
@@ -1319,7 +1338,7 @@ FROM prediction_results p, table_test s
 WHERE s.id = p.id ORDER BY id;
 </pre>
 <pre class='result'>
- id | expected_response | estimated_response 
+ id | expected_response | estimated_response
 ----+-------------------+--------------------
   1 | a                 | a
   2 | b                 | b
@@ -1327,20 +1346,20 @@ WHERE s.id = p.id ORDER BY id;
   4 | d                 | d
 (4 rows)
 </pre>
-There is only training data for country 'US' so the 
-response for country 'IN' is 'a', corresponding to 
-a NULL (not 'US') country level.  Likewise, any 
-city in the 'US' that is not 'NY' will predict 
-response 'b', corresponding to a NULL (not 'NY') 
-city level. 
+There is only training data for country 'US' so the
+response for country 'IN' is 'a', corresponding to
+a NULL (not 'US') country level.  Likewise, any
+city in the 'US' that is not 'NY' will predict
+response 'b', corresponding to a NULL (not 'NY')
+city level.
 
 @anchor literature
 @par Literature
-[1] L. Breiman and A. Cutler. Random Forests. 
+[1] L. Breiman and A. Cutler. Random Forests.
 http://www.stat.berkeley.edu/~breiman/RandomForests
 
-[2] L. Breiman, A. Cutler, A. Liaw, and M. Wiener. 
-randomForest: Breiman and Cutler's Random Forests for 
+[2] L. Breiman, A. Cutler, A. Liaw, and M. Wiener.
+randomForest: Breiman and Cutler's Random Forests for
 Classification and Regression.
 http://cran.r-project.org/web/packages/randomForest/index.html
 

--- a/src/ports/postgres/modules/recursive_partitioning/test/random_forest.sql_in
+++ b/src/ports/postgres/modules/recursive_partitioning/test/random_forest.sql_in
@@ -53,6 +53,7 @@ SELECT forest_train(
 
 \x on
 SELECT * from train_output_summary;
+SELECT count(*) FROM train_output;
 SELECT * from train_output_group;
 
 -- classification with grouping
@@ -275,7 +276,7 @@ CREATE TABLE rf_gr_test (
     f2 integer, --filtered for gr = 2
     f3 double precision,
     cl integer
-) ;
+);
 
 INSERT INTO rf_gr_test (id,gr,f1,f2,f3,cl) VALUES
 (1,1,1,1,5,1),


### PR DESCRIPTION
JIRA: MADLIB-1205

This commit makes the following changes:
- Add impurity variable importance for random forests.
- Rename current cat_var_importance and con_var_importance measurements to
oob_cat_var_importance and oob_con_var_importance.

New impurity measurement is provided as impurity_var_importance, and supports
grouping. It combines the importance values for both categorical and
continuous features into a single array.

Co-authored-by: Rahul Iyer <riyer@pivotal.io>
Co-authored-by: Jingyi Mei <jmei@pivotal.io>
Co-authored-by: Arvind Sridhar <asridhar@pivotal.io>
Co-authored-by: Nandish Jayaram <njayaram@apache.org>