### PR TITLE
Fix false positive for Postgres 10+

### DIFF
--- a/src/ports/postgres/cmake/PostgreSQLUtils.cmake
+++ b/src/ports/postgres/cmake/PostgreSQLUtils.cmake
@@ -82,8 +82,7 @@ function(determine_target_versions OUT_VERSIONS)
                     set(VERSION "4.3ORCA")
                 endif()
             elseif(${PORT_UC} STREQUAL "POSTGRESQL" AND
-                    (${${PORT_UC}_VERSION_MAJOR} EQUAL 10 OR
-                    ${${PORT_UC}_VERSION_PATCH} GREATER 10))
+                    (${${PORT_UC}_VERSION_MAJOR} EQUAL 10))
                 # Starting Postgresql 10, semantic versioning will be followed,
                 # implying we only need 1 folder for same major versions
                 set(VERSION ${${PORT_UC}_VERSION_MAJOR})


### PR DESCRIPTION
We used to mistake 9.3.24 as a higher version than Postgres 10 and stop
matching it to the correct "port". This patch fixes that.