### PR TITLE
Bring dev check commented test cases back

### DIFF
--- a/src/ports/postgres/modules/graph/test/pagerank.sql_in
+++ b/src/ports/postgres/modules/graph/test/pagerank.sql_in
@@ -60,6 +60,7 @@ INSERT INTO "EDGE" VALUES
 (5, 6, 2),
 (6, 3, 2);
 
+-- Test pagerank without group
 DROP TABLE IF EXISTS pagerank_out, pagerank_out_summary;
 SELECT pagerank(
              'vertex',        -- Vertex table
@@ -73,6 +74,8 @@ SELECT assert(relative_error(SUM(pagerank), 1) < 0.00001,
         'PageRank: Scores do not sum up to 1.'
     ) FROM pagerank_out;
 
+
+-- Test pagerank with group
 DROP TABLE IF EXISTS pagerank_gr_out;
 DROP TABLE IF EXISTS pagerank_gr_out_summary;
 SELECT pagerank(
@@ -84,7 +87,7 @@ SELECT pagerank(
              NULL,              -- Default damping factor (0.85)
              NULL,              -- Default max iters (100)
              NULL,              -- Default Threshold
-             'user_id');             -- Personlized Nodes
+             'user_id');        -- Grouping Column
 
 -- View the PageRank of all vertices, sorted by their scores.
 SELECT assert(relative_error(SUM(pagerank), 1) < 0.00001,
@@ -94,8 +97,16 @@ SELECT assert(relative_error(SUM(pagerank), 1) < 0.00001,
         'PageRank: Scores do not sum up to 1 for group 2.'
     ) FROM pagerank_gr_out WHERE user_id=2;
 
--- Tests for Personalized Page Rank
+-- Check the iteration numbers for convergency
+SELECT assert(relative_error(__iterations__, 11) = 0,
+        'PageRank: Incorrect iterations for group 1.'
+    ) FROM pagerank_gr_out_summary WHERE user_id=1;
+SELECT assert(relative_error(__iterations__, 14) = 0,
+        'PageRank: Incorrect iterations for group 2.'
+    ) FROM pagerank_gr_out_summary WHERE user_id=2;
 
+
+-- Tests for Personalized Page Rank
 -- Test without grouping
 
 DROP TABLE IF EXISTS pagerank_ppr_out;
@@ -141,14 +152,6 @@ SELECT assert(relative_error(SUM(pagerank), 1) < 0.005,
     ) FROM pagerank_ppr_grp_out WHERE user_id=1;
 select assert(array_agg(user_id order by pagerank desc)= '{2, 2, 1, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1}','Unexpected Ranking with grouping ') from  pagerank_ppr_grp_out  ;
 
--- These tests have been temporarily removed for GPDB5 alpha support
-
--- SELECT assert(relative_error(__iterations__, 27) = 0,
---         'PageRank: Incorrect iterations for group 1.'
---     ) FROM pagerank_gr_out_summary WHERE user_id=1;
--- SELECT assert(relative_error(__iterations__, 31) = 0,
---         'PageRank: Incorrect iterations for group 2.'
---     ) FROM pagerank_gr_out_summary WHERE user_id=2;
 
 -- Test to capture corner case reported in https://issues.apache.org/jira/browse/MADLIB-1229
 

--- a/src/ports/postgres/modules/pca/test/pca.sql_in
+++ b/src/ports/postgres/modules/pca/test/pca.sql_in
@@ -146,15 +146,16 @@ COPY mat (id, row_vec, grp) FROM stdin delimiter '|';
 \.
 
 -- This test has been temporarily removed for GPDB5 alpha support
+-- Update: just ran fine on GPDB5, adding back
 
 -- Learn individaul PCA models based on grouping column (grp)
--- drop table if exists result_table_214712398172490837;
--- drop table if exists result_table_214712398172490837_mean;
--- drop table if exists result_table_214712398172490838;
--- select pca_train('mat', 'result_table_214712398172490837', 'id', 0.8,
--- 'grp', 5, FALSE, 'result_table_214712398172490838');
--- select * from result_table_214712398172490837;
--- select * from result_table_214712398172490838;
+drop table if exists result_table_214712398172490837;
+drop table if exists result_table_214712398172490837_mean;
+drop table if exists result_table_214712398172490838;
+select pca_train('mat', 'result_table_214712398172490837', 'id', 0.8,
+'grp', 5, FALSE, 'result_table_214712398172490838');
+select * from result_table_214712398172490837;
+select * from result_table_214712398172490838;
 
 -- Matrix in the column format
 DROP TABLE IF EXISTS cmat;

--- a/src/ports/postgres/modules/svm/test/svm.sql_in
+++ b/src/ports/postgres/modules/svm/test/svm.sql_in
@@ -822,9 +822,6 @@ FROM svm_unbalanced JOIN svm_predict_out
 using (index)
 WHERE y = prediction and y = 1;
 
--- Disabling cross validation tests due to a DROP CASCADE issue
--- Update: just ran fine on GPDB5, adding back
-
 -- Cross validation tests
 SELECT svm_one_class(
     'svm_normalized',

--- a/src/ports/postgres/modules/svm/test/svm.sql_in
+++ b/src/ports/postgres/modules/svm/test/svm.sql_in
@@ -822,6 +822,9 @@ FROM svm_unbalanced JOIN svm_predict_out
 using (index)
 WHERE y = prediction and y = 1;
 
+-- Disabling cross validation tests due to a DROP CASCADE issue
+-- Update: just ran fine on GPDB5, adding back
+
 -- Cross validation tests
 SELECT svm_one_class(
     'svm_normalized',


### PR DESCRIPTION
Previously, there are several dev check test cases that got commented out, with a disclaimer similar to
"This test has been temporarily removed for GPDB5 support". We looked into those test cases and brought  some of them back.