### PR TITLE
DL: Refactor code to move some constants to helper file

### DIFF
--- a/src/ports/postgres/modules/deep_learning/input_data_preprocessor.py_in
+++ b/src/ports/postgres/modules/deep_learning/input_data_preprocessor.py_in
@@ -48,13 +48,11 @@ from madlib_keras_helper import CLASS_VALUES_COLNAME
 from madlib_keras_helper import DEPENDENT_VARNAME_COLNAME
 from madlib_keras_helper import DEPENDENT_VARTYPE_COLNAME
 from madlib_keras_helper import INDEPENDENT_VARNAME_COLNAME
+from madlib_keras_helper import MINIBATCH_OUTPUT_DEPENDENT_COLNAME_DL
+from madlib_keras_helper import MINIBATCH_OUTPUT_INDEPENDENT_COLNAME_DL
 from madlib_keras_helper import NORMALIZING_CONST_COLNAME
 from madlib_keras_helper import strip_trailing_nulls_from_class_values
 
-# These are readonly variables, do not modify
-# MADLIB-1300 Adding these variables for DL only at this time.
-MINIBATCH_OUTPUT_DEPENDENT_COLNAME_DL = "dependent_var"
-MINIBATCH_OUTPUT_INDEPENDENT_COLNAME_DL = "independent_var"
 NUM_CLASSES_COLNAME = "num_classes"
 
 class InputDataPreprocessorDL(object):

--- a/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
@@ -36,8 +36,8 @@ from keras.models import *
 from keras.optimizers import *
 from keras.regularizers import *
 import madlib_keras_serializer
-from input_data_preprocessor import MINIBATCH_OUTPUT_DEPENDENT_COLNAME_DL
-from input_data_preprocessor import MINIBATCH_OUTPUT_INDEPENDENT_COLNAME_DL
+from madlib_keras_helper import MINIBATCH_OUTPUT_DEPENDENT_COLNAME_DL
+from madlib_keras_helper import MINIBATCH_OUTPUT_INDEPENDENT_COLNAME_DL
 from madlib_keras_helper import CLASS_VALUES_COLNAME
 from madlib_keras_helper import DEPENDENT_VARTYPE_COLNAME
 from madlib_keras_helper import NORMALIZING_CONST_COLNAME

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_helper.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_helper.py_in
@@ -72,3 +72,9 @@ INDEPENDENT_VARNAME_COLNAME = "independent_varname"
 MODEL_ARCH_TABLE_COLNAME = "model_arch_table"
 MODEL_ARCH_ID_COLNAME = "model_arch_id"
 MODEL_DATA_COLNAME = "model_data"
+
+# Name of independent and dependent colnames in batched table.
+# These are readonly variables, do not modify.
+# MADLIB-1300 Adding these variables for DL only at this time.
+MINIBATCH_OUTPUT_DEPENDENT_COLNAME_DL = "dependent_var"
+MINIBATCH_OUTPUT_INDEPENDENT_COLNAME_DL = "independent_var"


### PR DESCRIPTION
Define MINIBATCH_OUTPUT_DEPENDENT_COLNAME_DL and
MINIBATCH_OUTPUT_INDEPENDENT_COLNAME_DL in madlib_keras_helper.py_in
instead of in input_data_preprocessor.py_in. Importing these from
input_data_preprocessor was also doing other imports that are not
necessary for madlib_keras.py_in.