### PR TITLE
Use 64 bit flag for compiling MADlib with greenplum on macOS.

### DIFF
--- a/src/ports/greenplum/CMakeLists.txt
+++ b/src/ports/greenplum/CMakeLists.txt
@@ -11,8 +11,7 @@ set(PORT_DEPLOY_SCRIPT "${CMAKE_BINARY_DIR}/deploy/Component_${PORT}.cmake")
 
 if(APPLE)
     # FIXME: This should be handled in a better way.
-    # Greenplum is 32bit on the Mac.
-    set(ADDITIONAL_GCC_FLAGS "-m32")
+    set(ADDITIONAL_GCC_FLAGS "-m64")
 else(APPLE)
     unset(ADDITIONAL_GCC_FLAGS)
 endif(APPLE)


### PR DESCRIPTION
We used to assume that gpdb on mac is 32 bit but that is not the case
anymore.