### PR TITLE
DL: Add support for reporting various metrics in fit/evaluate

### DIFF
--- a/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
@@ -183,9 +183,8 @@ def fit(schema_madlib, source_table, model,model_arch_table,
         FROM {source_table}
         """.format(**locals()), ["bytea"])
 
-    # Define the state for the model and loss/accuracy storage lists
-    model_state = madlib_keras_serializer.serialize_weights(
-        0, 0, 0, model_weights)
+    # Define the state for the model and loss/metric storage lists
+    model_state = madlib_keras_serializer.serialize_weights(0, model_weights)
     training_loss, training_metrics, aggregate_runtime = [], [], []
     metrics_iters = []
 
@@ -201,19 +200,11 @@ def fit(schema_madlib, source_table, model,model_arch_table,
         end_iteration = time.time()
         plpy.info("Time for iteration {0}: {1} sec".
                   format(i, end_iteration - start_iteration))
-        avg_loss, avg_metric, model_state = madlib_keras_serializer.\
-            deserialize_iteration_state(iteration_result)
-        plpy.info("Average loss after training iteration {0}: {1}".format(
-            i, avg_loss))
-        plpy.info("Average accuracy after training iteration {0}: {1}".format(
-            i, avg_metric))
+        model_state = madlib_keras_serializer.deserialize_iteration_state(
+            iteration_result)
 
         if should_compute_metrics_this_iter(i, metrics_compute_frequency,
                                             num_iterations):
-            # TODO: Do we need this code?
-            # _, _, _, updated_weights = madlib_keras_serializer.deserialize_weights(
-            #     model_state, model_shapes)
-            # master_model.set_weights(updated_weights)
             # Compute loss/accuracy for training data.
             aggregate_runtime.append(datetime.datetime.now())
             compute_loss_and_metrics(
@@ -331,7 +322,7 @@ def fit(schema_madlib, source_table, model,model_arch_table,
 def compute_loss_and_metrics(schema_madlib, table, dependent_varname,
                              independent_varname, compile_params, model_arch,
                              model_state, gpus_per_host, segments_per_host,
-                             seg_ids_val, rows_per_seg_val,
+                             seg_ids, rows_per_seg,
                              gp_segment_id_col, metrics_list, loss_list,
                              curr_iter, dataset_name):
     """
@@ -339,18 +330,18 @@ def compute_loss_and_metrics(schema_madlib, table, dependent_varname,
     given dataset (table.)
     """
     start_val = time.time()
-    evaluate_result = get_loss_acc_from_keras_eval(schema_madlib,
-                                                   table,
-                                                   dependent_varname,
-                                                   independent_varname,
-                                                   compile_params,
-                                                   model_arch,
-                                                   model_state,
-                                                   gpus_per_host,
-                                                   segments_per_host,
-                                                   seg_ids_val,
-                                                   rows_per_seg_val,
-                                                   gp_segment_id_col)
+    evaluate_result = get_loss_metric_from_keras_eval(schema_madlib,
+                                                      table,
+                                                      dependent_varname,
+                                                      independent_varname,
+                                                      compile_params,
+                                                      model_arch,
+                                                      model_state,
+                                                      gpus_per_host,
+                                                      segments_per_host,
+                                                      seg_ids,
+                                                      rows_per_seg,
+                                                      gp_segment_id_col)
     end_val = time.time()
     plpy.info("Time for evaluation in iteration {0}: {1} sec.". format(
         curr_iter, end_val - start_val))
@@ -439,14 +430,11 @@ def fit_transition(state, dependent_var, independent_var, model_architecture,
         compile_and_set_weights(segment_model, compile_params, device_name,
                                 previous_state, SD['model_shapes'])
         SD['segment_model'] = segment_model
-        agg_loss = 0
-        agg_accuracy = 0
+        image_count = 0
         agg_image_count = 0
     else:
         segment_model = SD['segment_model']
-        #TODO we don't need to deserialize the weights here.
-        agg_loss, agg_accuracy, agg_image_count, _ = madlib_keras_serializer.deserialize_weights(
-            state, SD['model_shapes'])
+        agg_image_count = madlib_keras_serializer.get_image_count_from_state(state)
 
     # Prepare the data
     x_train = np.array(independent_var, dtype='float64')
@@ -458,15 +446,11 @@ def fit_transition(state, dependent_var, independent_var, model_architecture,
         #TODO consider not doing this every time
         fit_params = parse_and_validate_fit_params(fit_params)
         history = segment_model.fit(x_train, y_train, **fit_params)
-        loss = history.history['loss'][0]
-        accuracy = history.history['acc'][0]
     end_fit = time.time()
 
     image_count = len(x_train)
     # Aggregating number of images, loss and accuracy
     agg_image_count += image_count
-    agg_loss += (image_count * loss)
-    agg_accuracy += (image_count * accuracy)
 
     with K.tf.device(device_name):
         updated_weights = segment_model.get_weights()
@@ -492,11 +476,10 @@ def fit_transition(state, dependent_var, independent_var, model_architecture,
             clear_keras_session()
     elif agg_image_count > total_images:
         plpy.error('Processed {0} images, but there were supposed to be only {1}!'
-            .format(agg_image_count,total_images))
+            .format(agg_image_count, total_images))
 
     new_model_state = madlib_keras_serializer.serialize_weights(
-            agg_loss, agg_accuracy, agg_image_count, updated_weights)
-
+        agg_image_count, updated_weights)
 
     del x_train
     del y_train
@@ -514,40 +497,32 @@ def fit_merge(state1, state2, **kwargs):
         return state1 or state2
 
     # Deserialize states
-    loss1, accuracy1, image_count1, weights1 = madlib_keras_serializer.deserialize_weights_merge(state1)
-    loss2, accuracy2, image_count2, weights2 = madlib_keras_serializer.deserialize_weights_merge(state2)
+    image_count1, weights1 = madlib_keras_serializer.deserialize_weights_merge(state1)
+    image_count2, weights2 = madlib_keras_serializer.deserialize_weights_merge(state2)
 
     # Compute total image counts
     image_count = (image_count1 + image_count2) * 1.0
-
-    # Aggregate the losses
-    total_loss = loss1 + loss2
-
-    # Aggregate the accuracies
-    total_accuracy = accuracy1 + accuracy2
 
     # Aggregate the weights
     total_weights = weights1 + weights2
 
     # Return the merged state
     return madlib_keras_serializer.serialize_weights_merge(
-        total_loss, total_accuracy, image_count, total_weights)
+        image_count, total_weights)
 
 def fit_final(state, **kwargs):
     # Return if called early
     if not state:
         return state
 
-    loss, accuracy, image_count, weights = madlib_keras_serializer.deserialize_weights_merge(state)
+    image_count, weights = madlib_keras_serializer.deserialize_weights_merge(state)
     if image_count == 0:
         plpy.error("fit_final: Total images processed is 0")
 
-    # Averaging the accuracy, loss and weights
-    loss /= image_count
-    accuracy /= image_count
+    # Averaging the weights
     weights /= image_count
     return madlib_keras_serializer.serialize_weights_merge(
-        loss, accuracy, image_count, weights)
+        image_count, weights)
 
 def evaluate1(schema_madlib, model_table, test_table, id_col, model_arch_table,
             model_arch_id, dependent_varname, independent_varname,
@@ -572,19 +547,20 @@ def evaluate1(schema_madlib, model_table, test_table, id_col, model_arch_table,
     model_arch = query_result[Format.MODEL_ARCH]
     compile_params = "$madlib$" + compile_params + "$madlib$"
 
-    loss_acc = get_loss_acc_from_keras_eval(schema_madlib, test_table, dependent_varname,
-                                            independent_varname, compile_params, model_arch,
-                                            model_data, False, None)
+    loss_metric = get_loss_metric_from_keras_eval(
+                    schema_madlib, test_table, dependent_varname,
+                    independent_varname, compile_params, model_arch,
+                    model_data, False, None)
 
     #TODO remove these infos after adding create table command
-    plpy.info('len of evaluate result is {}'.format(len(loss_acc)))
-    plpy.info('evaluate result loss is {}'.format(loss_acc[0]))
-    plpy.info('evaluate result acc is {}'.format(loss_acc[1]))
+    plpy.info('len of evaluate result is {}'.format(len(loss_metric)))
+    plpy.info('evaluate result loss is {}'.format(loss_metric[0]))
+    plpy.info('evaluate result metric is {}'.format(loss_metric[1]))
 
-def get_loss_acc_from_keras_eval(schema_madlib, table, dependent_varname,
+def get_loss_metric_from_keras_eval(schema_madlib, table, dependent_varname,
                                  independent_varname, compile_params,
                                  model_arch, model_data, gpus_per_host,
-                                 segments_per_host, seg_ids_val, images_per_seg_val,
+                                 segments_per_host, seg_ids, images_per_seg,
                                  gp_segment_id_col):
     """
     This function will call the internal keras evaluate function to get the loss
@@ -595,23 +571,23 @@ def get_loss_acc_from_keras_eval(schema_madlib, table, dependent_varname,
     --  The right solution is either to change the datatype of the agg function from
     --  SMALLINT to INTEGER, or change the output of minibatch util to produce SMALLINT
     --  For the first, we should change fit_step also
-    select ({schema_madlib}.internal_keras_evaluate(
-                                            {dependent_varname}::SMALLINT[],
-                                            {independent_varname}::REAL[],
-                                            $MAD${model_arch}$MAD$,
-                                            $1,
-                                            {compile_params},
-                                            {gp_segment_id_col},
-                                            ARRAY{seg_ids_val},
-                                            ARRAY{images_per_seg_val},
-                                            {gpus_per_host},
-                                            {segments_per_host}
-                                            )) as loss_acc
-        from {table}
+    SELECT ({schema_madlib}.internal_keras_evaluate(
+                {dependent_varname}::SMALLINT[],
+                {independent_varname}::REAL[],
+                $MAD${model_arch}$MAD$,
+                $1,
+                {compile_params},
+                {gp_segment_id_col},
+                ARRAY{seg_ids},
+                ARRAY{images_per_seg},
+                {gpus_per_host},
+                {segments_per_host}
+                )) AS loss_metric
+    FROM {table}
     """.format(**locals()), ["bytea"])
     res = plpy.execute(evaluate_query, [model_data])
-    loss_acc = res[0]['loss_acc']
-    return loss_acc
+    loss_metric = res[0]['loss_metric']
+    return loss_metric
 
 def internal_keras_eval_transition(state, dependent_var, independent_var,
                                    model_architecture, model_data, compile_params,
@@ -620,21 +596,21 @@ def internal_keras_eval_transition(state, dependent_var, independent_var,
     SD = kwargs['SD']
     device_name = get_device_name_and_set_cuda_env(gpus_per_host, current_seg_id)
 
-    agg_loss, agg_accuracy, agg_image_count = state
+    agg_loss, agg_metric, agg_image_count = state
 
     if not agg_image_count:
         if not is_platform_pg():
             set_keras_session(gpus_per_host, segments_per_host)
         model = model_from_json(model_architecture)
         model_shapes = madlib_keras_serializer.get_model_shapes(model)
-        _, _, _, model_weights = madlib_keras_serializer.deserialize_weights(
+        _, model_weights = madlib_keras_serializer.deserialize_weights(
             model_data, model_shapes)
         model.set_weights(model_weights)
         with K.tf.device(device_name):
             compile_model(model, compile_params)
         SD['segment_model'] = model
         # These should already be 0, but just in case make sure
-        agg_accuracy = 0
+        agg_metric = 0
         agg_loss = 0
     else:
         # Same model every time, no need to re-compile or update weights
@@ -646,13 +622,19 @@ def internal_keras_eval_transition(state, dependent_var, independent_var,
     with K.tf.device(device_name):
         res = model.evaluate(x_val, y_val)
 
-    loss, accuracy = res
+    # if metric is None, model.evaluate will only return loss as a scalar
+    # Otherwise, it will return a list which has loss and metric
+    if type(res) is list:
+        loss, metric = res
+    else:
+        loss = res
+        metric = 0
 
     image_count = len(dependent_var)
 
     agg_image_count += image_count
     agg_loss += (image_count * loss)
-    agg_accuracy += (image_count * accuracy)
+    agg_metric += (image_count * metric)
 
     if is_platform_pg():
         total_images = images_per_seg[0]
@@ -667,7 +649,7 @@ def internal_keras_eval_transition(state, dependent_var, independent_var,
         plpy.error("Evaluated too many images.")
 
     state[0] = agg_loss
-    state[1] = agg_accuracy
+    state[1] = agg_metric
     state[2] = agg_image_count
 
     return state
@@ -677,26 +659,25 @@ def internal_keras_eval_merge(state1, state2, **kwargs):
     if not state1 or not state2:
         return state1 or state2
 
-    loss1, accuracy1, image_count1 = state1
-    loss2, accuracy2, image_count2 = state2
+    loss1, metric1, image_count1 = state1
+    loss2, metric2, image_count2 = state2
 
     merged_loss = loss1 + loss2
-    merged_accuracy = accuracy1 + accuracy2
-
+    merged_metric = metric1 + metric2
     total_image_count = image_count1 + image_count2
 
-    merged_state = [ merged_loss, merged_accuracy , total_image_count ]
+    merged_state = [ merged_loss, merged_metric , total_image_count ]
 
     return merged_state
 
 def internal_keras_eval_final(state, **kwargs):
-    loss, accuracy, image_count = state
+    loss, metric, image_count = state
 
     if image_count == 0:
         plpy.error("internal_keras_eval_final: Total images processed is 0")
 
     loss /= image_count
-    accuracy /= image_count
+    metric /= image_count
 
-    state = loss, accuracy
+    state = loss, metric
     return state

--- a/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
@@ -201,7 +201,6 @@ def fit(schema_madlib, source_table, model,model_arch_table,
         end_iteration = time.time()
         plpy.info("Time for iteration {0}: {1} sec".
                   format(i, end_iteration - start_iteration))
-        aggregate_runtime.append(datetime.datetime.now())
         avg_loss, avg_metric, model_state = madlib_keras_serializer.\
             deserialize_iteration_state(iteration_result)
         plpy.info("Average loss after training iteration {0}: {1}".format(
@@ -216,14 +215,14 @@ def fit(schema_madlib, source_table, model,model_arch_table,
             #     model_state, model_shapes)
             # master_model.set_weights(updated_weights)
             # Compute loss/accuracy for training data.
-            # TODO: Uncomment this once JIRA MADLIB-1332 is merged to master
-            # compute_loss_and_metrics(
-            #     schema_madlib, source_table, dependent_varname,
-            #     independent_varname, compile_params_to_pass, model_arch,
-            #     model_state, gpus_per_host, segments_per_host, seg_ids_val,
-            #     images_per_seg_val, gp_segment_id_col,
-            #     training_metrics, training_loss,
-            #     i, "Training")
+            aggregate_runtime.append(datetime.datetime.now())
+            compute_loss_and_metrics(
+                schema_madlib, source_table, dependent_varname,
+                independent_varname, compile_params_to_pass, model_arch,
+                model_state, gpus_per_host, segments_per_host, seg_ids_train,
+                images_per_seg_train, gp_segment_id_col,
+                training_metrics, training_loss,
+                i, "Training")
             metrics_iters.append(i)
             if validation_set_provided:
                 # Compute loss/accuracy for validation data.
@@ -234,8 +233,6 @@ def fit(schema_madlib, source_table, model,model_arch_table,
                     images_per_seg_val, gp_segment_id_col,
                     validation_metrics, validation_loss,
                     i, "Validation")
-        training_loss.append(avg_loss)
-        training_metrics.append(avg_metric)
 
     end_training_time = datetime.datetime.now()
 
@@ -281,30 +278,30 @@ def fit(schema_madlib, source_table, model,model_arch_table,
             $MAD${dependent_varname_in_source_table}$MAD$::TEXT AS dependent_varname,
             $MAD${independent_varname_in_source_table}$MAD$::TEXT AS independent_varname,
             $MAD${model_arch_table}$MAD$::TEXT AS model_arch_table,
-            {model_arch_id} AS model_arch_id,
+            {model_arch_id}::INTEGER AS model_arch_id,
             $1 AS compile_params,
             $2 AS fit_params,
-            {num_iterations} AS num_iterations,
+            {num_iterations}::INTEGER AS num_iterations,
             {validation_table}::TEXT AS validation_table,
-            {metrics_compute_frequency} AS metrics_compute_frequency,
+            {metrics_compute_frequency}::INTEGER AS metrics_compute_frequency,
             $3 AS name,
             $4 AS description,
             '{model_type}'::TEXT AS model_type,
-            {model_size} AS model_size,
+            {model_size}::INTEGER AS model_size,
             '{start_training_time}'::TIMESTAMP AS start_training_time,
             '{end_training_time}'::TIMESTAMP AS end_training_time,
             $5 AS time_iter,
             '{version}'::TEXT AS madlib_version,
-            {num_classes} AS num_classes,
+            {num_classes}::INTEGER AS num_classes,
             $6 AS {class_values_colname},
-            '{dep_vartype}' AS {dependent_vartype_colname},
-            {norm_const} AS {normalizing_const_colname},
-            {training_metrics_final} AS training_metrics_final,
-            {training_loss_final} AS training_loss_final,
+            $MAD${dep_vartype}$MAD$::TEXT AS {dependent_vartype_colname},
+            {norm_const}::DOUBLE PRECISION AS {normalizing_const_colname},
+            {training_metrics_final}::DOUBLE PRECISION AS training_metrics_final,
+            {training_loss_final}::DOUBLE PRECISION AS training_loss_final,
             ARRAY{training_metrics}::DOUBLE PRECISION[] AS training_metrics,
             ARRAY{training_loss}::DOUBLE PRECISION[] AS training_loss,
-            {validation_metrics_final} AS validation_metrics_final,
-            {validation_loss_final} AS validation_loss_final,
+            {validation_metrics_final}::DOUBLE PRECISION AS validation_metrics_final,
+            {validation_loss_final}::DOUBLE PRECISION AS validation_loss_final,
             {validation_metrics}::DOUBLE PRECISION[] AS validation_metrics,
             {validation_loss}::DOUBLE PRECISION[] AS validation_loss,
             ARRAY{metrics_iters}::INTEGER[] AS metrics_iters
@@ -347,7 +344,8 @@ def compute_loss_and_metrics(schema_madlib, table, dependent_varname,
                                                    dependent_varname,
                                                    independent_varname,
                                                    compile_params,
-                                                   model_arch, model_state,
+                                                   model_arch,
+                                                   model_state,
                                                    gpus_per_host,
                                                    segments_per_host,
                                                    seg_ids_val,

--- a/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
@@ -354,9 +354,9 @@ def compute_loss_and_metrics(schema_madlib, table, dependent_varname,
     end_val = time.time()
     plpy.info("Time for evaluation in iteration {0}: {1} sec.". format(
         curr_iter, end_val - start_val))
-    if len(evaluate_result) < 2:
-        plpy.error('Calling evaluate on table {0} returned < 2 '
-                   'metrics. Expected both loss and a metric.'.format(
+    if len(evaluate_result) not in [1, 2]:
+        plpy.error('Calling evaluate on table {0} must return loss '
+                   'and at most one metric value.'.format(
             table))
     loss = evaluate_result[0]
     metric = evaluate_result[1]
@@ -698,5 +698,5 @@ def internal_keras_eval_final(state, **kwargs):
     loss /= image_count
     accuracy /= image_count
 
-    state = loss, accuracy, image_count
+    state = loss, accuracy
     return state

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_serializer.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_serializer.py_in
@@ -39,10 +39,10 @@ def get_model_shapes(model):
 def deserialize_weights(model_state, model_shapes):
     """
     Parameters:
-        model_state: a stringified (serialized) state containing loss,
-        accuracy, image_count, and model_weights, passed from postgres
-        model_shapes: a list of tuples containing the shapes of each element
-        in keras.get_weights()
+        model_state: a stringified (serialized) state containing
+        image_count and model_weights, passed from postgres
+        model_shapes: a list of tuples containing the shapes of
+        each element in keras.get_weights()
     Returns:
         image_count: the buffer count from state
         model_weights: a list of numpy arrays that can be inputted into keras.set_weights()
@@ -50,20 +50,29 @@ def deserialize_weights(model_state, model_shapes):
     if not model_state or not model_shapes:
         return None
     state = np.fromstring(model_state, dtype=np.float32)
-    model_weights_serialized = state[3:]
+
+    model_weights_serialized = state[1:]
     i, j, model_weights = 0, 0, []
     while j < len(model_shapes):
         next_pointer = i + reduce(lambda x, y: x * y, model_shapes[j])
         weight_arr_portion = model_weights_serialized[i:next_pointer]
         model_weights.append(weight_arr_portion.reshape(model_shapes[j]))
         i, j = next_pointer, j + 1
-    return float(state[0]), float(state[1]), int(float(state[2])), model_weights
+    #TODO: float(state[0]) is the image_count, which can be get from
+    # get_image_count_from_state() we defined below, we should check if
+    # we still need to return it here when refactoring
+    return float(state[0]), model_weights
 
+def get_image_count_from_state(model_state):
+    if not model_state:
+        return None
+    state = np.fromstring(model_state, dtype=np.float32)
+    return float(state[0])
 
-def serialize_weights(loss, accuracy, image_count, model_weights):
+def serialize_weights(image_count, model_weights):
     """
     Parameters:
-        loss, accuracy, image_count: float values
+        image_count: float values
         model_weights: a list of numpy arrays, what you get from
         keras.get_weights()
     Returns:
@@ -74,7 +83,7 @@ def serialize_weights(loss, accuracy, image_count, model_weights):
         return None
     flattened_weights = [w.flatten() for w in model_weights]
     model_weights_serialized = np.concatenate(flattened_weights)
-    new_model_string = np.array([loss, accuracy, image_count])
+    new_model_string = np.array([image_count])
     new_model_string = np.concatenate((new_model_string, model_weights_serialized))
     new_model_string = np.float32(new_model_string)
     return new_model_string.tostring()
@@ -84,21 +93,19 @@ def deserialize_iteration_state(iteration_result):
     Parameters:
         iteration_result: the output of the step function
     Returns:
-        loss: the averaged loss from that iteration of training
-        accuracy: the averaged accuracy from that iteration of training
         new_model_state: the stringified (serialized) state to pass in to next
         iteration of step function training, represents the averaged weights
-        from the last iteration of training; zeros out loss, accuracy,
-        image_count in this state because the new iteration must start with
+        from the last iteration of training; zeros out image_count in this state
+        because the new iteration must start with
         fresh values
     """
     if not iteration_result:
         return None
     state = np.fromstring(iteration_result, dtype=np.float32)
     new_model_string = np.array(state)
-    new_model_string[0], new_model_string[1], new_model_string[2] = 0, 0, 0
+    new_model_string[0]= 0
     new_model_string = np.float32(new_model_string)
-    return float(state[0]), float(state[1]), new_model_string.tostring()
+    return new_model_string.tostring()
 
 
 def deserialize_weights_merge(state):
@@ -107,8 +114,6 @@ def deserialize_weights_merge(state):
         state: the stringified (serialized) state containing loss, accuracy, image_count, and
             model_weights, passed from postgres to merge function
     Returns:
-        loss: the averaged loss from that iteration of training
-        accuracy: the averaged accuracy from that iteration of training
         image_count: total buffer counts processed
         model_weights: a single flattened numpy array containing all of the
         weights, flattened because all we have to do is average them (so don't
@@ -117,13 +122,13 @@ def deserialize_weights_merge(state):
     if not state:
         return None
     state = np.fromstring(state, dtype=np.float32)
-    return float(state[0]), float(state[1]), int(float(state[2])), state[3:]
+    return float(state[0]), state[1:]
 
 
-def serialize_weights_merge(loss, accuracy, image_count, model_weights):
+def serialize_weights_merge(image_count, model_weights):
     """
     Parameters:
-        loss, accuracy, image_count: float values
+        image_count: float values
         model_weights: a single flattened numpy array containing all of the
         weights, averaged in merge function over the 2 states
     Returns:
@@ -132,7 +137,7 @@ def serialize_weights_merge(loss, accuracy, image_count, model_weights):
     """
     if model_weights is None:
         return None
-    new_model_string = np.array([loss, accuracy, image_count])
+    new_model_string = np.array([image_count])
     new_model_string = np.concatenate((new_model_string, model_weights))
     new_model_string = np.float32(new_model_string)
     return new_model_string.tostring()

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_wrapper.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_wrapper.py_in
@@ -169,13 +169,28 @@ def parse_and_validate_compile_params(str_of_args):
     compile_dict = validate_and_literal_eval_keys(compile_dict,
                                                   literal_eval_compile_params,
                                                   accepted_compile_params)
-
     _assert('optimizer' in compile_dict, "optimizer is a required parameter for compile")
     opt_name, opt_args = parse_optimizer(compile_dict)
 
     _assert('loss' in compile_dict, "loss is a required parameter for compile")
     validate_compile_param_types(compile_dict)
-    return (opt_name,opt_args,compile_dict)
+    _validate_metrics(compile_dict)
+    return (opt_name, opt_args, compile_dict)
+
+def _validate_metrics(compile_dict):
+    _assert('metrics' not in compile_dict.keys() or
+        compile_dict['metrics'] is None or
+        type(compile_dict['metrics']) is list,
+        "wrong input type for compile parameter metrics: multi-output model"
+        "and user defined metrics are not supported yet, please pass a list")
+    if 'metrics' in compile_dict and compile_dict['metrics']:
+        unsupported_metrics_list = ['sparse_categorical_accuracy',
+            'sparse_categorical_crossentropy', 'top_k_categorical_accuracy',
+            'sparse_top_k_categorical_accuracy']
+        _assert(len(compile_dict['metrics']) == 1,
+            "Only at most one metric is supported.")
+        _assert(compile_dict['metrics'][0] not in unsupported_metrics_list,
+            "Metric {0} is not supported.".format(compile_dict['metrics'][0]))
 
 # Parse the optimizer name and params.
 def parse_optimizer(compile_dict):
@@ -241,7 +256,6 @@ def parse_and_validate_fit_params(fit_param_str):
 # Validate the keys of the given dictionary and run literal_eval on the
 # user-defined subset
 def validate_and_literal_eval_keys(keys_dict, literal_eval_list, accepted_list):
-
     for ckey in keys_dict.keys():
         _assert(ckey in accepted_list,
             "{0} is not accepted as a parameter yet. "
@@ -277,13 +291,6 @@ def compile_model(model, compile_params):
     model.compile(**compile_dict)
 
 def validate_compile_param_types(compile_dict):
-
-    _assert('metrics' not in compile_dict.keys() or
-            compile_dict['metrics'] is None or
-            type(compile_dict['metrics']) is list,
-            "wrong input type for compile parameter metrics: multi-output model"
-            "and user defined metrics are not supported yet, please pass a list")
-
     _assert('loss_weights' not in compile_dict.keys() or
             compile_dict['loss_weights'] is None or
             type(compile_dict['loss_weights']) is list or

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_wrapper.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_wrapper.py_in
@@ -100,7 +100,7 @@ def compile_and_set_weights(segment_model, compile_params, device_name,
                             previous_state, model_shapes):
     with K.tf.device(device_name):
         compile_model(segment_model, compile_params)
-        _, _, _, model_weights = madlib_keras_serializer.deserialize_weights(
+        _, model_weights = madlib_keras_serializer.deserialize_weights(
             previous_state, model_shapes)
         segment_model.set_weights(model_weights)
 
@@ -109,7 +109,7 @@ def compile_and_set_weights(segment_model, compile_params, device_name,
 # now might create more merge conflicts with other JIRAs, so get to this later.
 def set_model_weights(segment_model, device_name, state, model_shapes):
     with K.tf.device(device_name):
-        _, _, _, model_weights = madlib_keras_serializer.deserialize_weights(
+        _, model_weights = madlib_keras_serializer.deserialize_weights(
             state, model_shapes)
         segment_model.set_weights(model_weights)
 

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras.sql_in
@@ -110,7 +110,7 @@ SELECT madlib_keras_fit(
     'keras_saved_out',
     'model_arch',
     1,
-    $$ optimizer=SGD(lr=0.01, decay=1e-6, nesterov=True), loss='categorical_crossentropy', metrics=['accuracy']$$::text,
+    $$ optimizer=SGD(lr=0.01, decay=1e-6, nesterov=True), loss='categorical_crossentropy', metrics=['mae']$$::text,
     $$ batch_size=2, epochs=1, verbose=0 $$::text,
     3,
     NULL,
@@ -133,7 +133,7 @@ SELECT assert(
         description is NULL AND
         model_size > 0 AND
         madlib_version is NOT NULL AND
-        compile_params = $$ optimizer=SGD(lr=0.01, decay=1e-6, nesterov=True), loss='categorical_crossentropy', metrics=['accuracy']$$::text AND
+        compile_params = $$ optimizer=SGD(lr=0.01, decay=1e-6, nesterov=True), loss='categorical_crossentropy', metrics=['mae']$$::text AND
         fit_params = $$ batch_size=2, epochs=1, verbose=0 $$::text AND
         num_iterations = 3 AND
         metrics_compute_frequency = 3 AND
@@ -272,6 +272,28 @@ SELECT assert(
 FROM (SELECT * FROM keras_out_summary) summary;
 
 SELECT assert(model_data IS NOT NULL , 'Keras model output validation failed') FROM (SELECT * FROM keras_out) k;
+
+-- Validate metrics=NULL works fine
+DROP TABLE IF EXISTS keras_saved_out, keras_saved_out_summary;
+SELECT madlib_keras_fit(
+'cifar_10_sample_batched',
+'keras_saved_out',
+'model_arch',
+1,
+$$ optimizer=SGD(lr=0.01, decay=1e-6, nesterov=True), loss='categorical_crossentropy'$$::text,
+$$ batch_size=2, epochs=1, verbose=0 $$::text,
+1);
+
+-- Validate metrics=[] works fine
+DROP TABLE IF EXISTS keras_saved_out, keras_saved_out_summary;
+SELECT madlib_keras_fit(
+'cifar_10_sample_batched',
+'keras_saved_out',
+'model_arch',
+1,
+$$ optimizer=SGD(lr=0.01, decay=1e-6, nesterov=True), loss='categorical_crossentropy', metrics=[]$$::text,
+$$ batch_size=2, epochs=1, verbose=0 $$::text,
+1);
 
 DROP TABLE IF EXISTS cifar10_predict;
 SELECT madlib_keras_predict(

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras.sql_in
@@ -141,9 +141,9 @@ SELECT assert(
         class_values = '{0,1}' AND
         training_metrics_final >= 0  AND
         training_loss_final  >= 0  AND
-        array_upper(training_metrics, 1) = 3 AND
-        array_upper(training_loss, 1) = 3 AND
-        array_upper(time_iter, 1) = 3 AND
+        array_upper(training_metrics, 1) = 1 AND
+        array_upper(training_loss, 1) = 1 AND
+        array_upper(time_iter, 1) = 1 AND
         validation_metrics_final >= 0 AND
         validation_loss_final  >= 0  AND
         array_upper(validation_metrics, 1) = 1 AND
@@ -175,10 +175,9 @@ SELECT assert(
         metrics_compute_frequency = 4 AND
         training_metrics_final >= 0  AND
         training_loss_final  >= 0  AND
-        -- TODO: Uncomment this after MADLIB-1332 is merged to master
-        -- array_upper(training_metrics, 1) = 2 AND
-        -- array_upper(training_loss, 1) = 2 AND
-        -- array_upper(time_iter, 1) = 2 AND
+        array_upper(training_metrics, 1) = 2 AND
+        array_upper(training_loss, 1) = 2 AND
+        array_upper(time_iter, 1) = 2 AND
         validation_metrics_final >= 0 AND
         validation_loss_final  >= 0  AND
         array_upper(validation_metrics, 1) = 2 AND
@@ -234,7 +233,7 @@ SELECT madlib_keras_fit(
     2,
     NULL,
     NULL,
-    NULL,
+    1,
     'model name', 'model desc');
 
 SELECT assert(
@@ -248,7 +247,7 @@ SELECT assert(
     fit_params = $$ batch_size=2, epochs=1, verbose=0 $$::text AND
     num_iterations = 2 AND
     validation_table is NULL AND
-    metrics_compute_frequency = 2 AND
+    metrics_compute_frequency = 1 AND
     name = 'model name' AND
     description = 'model desc' AND
     model_type = 'madlib_keras' AND

--- a/src/ports/postgres/modules/deep_learning/test/unit_tests/test_madlib_keras.py_in
+++ b/src/ports/postgres/modules/deep_learning/test/unit_tests/test_madlib_keras.py_in
@@ -42,8 +42,7 @@ class MadlibKerasFitTestCase(unittest.TestCase):
     def setUp(self):
         self.plpy_mock = Mock(spec='error')
         patches = {
-            'plpy': plpy,
-            'utilities.minibatch_preprocessing': Mock()
+            'plpy': plpy
         }
 
         self.plpy_mock_execute = MagicMock()
@@ -678,6 +677,40 @@ class MadlibKerasWrapperTestCase(unittest.TestCase):
         opt_name,opt_args,result_params = self.subject.parse_and_validate_compile_params(test_str)
         self.assertDictEqual(result_params, compile_dict)
 
+    def test_validate_metrics_None_pass(self):
+        compile_dict = {'optimizer':'SGD(lr=0.01, decay=1e-6, nesterov=True)',
+                        'metrics':['accuracy'], 'loss':'categorical_crossentropy'}
+        self.subject._validate_metrics(compile_dict)
+
+    def test_validate_metrics_empty_pass(self):
+        compile_dict = {'optimizer':'SGD(lr=0.01, decay=1e-6, nesterov=True)',
+                        'metrics':[], 'loss':'categorical_crossentropy'}
+        self.subject._validate_metrics(compile_dict)
+
+    def test_validate_metrics_two_params_fail(self):
+        compile_dict = {'optimizer':'SGD(lr=0.01, decay=1e-6, nesterov=True)',
+                        'metrics':['accuracy','mae'], 'loss':'categorical_crossentropy'}
+        with self.assertRaises(plpy.PLPYException) as error:
+            self.subject._validate_metrics(compile_dict)
+
+    def test_validate_metrics_one_unsupported_fail(self):
+        compile_dict = {'optimizer':'SGD(lr=0.01, decay=1e-6, nesterov=True)',
+                        'metrics':['sparse_categorical_accuracy'], 'loss':'categorical_crossentropy'}
+        with self.assertRaises(plpy.PLPYException) as error:
+            self.subject._validate_metrics(compile_dict)
+
+    def test_validate_metrics_two_unsupported_fail(self):
+        compile_dict = {'optimizer':'SGD(lr=0.01, decay=1e-6, nesterov=True)',
+                        'metrics':['sparse_categorical_accuracy', 'sparse_categorical_crossentropy'], 'loss':'categorical_crossentropy'}
+        with self.assertRaises(plpy.PLPYException) as error:
+            self.subject._validate_metrics(compile_dict)
+
+    def test_validate_metrics_one_supported_one_unsupported_fail(self):
+        compile_dict = {'optimizer':'SGD(lr=0.01, decay=1e-6, nesterov=True)',
+                        'metrics':['accuracy', 'sparse_categorical_crossentropy'], 'loss':'categorical_crossentropy'}
+        with self.assertRaises(plpy.PLPYException) as error:
+            self.subject._validate_metrics(compile_dict)
+
     def test_parse_and_validate_compile_params_default_optimizer_pass(self):
         test_str = "optimizer='SGD', loss='categorical_crossentropy'"
         _,_,result_dict = self.subject.parse_and_validate_compile_params(test_str)
@@ -1070,8 +1103,7 @@ class MadlibKerasEvaluationTestCase(unittest.TestCase):
     def setUp(self):
         self.plpy_mock = Mock(spec='error')
         patches = {
-            'plpy': plpy,
-            'utilities.minibatch_preprocessing': Mock()
+            'plpy': plpy
         }
 
         self.plpy_mock_execute = MagicMock()
@@ -1283,9 +1315,7 @@ class MadlibKerasEvaluationTestCase(unittest.TestCase):
         output_state = self.subject.internal_keras_eval_final(input_state)
         agg_loss = output_state[0]
         agg_accuracy = output_state[1]
-        image_count_output = output_state[2]
 
-        self.assertEqual(image_count, image_count_output)
         self.assertAlmostEqual(self.loss, agg_loss,2)
         self.assertAlmostEqual(self.accuracy, agg_accuracy,2)
 

--- a/src/ports/postgres/modules/deep_learning/test/unit_tests/test_madlib_keras.py_in
+++ b/src/ports/postgres/modules/deep_learning/test/unit_tests/test_madlib_keras.py_in
@@ -65,8 +65,6 @@ class MadlibKerasFitTestCase(unittest.TestCase):
         for a in self.model.get_weights():
             self.model_shapes.append(a.shape)
 
-        self.loss = 13.0
-        self.accuracy = 3.4
         self.all_seg_ids = [0,1,2]
 
         self.independent_var = [[[[0.5]]]] * 10
@@ -88,7 +86,7 @@ class MadlibKerasFitTestCase(unittest.TestCase):
         self.subject.is_platform_pg = Mock(return_value = True)
         starting_image_count = 0
         ending_image_count = len(self.dependent_var)
-        previous_state = [self.loss, self.accuracy, starting_image_count]
+        previous_state = [starting_image_count]
         previous_state.extend(self.model_weights)
         previous_state = np.array(previous_state, dtype=np.float32)
 
@@ -99,8 +97,8 @@ class MadlibKerasFitTestCase(unittest.TestCase):
             self.compile_params, self.fit_params, 0, self.all_seg_ids,
             self.total_images_per_seg, 0, 4, previous_state.tostring(), **k)
         state = np.fromstring(new_model_state, dtype=np.float32)
-        image_count = state[2]
-        weights = np.rint(state[3:]).astype(np.int)
+        image_count = state[0]
+        weights = np.rint(state[1:]).astype(np.int)
         self.assertEqual(ending_image_count, image_count)
         # weights should not be modified yet
         self.assertTrue((self.model_weights == weights).all())
@@ -121,7 +119,7 @@ class MadlibKerasFitTestCase(unittest.TestCase):
         self.subject.is_platform_pg = Mock(return_value = False)
         starting_image_count = 0
         ending_image_count = len(self.dependent_var)
-        previous_state = [self.loss, self.accuracy, starting_image_count]
+        previous_state = [starting_image_count]
         previous_state.extend(self.model_weights)
         previous_state = np.array(previous_state, dtype=np.float32)
 
@@ -132,8 +130,8 @@ class MadlibKerasFitTestCase(unittest.TestCase):
             self.compile_params, self.fit_params, 0, self.all_seg_ids,
             self.total_images_per_seg, 0, 4, previous_state.tostring(), **k)
         state = np.fromstring(new_model_state, dtype=np.float32)
-        image_count = state[2]
-        weights = np.rint(state[3:]).astype(np.int)
+        image_count = state[0]
+        weights = np.rint(state[1:]).astype(np.int)
         self.assertEqual(ending_image_count, image_count)
         # weights should not be modified yet
         self.assertTrue((self.model_weights == weights).all())
@@ -154,7 +152,7 @@ class MadlibKerasFitTestCase(unittest.TestCase):
         starting_image_count = len(self.dependent_var)
         ending_image_count = starting_image_count + len(self.dependent_var)
 
-        state = [self.loss, self.accuracy, starting_image_count]
+        state = [starting_image_count]
         state.extend(self.model_weights)
         state = np.array(state, dtype=np.float32)
 
@@ -169,8 +167,8 @@ class MadlibKerasFitTestCase(unittest.TestCase):
             self.total_images_per_seg, 0, 4, 'dummy_previous_state', **k)
 
         state = np.fromstring(new_model_state, dtype=np.float32)
-        image_count = state[2]
-        weights = np.rint(state[3:]).astype(np.int)
+        image_count = state[0]
+        weights = np.rint(state[1:]).astype(np.int)
         self.assertEqual(ending_image_count, image_count)
         # weights should not be modified yet
         self.assertTrue((self.model_weights == weights).all())
@@ -189,7 +187,7 @@ class MadlibKerasFitTestCase(unittest.TestCase):
         starting_image_count = 2*len(self.dependent_var)
         ending_image_count = starting_image_count + len(self.dependent_var)
 
-        state = [self.loss, self.accuracy, starting_image_count]
+        state = [starting_image_count]
         state.extend(self.model_weights)
         state = np.array(state, dtype=np.float32)
 
@@ -205,8 +203,8 @@ class MadlibKerasFitTestCase(unittest.TestCase):
             0, 4, 'dummy_previous_state', **k)
 
         state = np.fromstring(new_model_state, dtype=np.float32)
-        image_count = state[2]
-        weights = np.rint(state[3:]).astype(np.int)
+        image_count = state[0]
+        weights = np.rint(state[1:]).astype(np.int)
         self.assertEqual(ending_image_count, image_count)
         # weights should be multiplied by final image count
         self.assertTrue((multiplied_weights == weights).all())
@@ -226,7 +224,7 @@ class MadlibKerasFitTestCase(unittest.TestCase):
         starting_image_count = 2*len(self.dependent_var)
         ending_image_count = starting_image_count + len(self.dependent_var)
 
-        state = [self.loss, self.accuracy, starting_image_count]
+        state = [starting_image_count]
         state.extend(self.model_weights)
         state = np.array(state, dtype=np.float32)
 
@@ -242,8 +240,8 @@ class MadlibKerasFitTestCase(unittest.TestCase):
             self.total_images_per_seg, 0, 4, 'dummy_previous_state', **k)
 
         state = np.fromstring(new_model_state, dtype=np.float32)
-        image_count = state[2]
-        weights = np.rint(state[3:]).astype(np.int)
+        image_count = state[0]
+        weights = np.rint(state[1:]).astype(np.int)
         self.assertEqual(ending_image_count, image_count)
         # weights should be multiplied by final image count
         self.assertTrue((multiplied_weights == weights).all())
@@ -257,7 +255,7 @@ class MadlibKerasFitTestCase(unittest.TestCase):
         self.subject.K.set_session = Mock()
         self.subject.clear_keras_session = Mock()
         starting_image_count = 0
-        previous_state = [self.loss, self.accuracy, starting_image_count]
+        previous_state = [starting_image_count]
         previous_state.extend(self.model_weights)
         previous_state = np.array(previous_state, dtype=np.float32)
 
@@ -276,7 +274,7 @@ class MadlibKerasFitTestCase(unittest.TestCase):
         self.subject.K.set_session = Mock()
         self.subject.clear_keras_session = Mock()
         starting_image_count = 0
-        previous_state = [self.loss, self.accuracy, starting_image_count]
+        previous_state = [ starting_image_count]
         previous_state.extend(self.model_weights)
         previous_state = np.array(previous_state, dtype=np.float32)
 
@@ -312,56 +310,44 @@ class MadlibKerasFitTestCase(unittest.TestCase):
 
     def test_fit_merge(self):
         image_count = self.total_images_per_seg[0]
-        state1 = [3.0*self.loss, 3.0*self.accuracy, image_count]
+        state1 = [image_count]
         state1.extend(mult(3,self.model_weights))
         state1 = np.array(state1, dtype=np.float32)
-        state2 = [2.0*self.loss, 2.0*self.accuracy, image_count+30]
+        state2 = [image_count+30]
         state2.extend(mult(2,self.model_weights))
         state2 = np.array(state2, dtype=np.float32)
         merged_state = self.subject.fit_merge(state1.tostring(),state2.tostring())
         state = np.fromstring(merged_state, dtype=np.float32)
-        agg_loss = state[0]
-        agg_accuracy = state[1]
-        image_count_total = state[2]
-        weights = np.rint(state[3:]).astype(np.int)
+        image_count_total = state[0]
+        weights = np.rint(state[1:]).astype(np.int)
 
         self.assertEqual( 2*image_count+30 , image_count_total )
-        self.assertAlmostEqual( 5.0*self.loss, agg_loss, 2)
-        self.assertAlmostEqual( 5.0*self.accuracy, agg_accuracy, 2)
         self.assertTrue( (mult(5,self.model_weights) == weights).all())
 
     def test_fit_merge_none_first(self):
         image_count = self.total_images_per_seg[0]
-        input_state = [self.loss, self.accuracy, image_count]
+        input_state = [image_count]
         input_state.extend(self.model_weights)
         input_state = np.array(input_state, dtype=np.float32)
         merged_state = self.subject.fit_merge(None, input_state.tostring())
         state = np.fromstring(merged_state, dtype=np.float32)
-        agg_loss = state[0]
-        agg_accuracy = state[1]
-        image_count_total = state[2]
-        weights = np.rint(state[3:]).astype(np.int)
+        image_count_total = state[0]
+        weights = np.rint(state[1:]).astype(np.int)
 
         self.assertEqual(image_count, image_count_total)
-        self.assertAlmostEqual(self.loss, agg_loss, 2)
-        self.assertAlmostEqual(self.accuracy, agg_accuracy, 2)
         self.assertTrue((self.model_weights == weights).all())
 
     def test_fit_merge_none_second(self):
         image_count = self.total_images_per_seg[0]
-        input_state = [self.loss, self.accuracy, image_count]
+        input_state = [image_count]
         input_state.extend(self.model_weights)
         input_state = np.array(input_state, dtype=np.float32)
         merged_state = self.subject.fit_merge(input_state.tostring(), None)
         state = np.fromstring(merged_state, dtype=np.float32)
-        agg_loss = state[0]
-        agg_accuracy = state[1]
-        image_count_total = state[2]
-        weights = np.rint(state[3:]).astype(np.int)
+        image_count_total = state[0]
+        weights = np.rint(state[1:]).astype(np.int)
 
         self.assertEqual(image_count, image_count_total)
-        self.assertAlmostEqual(self.loss, agg_loss, 2)
-        self.assertAlmostEqual(self.accuracy, agg_accuracy, 2)
         self.assertTrue((self.model_weights == weights).all())
 
     def test_fit_merge_both_none(self):
@@ -370,25 +356,30 @@ class MadlibKerasFitTestCase(unittest.TestCase):
 
     def test_fit_final(self):
         image_count = self.total_images_per_seg[0]
-        input_state = [image_count*self.loss, image_count*self.accuracy, image_count]
+        input_state = [image_count]
         input_state.extend(mult(image_count,self.model_weights))
         input_state = np.array(input_state, dtype=np.float32)
 
         output_state = self.subject.fit_final(input_state.tostring())
         output_state = np.fromstring(output_state, dtype=np.float32)
-        agg_loss = output_state[0]
-        agg_accuracy = output_state[1]
-        image_count_output = output_state[2]
-        weights = np.rint(output_state[3:]).astype(np.int)
+        image_count_output = output_state[0]
+        weights = np.rint(output_state[1:]).astype(np.int)
 
         self.assertEqual(image_count, image_count_output)
-        self.assertAlmostEqual(self.loss, agg_loss,2)
-        self.assertAlmostEqual(self.accuracy, agg_accuracy,2)
         self.assertTrue((self.model_weights == weights).all())
 
     def test_fit_final_none(self):
         result = self.subject.fit_final(None)
         self.assertEqual(result, None)
+
+    def test_fit_final_image_count_zero(self):
+        input_state = [0]
+        input_state.extend(self.model_weights)
+        input_state = np.array(input_state, dtype=np.float32)
+
+        with self.assertRaises(plpy.PLPYException):
+            result = self.subject.fit_final(input_state.tostring())
+
     def test_should_compute_metrics_this_iter_last_iter_case1(self):
         res = self.subject.should_compute_metrics_this_iter(5, 5, 5)
         self.assertEqual(True, res)
@@ -408,13 +399,6 @@ class MadlibKerasFitTestCase(unittest.TestCase):
         res = self.subject.should_compute_metrics_this_iter(2, 1, 5)
         self.assertEqual(True, res)
 
-    def test_fit_final_image_count_zero(self):
-        input_state = [0, 0, 0]
-        input_state.extend(self.model_weights)
-        input_state = np.array(input_state, dtype=np.float32)
-
-        with self.assertRaises(plpy.PLPYException):
-            result = self.subject.fit_final(input_state.tostring())
 
 class MadlibKerasPredictTestCase(unittest.TestCase):
     def setUp(self):
@@ -943,12 +927,10 @@ class MadlibSerializerTestCase(unittest.TestCase):
         self.assertEqual(None, self.subject.deserialize_weights_merge(None))
 
     def test_deserialize_weights_merge_returns_not_none(self):
-        dummy_model_state = np.array([0,1,2,3,4,5,6], dtype=np.float32)
+        dummy_model_state = np.array([2,3,4,5,6], dtype=np.float32)
         res = self.subject.deserialize_weights_merge(dummy_model_state.tostring())
-        self.assertEqual(0, res[0])
-        self.assertEqual(1, res[1])
-        self.assertEqual(2, res[2])
-        self.assertEqual([3,4,5,6], res[3].tolist())
+        self.assertEqual(2, res[0])
+        self.assertEqual([3,4,5,6], res[1].tolist())
 
     def test_deserialize_weights_null_input_returns_none(self):
         dummy_model_state = np.array([0,1,2,3,4,5,6], dtype=np.float32)
@@ -957,14 +939,12 @@ class MadlibSerializerTestCase(unittest.TestCase):
         self.assertEqual(None, self.subject.deserialize_weights(None, None))
 
     def test_deserialize_weights_valid_input_returns_not_none(self):
-        dummy_model_state = np.array([0,1,2,3,4,5], dtype=np.float32)
+        dummy_model_state = np.array([0,3,4,5], dtype=np.float32)
         dummy_model_shape = [(2, 1, 1, 1), (1,)]
         res = self.subject.deserialize_weights(dummy_model_state.tostring(), dummy_model_shape)
         self.assertEqual(0, res[0])
-        self.assertEqual(1, res[1])
-        self.assertEqual(2, res[2])
-        self.assertEqual([[[[3.0]]], [[[4.0]]]], res[3][0].tolist())
-        self.assertEqual([5], res[3][1].tolist())
+        self.assertEqual([[[[3.0]]], [[[4.0]]]], res[1][0].tolist())
+        self.assertEqual([5], res[1][1].tolist())
 
     def test_deserialize_weights_invalid_input_fails(self):
         # pass an invalid state with missing model weights
@@ -987,31 +967,30 @@ class MadlibSerializerTestCase(unittest.TestCase):
         self.assertEqual(None, self.subject.deserialize_iteration_state(None))
 
     def test_deserialize_iteration_state_returns_valid_output(self):
-        dummy_iteration_state = np.array([0,1,2,3,4,5], dtype=np.float32)
+        dummy_iteration_state = np.array([2,3,4,5], dtype=np.float32)
         res = self.subject.deserialize_iteration_state(
             dummy_iteration_state.tostring())
-        self.assertEqual(0, res[0])
-        self.assertEqual(1, res[1])
-        self.assertEqual(res[2],
-                         np.array([0,0,0,3,4,5], dtype=np.float32).tostring())
+        self.assertEqual(res,
+                         np.array([0,3,4,5], dtype=np.float32).tostring())
+
 
     def test_serialize_weights_none_weights_returns_none(self):
-        res = self.subject.serialize_weights(0,1,2,None)
+        res = self.subject.serialize_weights(0,None)
         self.assertEqual(None , res)
 
     def test_serialize_weights_valid_output(self):
-        res = self.subject.serialize_weights(0,1,2,[np.array([1,3]),
+        res = self.subject.serialize_weights(0,[np.array([1,3]),
                                                     np.array([4,5])])
-        self.assertEqual(np.array([0,1,2,1,3,4,5], dtype=np.float32).tostring(),
+        self.assertEqual(np.array([0,1,3,4,5], dtype=np.float32).tostring(),
                          res)
 
     def test_serialize_weights_merge_none_weights_returns_none(self):
-        res = self.subject.serialize_weights_merge(0,1,2,None)
+        res = self.subject.serialize_weights_merge(0,None)
         self.assertEqual(None , res)
 
     def test_serialize_weights_merge_valid_output(self):
-        res = self.subject.serialize_weights_merge(0,1,2,np.array([1,3,4,5]))
-        self.assertEqual(np.array([0,1,2,1,3,4,5], dtype=np.float32).tostring(),
+        res = self.subject.serialize_weights_merge(0,np.array([1,3,4,5]))
+        self.assertEqual(np.array([0,1,3,4,5], dtype=np.float32).tostring(),
                          res)
 
 class PredictInputPredTypeValidationTestCase(unittest.TestCase):
@@ -1150,7 +1129,7 @@ class MadlibKerasEvaluationTestCase(unittest.TestCase):
         k = {'SD' : {}}
         state = [0,0,0]
 
-        serialized_weights = [0, 0, 0] # not used
+        serialized_weights = [0] # not used
         serialized_weights.extend(self.model_weights)
         serialized_weights = np.array(serialized_weights, dtype=np.float32).tostring()
 
@@ -1183,7 +1162,7 @@ class MadlibKerasEvaluationTestCase(unittest.TestCase):
 
         k = {'SD' : {}}
 
-        model_state = [self.loss, self.accuracy, starting_image_count]
+        model_state = [starting_image_count]
         model_state.extend(self.model_weights)
         model_state = np.array(model_state, dtype=np.float32)
 
@@ -1220,7 +1199,7 @@ class MadlibKerasEvaluationTestCase(unittest.TestCase):
         ending_image_count = starting_image_count + len(self.dependent_var)
         k = {'SD' : {}}
 
-        model_state = [self.loss, self.accuracy, starting_image_count]
+        model_state = [starting_image_count]
         model_state.extend(self.model_weights)
         model_state = np.array(model_state, dtype=np.float32)
 


### PR DESCRIPTION
This PR aims to improve the way metrics are handled. 
1. We add support for various metrics
2. We validate to make sure only a single metric is passed
3. We add support for metrics_compute_frequency for training data
4. We remove metric and loss computation from fit transition