### PR TITLE
Ubuntu support: Enable creation of gppkg on Ubuntu

### DIFF
--- a/ReadMe_Build.txt
+++ b/ReadMe_Build.txt
@@ -173,6 +173,11 @@ root directory) for more options, after having run `cmake` the first time.
     with `-DPYXB_TAR_SOURCE=/path/to/pyxb_x.tar.gz`, in which case
     this tarball is used.
 
+- `CREATE_RPM_FOR_UBUNTU` (default: *empty*)
+
+    By default, we create a .deb madlib installer on Ubuntu. If this
+    flag is set to 'True', we will create an RPM instead. Note that
+    package alien must be installed for this to work.
 
 Debugging
 =========

--- a/deploy/CMakeLists.txt
+++ b/deploy/CMakeLists.txt
@@ -26,10 +26,14 @@ elseif(UNIX)
         )
     elseif(IS_DEBIAN)
         message(STATUS "Detected Debian version ${DEB_VERSION}")
-        # -- If cmake flag -DCREATE_RPM_FOR_UBUNTU is set to some
-        # value, then we will create an RPM on Ubuntu. If that
-        # flag is not set to any value in cmake, then we create
-        # only .deb artifact on Ubuntu.
+        # By default, the cmake flag -DCREATE_RPM_FOR_UBUNTU is not
+        # set to any value. The default behavior is to create a .deb
+        # artifact when MADlib is compiled on Ubuntu.
+        # If we instead want to create an RPM artifact for MADlib
+        # on Ubuntu, then the cmake flag -DCREATE_RPM_FOR_UBUNTU can
+        # be set to some value (say True), and we will only create
+        # an RPM artifact on Ubuntu (i.e., we create an rpm instead
+        # of the default .deb).
         # Note that package alien must already be installed for
         # building an RPM on Ubuntu.
         if(CREATE_RPM_FOR_UBUNTU)

--- a/deploy/CMakeLists.txt
+++ b/deploy/CMakeLists.txt
@@ -10,12 +10,11 @@ if(APPLE)
         PackageMaker
     )
 elseif(UNIX)
-
     debian_version(DEB_VERSION)
     if(DEB_VERSION AND NOT (DEB_VERSION STREQUAL "DEB_VERSION-NOTFOUND"))
       set(IS_DEBIAN "True")
     endif()
-    rh_version(IS_REDHAT)
+    rh_version(RH_VERSION)
     if(RH_VERSION AND NOT (RH_VERSION STREQUAL "RH_VERSION-NOTFOUND"))
       set(IS_REDHAT "True")
     endif()
@@ -27,9 +26,21 @@ elseif(UNIX)
         )
     elseif(IS_DEBIAN)
         message(STATUS "Detected Debian version ${DEB_VERSION}")
-        list(APPEND CPACK_GENERATOR
-            DEB
-        )
+        # -- If cmake flag -DCREATE_RPM_FOR_UBUNTU is set to some
+        # value, then we will create an RPM on Ubuntu. If that
+        # flag is not set to any value in cmake, then we create
+        # only .deb artifact on Ubuntu.
+        # Note that package alien must already be installed for
+        # building an RPM on Ubuntu.
+        if(CREATE_RPM_FOR_UBUNTU)
+          list(APPEND CPACK_GENERATOR
+              RPM
+          )
+        else(CREATE_RPM_FOR_UBUNTU)
+          list(APPEND CPACK_GENERATOR
+              DEB
+          )
+        endif(CREATE_RPM_FOR_UBUNTU)
     endif()
 endif()
 
@@ -78,8 +89,10 @@ if(IS_REDHAT)
   set(CPACK_POSTFLIGHT_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/postflight.sh)
   set(CPACK_MONOLITHIC_INSTALL 1)
 elseif(IS_DEBIAN)
-  set(CPACK_PACKAGE_FILE_NAME
-    "madlib${_PACKAGE_SUFFIX}-${MADLIB_VERSION_STRING}-${CMAKE_SYSTEM_NAME}")
+  if(NOT CREATE_RPM_FOR_UBUNTU)
+    set(CPACK_PACKAGE_FILE_NAME
+      "madlib${_PACKAGE_SUFFIX}-${MADLIB_VERSION_STRING}-${CMAKE_SYSTEM_NAME}")
+  endif(NOT CREATE_RPM_FOR_UBUNTU)
   set(CPACK_PACKAGE_VERSION ${MADLIB_VERSION_STRING})
   set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_SOURCE_DIR}/DEB/config;${CMAKE_CURRENT_SOURCE_DIR}/DEB/templates;${CMAKE_CURRENT_SOURCE_DIR}/DEB/preinst;${CMAKE_CURRENT_SOURCE_DIR}/DEB/postinst;${CMAKE_CURRENT_SOURCE_DIR}/DEB/postrm")
 endif()


### PR DESCRIPTION
This commit makes necessary changes to create a gppkg on Ubuntu. The
default behavior when MADlib is built on Ubuntu is to create a .deb
installer. If we want to create a gppkg, then we need an RPM due to
limitations in gppkg. We now create an RPM on Ubuntu (assuming package
alien is installed on Ubuntu) if the right cmake flag is specified. Once
an RPM is created on `make package`, we can now go ahead and create the
gppkg using `make gppkg`.
The cmake flag to use if we want to create an .rpm instead of .deb on
Ubuntu when we run `make package` is:
-DCREATE_RPM_FOR_UBUNTU=True

Co-authored-by: Orhan Kislal <okislal@pivotal.io>