### PR TITLE
Build: Add single quote while setting AppendOnly guc

### DIFF
--- a/src/ports/postgres/modules/kmeans/test/kmeans.sql_in
+++ b/src/ports/postgres/modules/kmeans/test/kmeans.sql_in
@@ -9,8 +9,7 @@ CREATE TABLE kmeans_2d(
 	id SERIAL,
 	x DOUBLE PRECISION,
 	y DOUBLE PRECISION,
-	position DOUBLE PRECISION[],
-  PRIMARY KEY (id)
+	position DOUBLE PRECISION[]
 ) m4_ifdef(`__POSTGRESQL__', `', `DISTRIBUTED BY (id)');
 
 INSERT INTO kmeans_2d(x, y, position)

--- a/src/ports/postgres/modules/regress/test/linear.ic.sql_in
+++ b/src/ports/postgres/modules/regress/test/linear.ic.sql_in
@@ -35,7 +35,6 @@ CREATE TABLE weibull (
     x1 DOUBLE PRECISION,
     x2 DOUBLE PRECISION,
     y DOUBLE PRECISION
-    , CONSTRAINT pk_weibull PRIMARY KEY (id)
 );
 
 /*

--- a/src/ports/postgres/modules/regress/test/linear.sql_in
+++ b/src/ports/postgres/modules/regress/test/linear.sql_in
@@ -15,7 +15,6 @@ CREATE TABLE weibull (
     x1 DOUBLE PRECISION,
     x2 DOUBLE PRECISION,
     y DOUBLE PRECISION
-    , CONSTRAINT pk_weibull PRIMARY KEY (id)
 ) m4_ifdef(`__POSTGRESQL__', `', `DISTRIBUTED BY (id)');
 
 /*
@@ -68,7 +67,6 @@ CREATE TABLE unm (
     x1 DOUBLE PRECISION,
     x2 DOUBLE PRECISION,
     y DOUBLE PRECISION
-    , CONSTRAINT pk_unm PRIMARY KEY (id)
 );
 
 INSERT INTO unm(id, x1, x2, y) VALUES
@@ -106,7 +104,6 @@ CREATE TABLE houses (
     price INTEGER,
     size INTEGER,
     lot INTEGER
-    , CONSTRAINT pk_houses PRIMARY KEY (id)
 );
 
 INSERT INTO houses(tax, bedroom, bath, price, size, lot) VALUES

--- a/src/ports/postgres/modules/regress/test/logistic.ic.sql_in
+++ b/src/ports/postgres/modules/regress/test/logistic.ic.sql_in
@@ -35,7 +35,6 @@ CREATE TABLE patients (
     second_attack INTEGER,
     treatment INTEGER,
     trait_anxiety INTEGER
-    , CONSTRAINT pk_patient PRIMARY key (id)
 );
 
 INSERT INTO patients(ID, second_attack, treatment, trait_anxiety) VALUES

--- a/src/ports/postgres/modules/regress/test/logistic.sql_in
+++ b/src/ports/postgres/modules/regress/test/logistic.sql_in
@@ -15,7 +15,6 @@ CREATE TABLE patients (
     second_attack INTEGER,
     treatment INTEGER,
     trait_anxiety INTEGER
-    , CONSTRAINT pk_patient PRIMARY key (id)
 )m4_ifdef(`__POSTGRESQL__', `', `DISTRIBUTED BY (id)');
 
 INSERT INTO patients(ID, second_attack, treatment, trait_anxiety) VALUES
@@ -177,7 +176,6 @@ CREATE TABLE crime (
     Unemp2  INTEGER,
     Median  INTEGER,
     BelowMed INTEGER
-    , CONSTRAINT pk_crime PRIMARY key (id)
 )m4_ifdef(`__POSTGRESQL__', `', `DISTRIBUTED BY (id)');
 
 INSERT INTO crime(
@@ -271,7 +269,6 @@ CREATE TABLE grad_school (
     gre INTEGER,
     gpa DOUBLE PRECISION,
     rank INTEGER
-    , CONSTRAINT pk_grad_school PRIMARY key (id)
 )m4_ifdef(`__POSTGRESQL__', `', `DISTRIBUTED BY (id)');
 
 COPY grad_school (admit, gre, gpa, rank) FROM STDIN;

--- a/src/ports/postgres/modules/regress/test/marginal.ic.sql_in
+++ b/src/ports/postgres/modules/regress/test/marginal.ic.sql_in
@@ -29,7 +29,6 @@ CREATE TABLE patients (
     second_attack INTEGER,
     treatment INTEGER,
     trait_anxiety INTEGER
-    , CONSTRAINT pk_patient PRIMARY key (id)
 );
 INSERT INTO patients(ID, second_attack, treatment, trait_anxiety) VALUES
 ( 1, 1, 1, 70),

--- a/src/ports/postgres/modules/regress/test/marginal.sql_in
+++ b/src/ports/postgres/modules/regress/test/marginal.sql_in
@@ -10,7 +10,6 @@ CREATE TABLE patients (
     second_attack INTEGER,
     treatment INTEGER,
     trait_anxiety INTEGER
-    , CONSTRAINT pk_patient PRIMARY key (id)
 )m4_ifdef(`__POSTGRESQL__', `', `DISTRIBUTED BY (id)');
 INSERT INTO patients(ID, second_attack, treatment, trait_anxiety) VALUES
 ( 1, 1, 1, 70),

--- a/src/ports/postgres/modules/regress/test/multilogistic.ic.sql_in
+++ b/src/ports/postgres/modules/regress/test/multilogistic.ic.sql_in
@@ -35,7 +35,6 @@ CREATE TABLE patients (
     "SECOND_ATTACK" INTEGER,
     treatment INTEGER,
     trait_anxiety INTEGER
-    ,CONSTRAINT pk_patient PRIMARY key (id)
 );
 
 INSERT INTO patients(id, "SECOND_ATTACK", treatment, trait_anxiety) VALUES

--- a/src/ports/postgres/modules/regress/test/multilogistic.sql_in
+++ b/src/ports/postgres/modules/regress/test/multilogistic.sql_in
@@ -16,7 +16,6 @@ CREATE TABLE patients (
     "SECOND_ATTACK" INTEGER,
     treatment INTEGER,
     trait_anxiety INTEGER
-    ,CONSTRAINT pk_patient PRIMARY key (id)
 ) m4_ifdef(`__POSTGRESQL__', `', `DISTRIBUTED BY (id)');
 
 INSERT INTO patients(id, "SECOND_ATTACK", treatment, trait_anxiety) VALUES
@@ -380,7 +379,6 @@ CREATE TABLE patients_with_null (
     second_attack INTEGER,
     treatment INTEGER,
     trait_anxiety INTEGER
-    ,CONSTRAINT pk_patient_null PRIMARY key (id)
 ) m4_ifdef(`__POSTGRESQL__', `', `DISTRIBUTED BY (id)');
 INSERT INTO patients_with_null(ID, second_attack, treatment, trait_anxiety) VALUES
 ( 1, 1, 1, 70),
@@ -439,7 +437,6 @@ CREATE TABLE patients_all_null (
     second_attack INTEGER,
     treatment INTEGER,
     trait_anxiety INTEGER
-    ,CONSTRAINT pk_patient_all_null PRIMARY key (id)
 )m4_ifdef(`__POSTGRESQL__', `', `DISTRIBUTED BY (id)');
 INSERT INTO patients_all_null(ID, second_attack, treatment, trait_anxiety) VALUES
 ( 1, NULL, 1, 70),

--- a/src/ports/postgres/modules/regress/test/robust.ic.sql_in
+++ b/src/ports/postgres/modules/regress/test/robust.ic.sql_in
@@ -34,7 +34,6 @@ CREATE TABLE weibull (
     x1 DOUBLE PRECISION,
     x2 DOUBLE PRECISION,
     y DOUBLE PRECISION
-    , CONSTRAINT pk_weibull PRIMARY KEY (id)
 );
 
 /*

--- a/src/ports/postgres/modules/regress/test/robust.sql_in
+++ b/src/ports/postgres/modules/regress/test/robust.sql_in
@@ -15,7 +15,6 @@ CREATE TABLE weibull (
     x1 DOUBLE PRECISION,
     x2 DOUBLE PRECISION,
     y DOUBLE PRECISION
-    , CONSTRAINT pk_weibull PRIMARY KEY (id)
 ) m4_ifdef(`__POSTGRESQL__', `', `DISTRIBUTED BY (id)');
 
 /*
@@ -102,7 +101,6 @@ CREATE TABLE patients (
     second_attack INTEGER,
     treatment INTEGER,
     trait_anxiety INTEGER
-    , CONSTRAINT pk_patient PRIMARY key (id)
 ) m4_ifdef(`__POSTGRESQL__', `', `DISTRIBUTED BY (id)');
 INSERT INTO patients(ID, second_attack, treatment, trait_anxiety) VALUES
 ( 1, 1, 1, 70),

--- a/src/ports/postgres/modules/stats/test/cox_prop_hazards.ic.sql_in
+++ b/src/ports/postgres/modules/stats/test/cox_prop_hazards.ic.sql_in
@@ -33,7 +33,6 @@ CREATE TABLE leukemia (
     wbc DOUBLE PRECISION,
     timedeath INTEGER,
     status BOOLEAN
-    ,CONSTRAINT pk_leukemia PRIMARY key (id)
 );
 
 

--- a/src/ports/postgres/modules/stats/test/cox_prop_hazards.sql_in
+++ b/src/ports/postgres/modules/stats/test/cox_prop_hazards.sql_in
@@ -16,7 +16,6 @@ CREATE TABLE leukemia (
     wbc DOUBLE PRECISION,
     timedeath INTEGER,
     status BOOLEAN
-    ,CONSTRAINT pk_leukemia PRIMARY key (id)
 )m4_ifdef(<!__POSTGRESQL__!>, <!!>, <!DISTRIBUTED BY (id)!>);
 
 
@@ -101,7 +100,6 @@ CREATE TABLE leukemia (
     wbc DOUBLE PRECISION,
     timedeath INTEGER,
     status BOOLEAN
-    ,CONSTRAINT pk_leukemia PRIMARY key (id)
 )m4_ifdef(<!__POSTGRESQL__!>, <!!>, <!DISTRIBUTED BY (id)!>);
 
 INSERT INTO leukemia(id, grp, wbc, timedeath, status) VALUES

--- a/src/ports/postgres/modules/utilities/control.py_in
+++ b/src/ports/postgres/modules/utilities/control.py_in
@@ -199,25 +199,31 @@ class AOControl(ContextDecorator):
                         for k, v in self.storage_options_dict.iteritems()])
 
     def __enter__(self):
+        # We first check if we can get the guc value from the database using the
+        # show command. If this fails, then we assume that the guc doesn't exist
+        # and we ignore the error and return. This can happen when platform is
+        # postgres, or platform is gpdb but the guc doesn't exist anymore.
         try:
             _storage_options_str = plpy.execute(
                 "show gp_default_storage_options")[0]["gp_default_storage_options"]
-            self._parse_gp_default_storage_options(_storage_options_str)
+        except plpy.SPIError:
+            self.guc_exists = False
+            return self
 
+        if self.guc_exists:
+            self._parse_gp_default_storage_options(_storage_options_str)
             # Set APPENDONLY=<enable> after backing up existing value
             self.was_ao_enabled = self.storage_options_dict['appendonly']
             self.storage_options_dict['appendonly'] = self.to_enable
-            plpy.execute("set gp_default_storage_options={0}".
+            plpy.execute("set gp_default_storage_options='{0}'".
                          format(self._gp_default_storage_options))
-        except plpy.SPIError:
-            self.guc_exists = False
-        finally:
-            return self
+
+        return self
 
     def __exit__(self, *args):
         if self.guc_exists:
             self.storage_options_dict['appendonly'] = self.was_ao_enabled
-            plpy.execute("set gp_default_storage_options={0}".
+            plpy.execute("set gp_default_storage_options='{0}'".
                          format(self._gp_default_storage_options))
         if args and args[0]:
             # an exception was raised in code. We return False so that any

--- a/src/ports/postgres/modules/utilities/test/unit_tests/test_control.py_in
+++ b/src/ports/postgres/modules/utilities/test/unit_tests/test_control.py_in
@@ -55,8 +55,8 @@ class ControlTestCase(unittest.TestCase):
         with self.subject.AOControl(False) as C:
             self.assertFalse(C.storage_options_dict['appendonly'])
         self.plpy_mock_execute.assert_called_with(
-            "set gp_default_storage_options=compresstype=none,blocksize=32768"
-            ",appendonly=True,orientation=row,checksum=true")
+            "set gp_default_storage_options='compresstype=none,blocksize=32768"
+            ",appendonly=True,orientation=row,checksum=true'")
 
     def test_ao_control_true(self):
         option = ('appendonly=true,blocksize=32768,compresstype=none,'
@@ -65,8 +65,8 @@ class ControlTestCase(unittest.TestCase):
         with self.subject.AOControl(True) as C:
             self.assertTrue(C.storage_options_dict['appendonly'])
         self.plpy_mock_execute.assert_called_with(
-            "set gp_default_storage_options=compresstype=none,blocksize=32768"
-            ",appendonly=True,orientation=row,checksum=true")
+            "set gp_default_storage_options='compresstype=none,blocksize=32768"
+            ",appendonly=True,orientation=row,checksum=true'")
 
     def test_ao_control_missing(self):
         option = ('appendonly=true,blocksize=32768,compresstype=none,'


### PR DESCRIPTION
Commit 3db98babe3326fb5e2cd16d0639a2bef264f4b04 added a context manager
for setting appendonly to false for all madlib modules. The commit was
missing a quote around the `gp_default_storage_options` guc because of
which the set command always failed. This commit adds a quote while
setting the guc.

Co-authored-by: Nikhil Kak<nkak@pivotal.io>
