### PR TITLE
Madpack: Fix missing test logs bug.

### DIFF
--- a/src/madpack/madpack.py
+++ b/src/madpack/madpack.py
@@ -712,8 +712,8 @@ def _process_py_sql_files_in_modules(modset, args_dict):
                     cur_tmpdir)
             else:
                 error_(this, "Something is wrong, shouldn't be here: %s" % src_file, True)
-        shutil.rmtree(cur_tmpdir)
-
+        if calling_operation == DB_CREATE_OBJECTS:
+            shutil.rmtree(cur_tmpdir)
 # ------------------------------------------------------------------------------
 def _execute_per_module_db_create_obj_algo(schema, maddir_mod_py, module,
                                            sqlfile, algoname, cur_tmpdir,


### PR DESCRIPTION
Due to a recent commit, madpack cleaned log files of test operations as
well as the atomic operations. As a result, log files are missing even
after install/dev check fails. This commit fixes this issue.

Co-authored-by: Jingyi Mei <jmei@pivotal.io>