### PR TITLE
Allocator: Remove 16-byte alignment for pointers in GP6

### DIFF
--- a/src/ports/greenplum/dbconnector/dbconnector.hpp
+++ b/src/ports/greenplum/dbconnector/dbconnector.hpp
@@ -32,7 +32,7 @@ extern "C" {
 
 #include "Compatibility.hpp"
 
-#if PG_VERSION_NUM >= 90000
+#if GP_VERSION_NUM >= 60000
     // MADlib aligns the pointers returned by palloc() to 16-byte boundaries
     // (see Allocator_impl.hpp). This is done to allow Eigen vectorization  (see
     // http://eigen.tuxfamily.org/index.php?title=FAQ#Vectorization for more
@@ -40,9 +40,8 @@ extern "C" {
     // not 16-byte aligned.
     // Further, the pointer realignment invalidates a header that palloc creates
     // just prior to the pointer address.  Greenplum after commit <> fails due
-    // to this invalid header.  Hence, the pointer realignment (and Eigen
-    // vectorization) is disabled below for Greenplum 6 and above.
-    #define DISABLE_POINTER_ALIGNMENT_FOR_GREENPLUM
+    // to this invalid header.  Hence, the pointer realignment and Eigen
+    // vectorization is disabled below for Greenplum 6 and above.
 
     // See http://eigen.tuxfamily.org/dox/group__TopicUnalignedArrayAssert.html
     // for steps to disable vectorization

--- a/src/ports/greenplum/dbconnector/dbconnector.hpp
+++ b/src/ports/greenplum/dbconnector/dbconnector.hpp
@@ -32,6 +32,24 @@ extern "C" {
 
 #include "Compatibility.hpp"
 
+#if PG_VERSION_NUM >= 90000
+    // MADlib aligns the pointers returned by palloc() to 16-byte boundaries
+    // (see Allocator_impl.hpp). This is done to allow Eigen vectorization  (see
+    // http://eigen.tuxfamily.org/index.php?title=FAQ#Vectorization for more
+    // info).  This vectorization has to be explicitly disabled if pointers are
+    // not 16-byte aligned.
+    // Further, the pointer realignment invalidates a header that palloc creates
+    // just prior to the pointer address.  Greenplum after commit <> fails due
+    // to this invalid header.  Hence, the pointer realignment (and Eigen
+    // vectorization) is disabled below for Greenplum 6 and above.
+    #define DISABLE_POINTER_ALIGNMENT_FOR_GREENPLUM
+
+    // See http://eigen.tuxfamily.org/dox/group__TopicUnalignedArrayAssert.html
+    // for steps to disable vectorization
+    #define EIGEN_DONT_VECTORIZE
+    #define EIGEN_DISABLE_UNALIGNED_ARRAY_ASSERT
+#endif
+
 #include "../../postgres/dbconnector/dbconnector.hpp"
 
 #endif // defined(MADLIB_GREENPLUM_DBCONNECTOR_HPP)

--- a/src/ports/postgres/dbconnector/Allocator_impl.hpp
+++ b/src/ports/postgres/dbconnector/Allocator_impl.hpp
@@ -211,7 +211,7 @@ template <dbal::ZeroMemory ZM>
 inline
 void *
 Allocator::internalPalloc(size_t inSize) const {
-#if MAXIMUM_ALIGNOF >= 16
+#if MAXIMUM_ALIGNOF >= 16  || defined DISABLE_POINTER_ALIGNMENT_FOR_GREENPLUM
     return (ZM == dbal::DoZero) ? palloc0(inSize) : palloc(inSize);
 #else
     if (inSize > std::numeric_limits<size_t>::max() - 16)
@@ -221,7 +221,7 @@ Allocator::internalPalloc(size_t inSize) const {
     const size_t size = inSize + 16;
     void *raw = (ZM == dbal::DoZero) ? palloc0(size) : palloc(size);
     return makeAligned(raw);
-#endif
+#endif  // MAXIMUM_ALIGNOF >= 16
 }
 
 /**
@@ -243,7 +243,7 @@ template <dbal::ZeroMemory ZM>
 inline
 void *
 Allocator::internalRePalloc(void *inPtr, size_t inSize) const {
-#if MAXIMUM_ALIGNOF >= 16
+#if MAXIMUM_ALIGNOF >= 16 || defined DISABLE_POINTER_ALIGNMENT_FOR_GREENPLUM
     return repalloc(inPtr, inSize);
 #else
     if (inSize > std::numeric_limits<size_t>::max() - 16) {
@@ -262,7 +262,7 @@ Allocator::internalRePalloc(void *inPtr, size_t inSize) const {
     }
 
     return makeAligned(raw);
-#endif
+#endif // MAXIMUM_ALIGNOF >= 16
 }
 
 /**
@@ -298,7 +298,7 @@ Allocator::makeAligned(void *inPtr) const {
 inline
 void *
 Allocator::unaligned(void *inPtr) const {
-#if MAXIMUM_ALIGNOF >= 16
+#if MAXIMUM_ALIGNOF >= 16 || defined DISABLE_POINTER_ALIGNMENT_FOR_GREENPLUM
     return inPtr;
 #else
     return (*(reinterpret_cast<void**>(inPtr) - 1));

--- a/src/ports/postgres/dbconnector/Allocator_impl.hpp
+++ b/src/ports/postgres/dbconnector/Allocator_impl.hpp
@@ -211,7 +211,7 @@ template <dbal::ZeroMemory ZM>
 inline
 void *
 Allocator::internalPalloc(size_t inSize) const {
-#if MAXIMUM_ALIGNOF >= 16  || defined DISABLE_POINTER_ALIGNMENT_FOR_GREENPLUM
+#if MAXIMUM_ALIGNOF >= 16  || defined EIGEN_DONT_VECTORIZE
     return (ZM == dbal::DoZero) ? palloc0(inSize) : palloc(inSize);
 #else
     if (inSize > std::numeric_limits<size_t>::max() - 16)
@@ -243,7 +243,7 @@ template <dbal::ZeroMemory ZM>
 inline
 void *
 Allocator::internalRePalloc(void *inPtr, size_t inSize) const {
-#if MAXIMUM_ALIGNOF >= 16 || defined DISABLE_POINTER_ALIGNMENT_FOR_GREENPLUM
+#if MAXIMUM_ALIGNOF >= 16 || defined EIGEN_DONT_VECTORIZE
     return repalloc(inPtr, inSize);
 #else
     if (inSize > std::numeric_limits<size_t>::max() - 16) {
@@ -298,7 +298,7 @@ Allocator::makeAligned(void *inPtr) const {
 inline
 void *
 Allocator::unaligned(void *inPtr) const {
-#if MAXIMUM_ALIGNOF >= 16 || defined DISABLE_POINTER_ALIGNMENT_FOR_GREENPLUM
+#if MAXIMUM_ALIGNOF >= 16 || defined EIGEN_DONT_VECTORIZE
     return inPtr;
 #else
     return (*(reinterpret_cast<void**>(inPtr) - 1));


### PR DESCRIPTION
Findings:
1. MADlib performs a 16-byte alignment for pointers returned by palloc.
2. Postgres prepends a small (16 byte usually) header before every
pointer which includes
	a. the memory context and
	b. the size of the memory allocation.
3. Greenplum 6+ tweaks that scheme a little: instead of the memory context,
the header tracks a "shared header" which points to another struct with
richer information (aside from the memory context).
4. Postgres calls MemoryContextContains both with the final func
for an aggregate and finalize function for a windowed aggregate.
5. Currently Postgres always concludes that the datum from MADlib is
allocated outside of the context, and makes an extra copy. In
Greenplum, MemoryContextContains needs to dereference the shared header.
This is a problem since the pointer has been shifted and the function is
misinterpreting the header.

In this commit, we disable the pointer alignment for GPDB 6+ to avoid
failure in this check. Further, we also have to disable vectorization in
Eigen since it does not work when pointers are not 16-byte aligned.

Co-authored-by: Jesse Zhang <sbjesse@gmail.com>
Co-authored-by: Nandish Jayaram <njayaram@apache.org>