### PR TITLE
  SVD: Minor error message change

### DIFF
--- a/src/ports/postgres/modules/linalg/svd.py_in
+++ b/src/ports/postgres/modules/linalg/svd.py_in
@@ -83,7 +83,7 @@ def svd(schema_madlib, source_table, output_table_prefix,
         source_table = source_table_copy
 
     (new_source_table, bd_pref) = _svd_upper_wrap(schema_madlib, source_table,
-                                                  output_table_prefix, row_id, k, nIterations, result_summary_table)
+        output_table_prefix, row_id, k, nIterations, result_summary_table)
 
     _svd_lower_wrap(schema_madlib, new_source_table, output_table_prefix,
                     row_id, k, nIterations, bd_pref)
@@ -964,10 +964,10 @@ def lanczos_bidiagonalize(schema_madlib, source_table, output_table_prefix,
     if nIterations is None:
         nIterations = min(col_dim, MAX_LANCZOS_STEPS)
     elif nIterations < k or nIterations > col_dim:
-        plpy.error("SVD error: nIterations should be"
+        plpy.error("SVD error: n+Iterations should be"
                    " in the range of [{0}, {1}]".format(k, col_dim))
     elif nIterations > MAX_LANCZOS_STEPS:
-        plpy.error("SVD error: nIterations"
+        plpy.error("SVD error: n_Iterations"
                    " should be less than {0}".format(MAX_LANCZOS_STEPS))
     actual_lanczos_iterations = nIterations
 
@@ -1091,10 +1091,10 @@ def lanczos_bidiagonalize_sparse(schema_madlib, source_table,
     if nIterations is None:
         nIterations = min(col_dim, MAX_LANCZOS_STEPS)
     elif nIterations < k or nIterations > col_dim:
-        plpy.error("SVD error: nIterations should be in the"
+        plpy.error("SVD error: n_Iterations should be in the"
                    "range of [{k}, {col_dim}]".format(k=k, col_dim=col_dim))
     elif nIterations > MAX_LANCZOS_STEPS:
-        plpy.error("SVD error: nIterations"
+        plpy.error("SVD error: n_Iterations"
                    " should be less than {0}".format(MAX_LANCZOS_STEPS))
 
     actual_lanczos_iterations = nIterations

--- a/src/ports/postgres/modules/linalg/svd.py_in
+++ b/src/ports/postgres/modules/linalg/svd.py_in
@@ -964,7 +964,7 @@ def lanczos_bidiagonalize(schema_madlib, source_table, output_table_prefix,
     if nIterations is None:
         nIterations = min(col_dim, MAX_LANCZOS_STEPS)
     elif nIterations < k or nIterations > col_dim:
-        plpy.error("SVD error: n+Iterations should be"
+        plpy.error("SVD error: n_Iterations should be"
                    " in the range of [{0}, {1}]".format(k, col_dim))
     elif nIterations > MAX_LANCZOS_STEPS:
         plpy.error("SVD error: n_Iterations"

--- a/src/ports/postgres/modules/linalg/svd.py_in
+++ b/src/ports/postgres/modules/linalg/svd.py_in
@@ -40,6 +40,7 @@ actual_lanczos_iterations = 0
 
 # ------------------------------------------------------------------------
 
+
 def svd(schema_madlib, source_table, output_table_prefix,
         row_id, k, nIterations, result_summary_table=None):
     """
@@ -70,8 +71,8 @@ def svd(schema_madlib, source_table, output_table_prefix,
     plpy.execute("set client_min_messages to error")
 
     _validate_args(schema_madlib, source_table, output_table_prefix,
-               k, row_id, nIterations, col_id=None, val_id=None,
-               result_summary_table=result_summary_table)
+                   k, row_id, nIterations, col_id=None, val_id=None,
+                   result_summary_table=result_summary_table)
     # Make sure that the input table has row_id and row_vec
     # if not then make a copy of the source table and change column names
     source_table_copy = "pg_temp." + unique_string() + "_2"
@@ -81,17 +82,17 @@ def svd(schema_madlib, source_table, output_table_prefix,
     if(need_new_column_names):
         source_table = source_table_copy
 
-    (new_source_table, bd_pref)=_svd_upper_wrap(schema_madlib, source_table,
-        output_table_prefix, row_id,k, nIterations, result_summary_table)
+    (new_source_table, bd_pref) = _svd_upper_wrap(schema_madlib, source_table,
+                                                  output_table_prefix, row_id, k, nIterations, result_summary_table)
 
     _svd_lower_wrap(schema_madlib, new_source_table, output_table_prefix,
-        row_id, k, nIterations, bd_pref)
+                    row_id, k, nIterations, bd_pref)
 
     if result_summary_table:
 
         t1 = time.time()
         [row_dim, col_dim] = get_dims(source_table,
-            {'row': 'row_id', 'col': 'col_id', 'val': 'row_vec'})
+                                      {'row': 'row_id', 'col': 'col_id', 'val': 'row_vec'})
         arguments = {'schema_madlib': schema_madlib,
                      'source_table': source_table,
                      'matrix_u': add_postfix(output_table_prefix, "_u"),
@@ -136,7 +137,8 @@ def _validate_args(schema_madlib, source_table, output_table_prefix, k,
     if k <= 0:
         plpy.error("SVD error: k must be a positive integer!")
 
-    # output tables are created from the prefix by appending _u, _s, and _v as suffixes
+    # output tables are created from the prefix by appending _u, _s, and _v as
+    # suffixes
     if output_table_prefix:
         output_table_names = [add_postfix(output_table_prefix, i)
                               for i in ('_u', '_s', '_v')]
@@ -290,7 +292,13 @@ def svd_block(schema_madlib, source_table, output_table_prefix,
                       add_postfix(output_table_prefix, "_v"))
         plpy.execute("DROP TABLE IF EXISTS {0}".format(x_trans))
     else:
-        _svd(schema_madlib, source_table, output_table_prefix, k, nIterations, True)
+        _svd(
+            schema_madlib,
+            source_table,
+            output_table_prefix,
+            k,
+            nIterations,
+            True)
 
     if result_summary_table:
         t1 = time.time()
@@ -479,7 +487,7 @@ def svd_sparse_native(schema_madlib, source_table, output_table_prefix,
 
 
 def _svd_upper_wrap(schema_madlib, source_table, output_table_prefix,
-        row_id, k, nIterations, result_summary_table):
+                    row_id, k, nIterations, result_summary_table):
     """
     Compute the Singular Value Decomposition of a sparse matrix
 
@@ -506,7 +514,7 @@ def _svd_upper_wrap(schema_madlib, source_table, output_table_prefix,
         (source_table,bd_pref)
     """
     [row_dim, col_dim] = get_dims(source_table,
-        {'row': 'row_id', 'col': 'col_id', 'val': 'row_vec'})
+                                  {'row': 'row_id', 'col': 'col_id', 'val': 'row_vec'})
     validate_dense(source_table,
                    {'row': 'row_id', 'val': 'row_vec'},
                    check_col=False, row_dim=row_dim)
@@ -525,21 +533,32 @@ def _svd_upper_wrap(schema_madlib, source_table, output_table_prefix,
                 '{x_trans}', 'row=row_id, val=row_vec')
             """.format(schema_madlib=schema_madlib,
                        source_table=source_table, x_trans=x_trans))
-        bd_pref = _svd_upper(schema_madlib, x_trans, output_table_prefix, k, nIterations, is_block=False)
+        bd_pref = _svd_upper(
+            schema_madlib,
+            x_trans,
+            output_table_prefix,
+            k,
+            nIterations,
+            is_block=False)
 
-        return (x_trans,bd_pref)
+        return (x_trans, bd_pref)
 
     else:
-        bd_pref = _svd_upper(schema_madlib, source_table, output_table_prefix, k, nIterations, is_block=False)
+        bd_pref = _svd_upper(
+            schema_madlib,
+            source_table,
+            output_table_prefix,
+            k,
+            nIterations,
+            is_block=False)
 
     return (source_table, bd_pref)
 # ------------------------------------------------------------------------
 
 
 def _svd_upper(schema_madlib, source_table, output_table_prefix,
-         k, nIterations, is_block=False,
-         row_id=None, col_id=None, val=None):
-
+               k, nIterations, is_block=False,
+               row_id=None, col_id=None, val=None):
     """
     Compute the Singular Value Decomposition of a sparse matrix
 
@@ -656,7 +675,7 @@ def _svd_upper(schema_madlib, source_table, output_table_prefix,
 
 
 def _svd_lower_wrap(schema_madlib, source_table, output_table_prefix,
-        row_id, k, nIterations, bd_pref, matrix_s=None):
+                    row_id, k, nIterations, bd_pref, matrix_s=None):
     """
     Compute the Singular Value Decomposition of a sparse matrix
 
@@ -676,7 +695,7 @@ def _svd_lower_wrap(schema_madlib, source_table, output_table_prefix,
         None
     """
     _svd_lower(schema_madlib, source_table, output_table_prefix,
-        k, nIterations, bd_pref, False, None,None,None,matrix_s)
+               k, nIterations, bd_pref, False, None, None, None, matrix_s)
 
     if "_xt_3" in source_table and "pg_temp." in source_table:
 
@@ -686,15 +705,15 @@ def _svd_lower_wrap(schema_madlib, source_table, output_table_prefix,
                       add_postfix(output_table_prefix, "_v"))
         plpy.execute(
             """DROP TABLE IF EXISTS {source_table}""".format(
-            source_table=source_table
+                source_table=source_table
             ))
     return None
 # ------------------------------------------------------------------------
 
 
 def _svd_lower(schema_madlib, source_table, output_table_prefix,
-         k, nIterations, bd_pref, is_block=False,
-         row_id=None, col_id=None, val=None, matrix_s=None):
+               k, nIterations, bd_pref, is_block=False,
+               row_id=None, col_id=None, val=None, matrix_s=None):
     """
     Compute the Singular Value Decomposition of a sparse matrix
 
@@ -757,7 +776,7 @@ def _svd_lower(schema_madlib, source_table, output_table_prefix,
                    svd_bidiagonal=svd_bidiagonal,
                    k=k))
 
-    #plpy.execute("DROP TABLE if exists {matrix_s_tmp}"
+    # plpy.execute("DROP TABLE if exists {matrix_s_tmp}"
     #             .format(matrix_s_tmp=matrix_s_tmp))
     plpy.execute("DROP TABLE if exists {svd_bidiagonal}"
                  .format(svd_bidiagonal=svd_bidiagonal))
@@ -796,14 +815,15 @@ def _svd(schema_madlib, source_table, output_table_prefix,
         @param val Name of the value column
     """
     bd_pref = _svd_upper(schema_madlib, source_table, output_table_prefix, k,
-         nIterations, is_block, row_id, col_id, val)
+                         nIterations, is_block, row_id, col_id, val)
 
     _svd_lower(schema_madlib, source_table, output_table_prefix, k,
-         nIterations, bd_pref, is_block, row_id, col_id, val)
+               nIterations, bd_pref, is_block, row_id, col_id, val)
 # ------------------------------------------------------------------------
 
 
-def _lanczos_bidiagonalize_create_pq_table(schema_madlib, pq_table_prefix, col_dim):
+def _lanczos_bidiagonalize_create_pq_table(
+        schema_madlib, pq_table_prefix, col_dim):
     """
     Creates and initializes the P and Q (left and right) matrices output of
     Lanczos bidiagonalization.
@@ -944,15 +964,16 @@ def lanczos_bidiagonalize(schema_madlib, source_table, output_table_prefix,
     if nIterations is None:
         nIterations = min(col_dim, MAX_LANCZOS_STEPS)
     elif nIterations < k or nIterations > col_dim:
-        plpy.error("SVD error: Number of Lanczos iterations should be"
+        plpy.error("SVD error: nIterations should be"
                    " in the range of [{0}, {1}]".format(k, col_dim))
     elif nIterations > MAX_LANCZOS_STEPS:
-        plpy.error("SVD error: Number of Lanczos iterations"
+        plpy.error("SVD error: nIterations"
                    " should be less than {0}".format(MAX_LANCZOS_STEPS))
     actual_lanczos_iterations = nIterations
 
     pq_table_prefix = "pg_temp." + unique_string() + "_8"
-    _lanczos_bidiagonalize_create_pq_table(schema_madlib, pq_table_prefix, col_dim)
+    _lanczos_bidiagonalize_create_pq_table(
+        schema_madlib, pq_table_prefix, col_dim)
 
     # Transform the matrix
     x_trans = "pg_temp." + unique_string() + "_9"
@@ -1070,16 +1091,17 @@ def lanczos_bidiagonalize_sparse(schema_madlib, source_table,
     if nIterations is None:
         nIterations = min(col_dim, MAX_LANCZOS_STEPS)
     elif nIterations < k or nIterations > col_dim:
-        plpy.error("SVD error: Number of Lanczos iterations should be in the"
+        plpy.error("SVD error: nIterations should be in the"
                    "range of [{k}, {col_dim}]".format(k=k, col_dim=col_dim))
     elif nIterations > MAX_LANCZOS_STEPS:
-        plpy.error("SVD error: Number of Lanczos iterations"
+        plpy.error("SVD error: nIterations"
                    " should be less than {0}".format(MAX_LANCZOS_STEPS))
 
     actual_lanczos_iterations = nIterations
 
     pq_table_prefix = "pg_temp." + unique_string() + "_8"
-    _lanczos_bidiagonalize_create_pq_table(schema_madlib, pq_table_prefix, col_dim)
+    _lanczos_bidiagonalize_create_pq_table(
+        schema_madlib, pq_table_prefix, col_dim)
 
     lanczos_sql = """
         {schema_madlib}.__svd_sparse_lanczos_agg(


### PR DESCRIPTION
JIRA: MADLIB-983

- Changed the error message from `SVD error: Number of Lanczos iterations should be in the range of [{0},{1}]` to `SVD error: nIterations should be in the range of [{0},{1}]`

-  `SVD error:  Number of Lanczos iterations should be less than {0}` to `SVD error: nIterations should be less than {0}`
