### PR TITLE
Validation: Support other 'relkind' for input tables

### DIFF
--- a/src/ports/postgres/modules/utilities/validate_args.py_in
+++ b/src/ports/postgres/modules/utilities/validate_args.py_in
@@ -156,7 +156,6 @@ def table_exists(tbl, only_first_schema=False):
                 WHERE relnamespace = pg_namespace.oid
                   AND nspname {schema_expr}
                   AND (relname = '{table}')
-                  AND relkind IN ('r', 'v', 'm', 't', 'f')
             ) AS table_exists
             """.format(**locals()))[0]['table_exists']
         return bool(does_table_exist)


### PR DESCRIPTION
JIRA: MADLIB-1287

Within `validate_args.py_in:table_exists()` we checked if a table existed within
`pg_class` but limited the input table to specific `relkind`s. This limited
scope is unnecessary and precluded MADlib functions from accepting partition
tables.

This commit removes the `relkind` check, effectively adding 'partition',
'index' and 'sequence' tables as valid input tables.

Closes #340