### PR TITLE
Utilities: Add check for whether type is of any array variant

### DIFF
--- a/src/ports/postgres/modules/utilities/test/unit_tests/test_utilities.py_in
+++ b/src/ports/postgres/modules/utilities/test/unit_tests/test_utilities.py_in
@@ -243,6 +243,9 @@ class UtilitiesTestCase(unittest.TestCase):
         self.assertFalse(s.is_valid_psql_type('boolean[]', s.INCLUDE_ARRAY | s.ONLY_ARRAY))
         self.assertFalse(s.is_valid_psql_type('boolean', s.ONLY_ARRAY))
         self.assertFalse(s.is_valid_psql_type('boolean[]', s.ONLY_ARRAY))
+        self.assertTrue(s.is_valid_psql_type('boolean[]', s.ANY_ARRAY))
+        self.assertTrue(s.is_valid_psql_type('boolean[]', s.INTEGER | s.ANY_ARRAY))
+        self.assertFalse(s.is_valid_psql_type('boolean', s.ANY_ARRAY))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/ports/postgres/modules/utilities/utilities.py_in
+++ b/src/ports/postgres/modules/utilities/utilities.py_in
@@ -175,6 +175,7 @@ TEXT = set(['text', 'varchar', 'character varying', 'char', 'character'])
 BOOLEAN = set(['boolean'])
 INCLUDE_ARRAY = set([unique_string('__include_array__')])
 ONLY_ARRAY = set([unique_string('__only_array__')])
+ANY_ARRAY = set([unique_string('__any_array__')])
 
 def is_valid_psql_type(arg, valid_types):
     """ Verify if argument is a valid type
@@ -184,11 +185,14 @@ def is_valid_psql_type(arg, valid_types):
         @param valid_types: set. Set of type names to look into.
                             This is typically created using the global types
                             created in this module.
-                            Two non-type flags are provided:
+                            Three non-type flags are provided:
+                                - ANY_ARRAY: indicates that the type should be
+                                    checked for whether it's any array type
                                 - ONLY_ARRAY: indicates that only array forms
                                     of the valid types should be checked
                                 - INCLUDE_ARRAY: indicates that array and scalar
                                     forms of the valid types should be checked
+                            ANY_ARRAY takes precedence over all other flags
                             If both ONLY_ARRAY and INCLUDE_ARRAY are present,
                             then ONLY_ARRAY takes precedence
 
@@ -196,6 +200,8 @@ def is_valid_psql_type(arg, valid_types):
                           2. valid_types = BOOLEAN | INTEGER | ONLY_ARRAY
                           3. valid_types = NUMERIC | INCLUDE_ARRAY
     """
+    if ANY_ARRAY <= valid_types:
+         return ('[]' in arg)
     if ONLY_ARRAY <= valid_types:
         return ('[]' in arg and arg.rstrip('[]') in valid_types)
     if INCLUDE_ARRAY <= valid_types:


### PR DESCRIPTION
Edited a utilities function to recognize whether a given column was of type array, no matter the actual data type of the array