### PR TITLE
Upgrade: Fix issue with upgrading RPM to 1.15.1

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -9,6 +9,34 @@ commit history located at https://github.com/apache/madlib/commits/master.
 
 Current list of bugs and issues can be found at https://issues.apache.org/jira/browse/MADLIB.
 —-------------------------------------------------------------------------
+MADlib v1.15.1:
+
+Release Date: 2018-Oct-XX
+
+New features:
+    - Add ubuntu support for MADlib (MADLIB-1256).
+    - Elastic Net: Add grouping by non-numeric column support (MADLIB-1262).
+    - KNN: Accept expressions for point_column_name and test_column_name (MADLIB-1060).
+    - Vec2Cols: Allow arrays of different lengths (MADLIB-1270).
+    - Madpack: Add a script for automating changelist creation.
+
+Bug fixes:
+    - Allocator: Remove 16-byte alignment in GPDB 6.
+    - Build: Download compatible Boost if version >= 1.65 (MADLIB-1235).
+    - Build: Remove primary key constraint in IC/DC.
+    - CMake: Fix false positive for Postgres 10+ check.
+    - MLP: Simplify momentum and Nesterov updates (MADLIB-1272).
+    - Utilities: Use plpy.quote_ident if available.
+
+Others:
+    - Simplify maintenance via removing online examples from sql functions (MADLIB-1260).
+    - Re-enable PCA and PageRank tests (MADLIB-1264).
+    - Build: Disable AppendOnly if available (MADLIB-1171, MADLIB-1273).
+    - Improve documentation of various modules.
+
+
+
+—-------------------------------------------------------------------------
 MADlib v1.15:
 
 Release Date: 2018-Aug-15

--- a/deploy/postflight.sh
+++ b/deploy/postflight.sh
@@ -2,7 +2,7 @@
 
 # $0 - Script Path, $1 - Package Path, $2 - Target Location, and $3 - Target Volume
 
-MADLIB_VERSION=1.15.1-dev
+MADLIB_VERSION=1.15.1
 
 # Remove existing soft links
 find $2/usr/local/madlib/bin -depth -type l -exec rm {} \; 2>/dev/null

--- a/deploy/rpm_post_uninstall.sh
+++ b/deploy/rpm_post_uninstall.sh
@@ -17,10 +17,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# remove symlinks created during rpm install
-find $RPM_INSTALL_PREFIX/madlib/Current -depth -type l -exec rm {} \; 2>/dev/null
-find $RPM_INSTALL_PREFIX/madlib/bin -depth -type l -exec rm {} \; 2>/dev/null
-find $RPM_INSTALL_PREFIX/madlib/doc -depth -type l -exec rm {} \; 2>/dev/null
+##############################################################
+#### During RPM upgrade, rpm_post.sh is run first, followed by
+## rpm_post_uninstall.sh. So we must do all the uninstallation specific stuff
+## based on the current operation being uninstall or upgrade.
 
-# remove "Versions" directory if it's empty
-rmdir $RPM_INSTALL_PREFIX/madlib/Versions 2>/dev/null
+# If the first argument to %preun and %postun is 1, the action is an upgrade
+# If the first argument to %preun and %postun is 0, the action is uninstallation
+##############################################################
+if [ "$1" = "0" ]; then
+    # remove symlinks created during rpm install
+    find $RPM_INSTALL_PREFIX/madlib/Current -depth -type l -exec rm {} \; 2>/dev/null
+    find $RPM_INSTALL_PREFIX/madlib/bin -depth -type l -exec rm {} \; 2>/dev/null
+    find $RPM_INSTALL_PREFIX/madlib/doc -depth -type l -exec rm {} \; 2>/dev/null
+
+    # remove "Versions" directory if it's empty
+    if [ -d $RPM_INSTALL_PREFIX/madlib/Versions ]; then
+        rmdir $RPM_INSTALL_PREFIX/madlib/Versions 2>/dev/null
+    fi
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.apache.madlib</groupId>
   <artifactId>madlib</artifactId>
-  <version>1.15.1-dev</version>
+  <version>1.15.1</version>
   <packaging>pom</packaging>
 
   <build>

--- a/src/config/Version.yml
+++ b/src/config/Version.yml
@@ -1,1 +1,1 @@
-version: 1.15.1-dev
+version: 1.15.1

--- a/src/madpack/changelist_1.15_1.15.1.yaml
+++ b/src/madpack/changelist_1.15_1.15.1.yaml
@@ -1,0 +1,59 @@
+# ------------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ------------------------------------------------------------------------------
+
+# Changelist for MADlib version rel/v1.15 to rel/v1.15.1
+
+# This file contains all changes that were introduced in a new version of
+# MADlib. This changelist is used by the upgrade script to detect what objects
+# should be upgraded (while retaining all other objects from the previous version)
+
+# New modules (actually .sql_in files) added in upgrade version
+# For these files the sql_in code is retained as is with the functions in the
+# file installed on the upgrade version. All other files (that don't have
+# updates), are cleaned up to remove object replacements
+new module:
+
+# Changes in the types (UDT) including removal and modification
+udt:
+
+# List of the UDF changes that affect the user externally. This includes change
+# in function name, return type, argument order or types, or removal of
+# the function. In each case, the original function is as good as removed and a
+# new function is created. In such cases, we should abort the upgrade if there
+# are user views dependent on this function, since the original function will
+# not be present in the upgraded version.
+udf:
+    - __knn_validate_src:
+        rettype: integer
+        argument: character varying, character varying, character varying, character varying, character varying, character varying, character varying, character varying, integer
+    - stratified_sample_help:
+        rettype: character varying
+        argument:
+    - stratified_sample_help:
+        rettype: character varying
+        argument: character varying
+
+# Changes to aggregates (UDA) including removal and modification
+# Overloaded functions should be mentioned separately
+uda:
+
+# List of the UDC, UDO and UDOC changes.
+udc:
+udo:
+udoc:

--- a/src/madpack/upgrade_util.py
+++ b/src/madpack/upgrade_util.py
@@ -11,6 +11,7 @@ from utilities import get_rev_num
 from utilities import remove_comments_from_sql
 from utilities import run_query
 
+
 if not __name__ == "__main__":
     def run_sql(sql, portid, con_args):
         """
@@ -180,7 +181,7 @@ class ChangeHandler(UpgradeBase):
                 for obj_name, obj_details in each_config.iteritems():
                     formatted_obj = {}
                     for k, v in obj_details.items():
-                        v = v.lower().replace('schema_madlib', self._schema)
+                        v = v.lower().replace('schema_madlib', self._schema) if v else ""
                         formatted_obj[k] = v
                     _return_obj[obj_name].append(formatted_obj)
         return _return_obj


### PR DESCRIPTION
JIRA: MADLIB-1278

During RPM upgrade, rpm_post.sh is run first, followed by
rpm_post_uninstall.sh. So we must do all the uninstallation specific
stuff based on the current operation being uninstall or upgrade.
This commit makes the necessary change to remove symlinks only during
uninstallation, and not while upgrading.

Co-authored-by: Domino Valdano <dvaldano@pivotal.io>