### PR TITLE
Margins: Copy summary table instead of renaming

### DIFF
--- a/src/ports/postgres/modules/regress/marginal.py_in
+++ b/src/ports/postgres/modules/regress/marginal.py_in
@@ -15,7 +15,6 @@ from utilities.utilities import _assert
 from utilities.utilities import py_list_to_sql_string
 
 from utilities.validate_args import table_exists
-from utilities.validate_args import rename_table
 from utilities.validate_args import columns_exist_in_table
 from utilities.validate_args import table_is_empty
 
@@ -167,9 +166,8 @@ def margins_logregr(schema_madlib, source_table, out_table,
                        tolerance_str=tolerance_str, verbose=verbose_mode))
 
         # Rename the output summary table
-        rename_table(schema_madlib,
-                     "{old}_summary".format(old=logr_out_table),
-                     "{new}_summary".format(new=out_table))
+        plpy.execute("""CREATE TABLE {out_table}_summary AS
+            SELECT * FROM {logr_out_table}_summary""".format(**locals()))
 
         plpy.execute("""UPDATE {out_table}_summary SET out_table = '{out_table}'
                      """.format(out_table=out_table))
@@ -522,9 +520,8 @@ def margins_mlogregr(schema_madlib, source_table, out_table,
             """.format(**all_arguments))
 
         # Rename the output summary table
-        rename_table(schema_madlib,
-                     "{old}_summary".format(old=mlog_out_table),
-                     "{new}_summary".format(new=out_table))
+        plpy.execute("""CREATE TABLE {out_table}_summary AS
+            SELECT * FROM {mlog_out_table}_summary""".format(**locals()))
 
         plpy.execute("UPDATE {out_table}_summary SET out_table = '{out_table}'".
                      format(out_table=out_table))


### PR DESCRIPTION
JIRA: MADLIB-1274

Margins summary table gets dropped since its schema remains pg_temp.
This commit fixed the issue by copying the contents instead of renaming.