### PR TITLE
Deep Learning: Disable deep learning for gpdb 4.3

### DIFF
--- a/src/ports/greenplum/4.3ORCA/CMakeLists.txt
+++ b/src/ports/greenplum/4.3ORCA/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_current_greenplum_version()
+add_subdirectory(config)

--- a/src/ports/greenplum/4.3ORCA/CMakeLists.txt
+++ b/src/ports/greenplum/4.3ORCA/CMakeLists.txt
@@ -1,1 +1,4 @@
 add_current_greenplum_version()
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/config/Modules.yml DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/config)
+

--- a/src/ports/greenplum/4.3ORCA/CMakeLists.txt
+++ b/src/ports/greenplum/4.3ORCA/CMakeLists.txt
@@ -1,4 +1,1 @@
 add_current_greenplum_version()
-
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/config/Modules.yml DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/config)
-

--- a/src/ports/greenplum/4.3ORCA/config/CMakeLists.txt
+++ b/src/ports/greenplum/4.3ORCA/config/CMakeLists.txt
@@ -25,12 +25,12 @@ file(GLOB_RECURSE CONFIG_FILES
     "*.yml"
 )
 add_files(CONFIG_TARGET_FILES . "${CMAKE_CURRENT_BINARY_DIR}" ${CONFIG_FILES})
-add_custom_target(configFiles ALL DEPENDS ${CONFIG_TARGET_FILES})
+add_custom_target(configFilesgp43 ALL DEPENDS ${CONFIG_TARGET_FILES})
 
 
 # -- 2. Install config files to config ----------------------------
 
 install(FILES ${CONFIG_TARGET_FILES}
-    DESTINATION src/ports/greenplum/4.3ORCA/config
+    DESTINATION ports/greenplum/4.3ORCA/config
     COMPONENT core
 )

--- a/src/ports/greenplum/4.3ORCA/config/CMakeLists.txt
+++ b/src/ports/greenplum/4.3ORCA/config/CMakeLists.txt
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+add_current_greenplum_version()
+
+# -- 1. Copy all *.yml files ---------------------------------------------------
+
+file(GLOB_RECURSE CONFIG_FILES
+    RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+    "*.yml"
+)
+add_files(CONFIG_TARGET_FILES . "${CMAKE_CURRENT_BINARY_DIR}" ${CONFIG_FILES})
+add_custom_target(configFiles ALL DEPENDS ${CONFIG_TARGET_FILES})
+
+
+# -- 2. Install config files to config ----------------------------
+
+install(FILES ${CONFIG_TARGET_FILES}
+    DESTINATION src/ports/greenplum/4.3ORCA/config
+    COMPONENT core
+)

--- a/src/ports/greenplum/4.3ORCA/config/Modules.yml
+++ b/src/ports/greenplum/4.3ORCA/config/Modules.yml
@@ -1,0 +1,74 @@
+# coding=utf-8
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+###
+# List of methods/modules and their dependencies:
+# gpdb 4.3 does not support the deep_learning module. This file is required to disable
+# deep learning for gpdb 4.3.
+# Please add any new modules that should be supported on gpdb 4.3
+###
+modules:
+    - name: array_ops
+    - name: assoc_rules
+      depends: ['svec_util']
+    - name: bayes
+    - name: conjugate_gradient
+      depends: ['array_ops']
+    - name: convex
+      depends: ['utilities']
+    - name: crf
+    - name: elastic_net
+    - name: glm
+      depends: ['utilities']
+    - name: graph
+      depends: ['utilities']
+    - name: kmeans
+      depends: ['array_ops', 'svec_util', 'sample']
+    - name: knn
+      depends: ['array_ops']
+    - name: lda
+      depends: ['array_ops']
+    - name: linalg
+    - name: linear_systems
+      depends: ['utilities']
+    - name: pca
+      depends: ['linalg', 'convex']
+    - name: pmml
+    - name: prob
+    - name: recursive_partitioning
+      depends: ['utilities']
+    - name: regress
+      depends: ['utilities', 'array_ops']
+    - name: sample
+      depends: ['utilities', 'stats']
+    - name: sketch
+    - name: stats
+      depends: ['array_ops']
+    - name: summary
+      depends: ['utilities', 'sketch']
+    - name: svec
+    - name: svec_util
+      depends: ['svec']
+    - name: svm
+    - name: tsa
+    - name: utilities
+      depends: ['linalg']
+    - name: validation
+      depends: ['array_ops', 'regress']
+    - name: stemmer


### PR DESCRIPTION
We won't support deep learning on gpdb 4.3 because
1. Deep learning requires the type 'JSON' which isn't supported in gpdb
4.3.
2. Our deep learning module depends on tensorflow to be pre installed.
GPDB 4.3 ships with python 2.6.9 which doesn't support tensorflow.

madpack currently looks for Modules.yml first in
"src/ports/portid/dbver/config" and then in src/config. This commit
copies the custom Modules.yml in the src/ports/portid/dbver/config/ dir.
We use a custom Modules.yml file for gpdb 4.3 which is just a copy of
the existing Modules.yml file.

A future commit will add support for the 'deep_learning' module which
will not be included in this yml.

Closes #358

Co-authored-by: Orhan Kislal <okislal@apache.org>