### PR TITLE
Graph: Add id of nodes with 0 in-degree

### DIFF
--- a/src/ports/postgres/modules/graph/measures.py_in
+++ b/src/ports/postgres/modules/graph/measures.py_in
@@ -214,7 +214,7 @@ class Graph(object):
             CREATE TABLE {out_table} AS
             SELECT
                 {grouping_cols_comma}
-                in_q.vertex as {self.vertex_id_col},
+                coalesce(in_q.vertex, out_q.vertex) as {self.vertex_id_col},
                 coalesce(indegree, 0) as indegree,
                 coalesce(outdegree, 0) as outdegree
             FROM

--- a/src/ports/postgres/modules/graph/test/measures.sql_in
+++ b/src/ports/postgres/modules/graph/test/measures.sql_in
@@ -101,6 +101,23 @@ SELECT * FROM out_degrees;
 SELECT assert(indegree = 2 and outdegree = 3, 'Invalid value for degrees')
 FROM out_degrees
 WHERE id = 0;
+
+SELECT assert(COUNT(*)=1, 'Invalid value for node with only one incoming edge.')
+FROM out_degrees
+WHERE id = 7;
+
+DELETE FROM "EDGE" WHERE "DEST_ID"=7;
+INSERT INTO "EDGE" VALUES (7,6,1);
+DROP TABLE IF EXISTS out_degrees;
+SELECT graph_vertex_degrees('vertex',      -- Vertex table
+                     'id',          -- Vertix id column (NULL means use default naming)
+                     '"EDGE"',        -- "EDGE" table
+                     'src=src_id, dest="DEST_ID", weight=edge_weight',
+                                 -- "EDGE" arguments (NULL means use default naming)
+                     'out_degrees');
+SELECT assert(COUNT(*)=1, 'Invalid value for node with only one outgoing edge.')
+FROM out_degrees
+WHERE id = 7;
 -------------------------------------------------------------------------
 -- Grouping -----------------------------------------------------------
 ------------------------------------------------------------------------------
@@ -148,3 +165,22 @@ SELECT graph_vertex_degrees('vertex',      -- Vertex table
                      'out_degrees',
                      'grp');
 SELECT * FROM out_degrees ORDER BY grp, id;
+SELECT assert(COUNT(*)=1, 'Invalid value for node with only one incoming edge, with grouping.')
+FROM out_degrees
+WHERE id = 7 AND grp = 0;
+
+
+DELETE FROM edge_gr WHERE src_id=7 and grp=0;
+INSERT INTO edge_gr VALUES (6,7,1,0);
+DROP TABLE IF EXISTS out_degrees;
+SELECT graph_vertex_degrees('vertex',      -- Vertex table
+                     'id',          -- Vertix id column (NULL means use default naming)
+                     'edge_gr',        -- "EDGE" table
+                     'src=src_id, dest="DEST_ID", weight=edge_weight',
+                                 -- "EDGE" arguments (NULL means use default naming)
+                     'out_degrees',
+                     'grp');
+SELECT * FROM out_degrees ORDER BY grp, id;
+SELECT assert(COUNT(*)=1, 'Invalid value for node with only one outgoing edge, with grouping.')
+FROM out_degrees
+WHERE id=7 AND grp = 0;


### PR DESCRIPTION
JIRA: MADLIB-1279

IDs of nodes with 0 in-degree were not showing in the output of
`in_out_degrees` since the output table was a result of a full outer
join where the id was obtained from only one side.

This has been fixed by checking for NULL values (using coalesce) and the
result from other side is obtained if the ID is missing on primary side.

Closes #328