### PR TITLE
DL: Improve minibatch performance by using array_cat

### DIFF
--- a/src/ports/postgres/modules/deep_learning/input_data_preprocessor.py_in
+++ b/src/ports/postgres/modules/deep_learning/input_data_preprocessor.py_in
@@ -187,10 +187,10 @@ class InputDataPreprocessorDL(object):
             SELECT * FROM
             (
                 SELECT {self.schema_madlib}.agg_array_concat(
-                    ARRAY[{norm_tbl}.x_norm::REAL[]]) AS {x},
-                    {self.schema_madlib}.agg_array_concat(
-                    ARRAY[{norm_tbl}.y]) AS {y},
-                    ({norm_tbl}.row_id%{self.num_of_buffers})::smallint AS buffer_id
+                            ARRAY[{norm_tbl}.x_norm::REAL[]]) AS {x},
+                       {self.schema_madlib}.agg_array_concat(
+                            ARRAY[{norm_tbl}.y]) AS {y},
+                       ({norm_tbl}.row_id%{self.num_of_buffers})::smallint AS buffer_id
                 FROM {norm_tbl}
                 GROUP BY buffer_id
             ) b

--- a/src/ports/postgres/modules/deep_learning/input_data_preprocessor.sql_in
+++ b/src/ports/postgres/modules/deep_learning/input_data_preprocessor.sql_in
@@ -826,22 +826,9 @@ $$ LANGUAGE plpythonu VOLATILE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
 
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.agg_array_concat_transition(anyarray, anyarray)
-  RETURNS anyarray
-   AS 'select $1 || $2'
-   LANGUAGE SQL
-   IMMUTABLE;
-
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.agg_array_concat_merge(anyarray, anyarray)
-  RETURNS anyarray
-   AS 'select $1 || $2'
-   LANGUAGE SQL
-   IMMUTABLE
-   RETURNS NULL ON NULL INPUT;
-
 DROP AGGREGATE IF EXISTS MADLIB_SCHEMA.agg_array_concat(anyarray);
 CREATE AGGREGATE MADLIB_SCHEMA.agg_array_concat(anyarray) (
-   SFUNC = MADLIB_SCHEMA.agg_array_concat_transition,
+   SFUNC = array_cat,
    STYPE = anyarray,
-   PREFUNC = MADLIB_SCHEMA.agg_array_concat_merge
+   PREFUNC = array_cat
    );

--- a/src/ports/postgres/modules/utilities/minibatch_preprocessing.py_in
+++ b/src/ports/postgres/modules/utilities/minibatch_preprocessing.py_in
@@ -286,8 +286,8 @@ class MiniBatchPreProcessor:
             FROM (
                 SELECT (row_number() OVER ({partition_by} ORDER BY random()) - 1)
                         / {buffer_size}
-                            as {row_id}, * FROM
-                (
+                            as {row_id}, *
+                FROM (
                     {standardize_query}
                  ) sub_query_1
                  WHERE NOT {self.schema_madlib}.array_contains_null({dep_colname})


### PR DESCRIPTION
JIRA: MADLIB-1334

The deep learning specific minibatch preprocessor was using a custom array concat
function. This PR replaces it with the Postgres built-in `array_cat()` function
since it was performing better.