### PR TITLE
MLP - Fixed column names in the Output Table

### DIFF
--- a/src/ports/postgres/modules/convex/mlp_igd.py_in
+++ b/src/ports/postgres/modules/convex/mlp_igd.py_in
@@ -59,6 +59,8 @@ from utilities.validate_args import output_tbl_valid
 from utilities.validate_args import table_exists
 from utilities.validate_args import quote_ident
 from utilities.minibatch_validation import validate_dependent_var_for_minibatch
+from utilities.utilities import create_cols_from_array_sql_string
+
 
 
 @MinWarning("error")
@@ -1048,14 +1050,8 @@ def mlp_predict(schema_madlib, model_table, data_table, id_col_name,
         else:
             intermediate_col = unique_string()
             if classes:
-                # we cannot call sql quote_ident on the class value because
-                # aliasing does not support quote_ident. Hence calling our
-                # python implementation of quote_ident
-                score_format = ',\n'.join([
-                    'CAST({interim}[{j}] as DOUBLE PRECISION) as "{c_str}"'.
-                    format(j=i + 1, c_str=quote_ident("estimated_prob_{0}".
-                        format(str(c))).strip(' "'), interim=intermediate_col)
-                    for i, c in enumerate(classes)])
+                score_format = create_cols_from_array_sql_string(
+                    classes, intermediate_col, 'prob', 'double precision', False, 'convex') 
             else:
                 # Case when the training step did not have to one-hot encode
                 # the dependent var.

--- a/src/ports/postgres/modules/convex/mlp_igd.py_in
+++ b/src/ports/postgres/modules/convex/mlp_igd.py_in
@@ -1051,7 +1051,7 @@ def mlp_predict(schema_madlib, model_table, data_table, id_col_name,
             intermediate_col = unique_string()
             if classes:
                 score_format = create_cols_from_array_sql_string(
-                    classes, intermediate_col, 'prob', 'double precision', False, 'convex') 
+                    classes, intermediate_col, 'prob', 'double precision', False, 'MLP') 
             else:
                 # Case when the training step did not have to one-hot encode
                 # the dependent var.

--- a/src/ports/postgres/modules/convex/test/mlp.sql_in
+++ b/src/ports/postgres/modules/convex/test/mlp.sql_in
@@ -454,6 +454,13 @@ SELECT mlp_predict(
     'mlp_prediction_batch_output',
     'prob');
 SELECT * FROM mlp_prediction_batch_output;
+
+-- assert to test if the newly created column name exists and matches the count
+SELECT assert(count(*) =3, 'Column Names does not exists')
+	   from pg_attribute
+	   where attrelid = 'mlp_prediction_batch_output'::regclass
+       and attname in( 'prob_1', 'prob_2','prob_3');
+
 DROP TABLE IF EXISTS mlp_prediction_batch_output;
 DROP TABLE IF EXISTS mlp_class_batch, mlp_class_batch_summary, mlp_class_batch_standardization;
 


### PR DESCRIPTION
JIRA: MADLIB-1323

Code Refactor: 
Used **create_cols_from_array_sql_string** to change the column names of the output table as per the JIRA. 