### PR TITLE
DL: Enable transfer learning

### DIFF
--- a/src/madpack/madpack.py
+++ b/src/madpack/madpack.py
@@ -1027,8 +1027,9 @@ def run_install_check(args, testcase, madpack_cmd):
         _internal_run_query("DROP OWNED BY %s CASCADE;" % (test_user), True)
         _internal_run_query("DROP USER IF EXISTS %s;" % (test_user), True)
 
-    _internal_run_query("CREATE USER %s;" % (test_user), True)
+    _internal_run_query("CREATE USER %s WITH SUPERUSER NOINHERIT;" % (test_user), True)
     _internal_run_query("GRANT USAGE ON SCHEMA %s TO %s;" % (schema, test_user), True)
+    _internal_run_query("GRANT ALL PRIVILEGES ON DATABASE %s TO %s;" % (db_name, test_user), True)
 
     # 2) Run test SQLs
     info_(this, "> Running %s scripts for:" % madpack_cmd, verbose)
@@ -1053,6 +1054,8 @@ def run_install_check(args, testcase, madpack_cmd):
             from time import sleep
             sleep(1)
             _internal_run_query("DROP OWNED BY %s CASCADE;" % (test_user), show_error=True)
+
+        _internal_run_query("REVOKE ALL PRIVILEGES ON DATABASE %s FROM %s;" % (db_name, test_user), True)
         _internal_run_query("DROP USER %s;" % (test_user), True)
 
 

--- a/src/ports/postgres/modules/deep_learning/keras_model_arch_table.py_in
+++ b/src/ports/postgres/modules/deep_learning/keras_model_arch_table.py_in
@@ -34,7 +34,7 @@ from utilities.validate_args import input_tbl_valid
 from utilities.validate_args import quote_ident
 from utilities.validate_args import table_exists
 
-class Format:
+class ModelArchSchema:
     """Expected format of keras_model_arch_table.
        Example uses:
 
@@ -63,8 +63,8 @@ def load_keras_model(keras_model_arch_table, model_arch, model_weights,
                      name, description, **kwargs):
     model_arch_table = quote_ident(keras_model_arch_table)
     if not table_exists(model_arch_table):
-        col_defs = get_col_name_type_sql_string(Format.col_names,
-                                                Format.col_types)
+        col_defs = get_col_name_type_sql_string(ModelArchSchema.col_names,
+                                                ModelArchSchema.col_types)
 
         sql = "CREATE TABLE {model_arch_table} ({col_defs})" \
               .format(**locals())
@@ -74,7 +74,7 @@ def load_keras_model(keras_model_arch_table, model_arch, model_weights,
             .format(model_arch_table))
     else:
         missing_cols = columns_missing_from_table(model_arch_table,
-                                                  Format.col_names)
+                                                  ModelArchSchema.col_names)
         if len(missing_cols) > 0:
             plpy.error("Keras Model Arch: Invalid keras model arch table {0},"
                        " missing columns: {1}".format(model_arch_table,
@@ -83,37 +83,37 @@ def load_keras_model(keras_model_arch_table, model_arch, model_weights,
     unique_str = unique_string(prefix_has_temp=False)
     insert_query = plpy.prepare("INSERT INTO {model_arch_table} "
                                 "VALUES(DEFAULT, $1, $2, $3, $4, $5);".format(**locals()),
-                                Format.col_types[1:])
+                                ModelArchSchema.col_types[1:])
     insert_res = plpy.execute(insert_query,[model_arch, model_weights, name, description,
                                unique_str], 0)
 
     select_query = "SELECT {model_id_col}, {model_arch_col} FROM {model_arch_table} " \
                    "WHERE {internal_id_col} = '{unique_str}'".format(
-                    model_id_col=Format.MODEL_ID,
-                    model_arch_col=Format.MODEL_ARCH,
+                    model_id_col=ModelArchSchema.MODEL_ID,
+                    model_arch_col=ModelArchSchema.MODEL_ARCH,
                     model_arch_table=model_arch_table,
-                    internal_id_col=Format.__INTERNAL_MADLIB_ID__,
+                    internal_id_col=ModelArchSchema.__INTERNAL_MADLIB_ID__,
                     unique_str=unique_str)
     select_res = plpy.execute(select_query,1)
 
-    if len(select_res) != 1 or select_res[0][Format.MODEL_ARCH] != model_arch:
+    if len(select_res) != 1 or select_res[0][ModelArchSchema.MODEL_ARCH] != model_arch:
         raise Exception("Failed to insert new row in {0} table--try again?"
                        .format(model_arch_table))
     plpy.info("Keras Model Arch: Added model id {0} to {1} table".
-        format(select_res[0][Format.MODEL_ID], model_arch_table))
+              format(select_res[0][ModelArchSchema.MODEL_ID], model_arch_table))
 
 def delete_keras_model(keras_model_arch_table, model_id, **kwargs):
     model_arch_table = quote_ident(keras_model_arch_table)
     input_tbl_valid(model_arch_table, "Keras Model Arch")
 
-    missing_cols = columns_missing_from_table(model_arch_table, Format.col_names)
+    missing_cols = columns_missing_from_table(model_arch_table, ModelArchSchema.col_names)
     if len(missing_cols) > 0:
         plpy.error("Keras Model Arch: Invalid keras model arch table {0},"
                    " missing columns: {1}".format(model_arch_table, missing_cols))
 
     sql = """
            DELETE FROM {model_arch_table} WHERE {model_id_col}={model_id}
-          """.format(model_arch_table=model_arch_table, model_id_col=Format.MODEL_ID,
+          """.format(model_arch_table=model_arch_table, model_id_col=ModelArchSchema.MODEL_ID,
                      model_id=model_id)
     res = plpy.execute(sql, 0)
 
@@ -123,7 +123,7 @@ def delete_keras_model(keras_model_arch_table, model_id, **kwargs):
     else:
         plpy.error("Keras Model Arch: Model id {0} not found".format(model_id))
 
-    sql = "SELECT {0} FROM {1}".format(Format.MODEL_ID, model_arch_table)
+    sql = "SELECT {0} FROM {1}".format(ModelArchSchema.MODEL_ID, model_arch_table)
     res = plpy.execute(sql, 0)
     if not res:
         plpy.info("Keras Model Arch: Dropping empty keras model arch "\

--- a/src/ports/postgres/modules/deep_learning/keras_model_arch_table.py_in
+++ b/src/ports/postgres/modules/deep_learning/keras_model_arch_table.py_in
@@ -53,16 +53,14 @@ class Format:
            arch = plpy.execute(sql)[0]
 
     """
-    col_names = ('model_id', 'model_arch', 'model_weights', '__internal_madlib_id__')
-    col_types = ('SERIAL PRIMARY KEY', 'JSON', 'DOUBLE PRECISION[]', 'TEXT')
-    (MODEL_ID, MODEL_ARCH, MODEL_WEIGHTS, __INTERNAL_MADLIB_ID__) = col_names
+    col_names = ('model_id', 'model_arch', 'model_weights', 'name', 'description',
+                 '__internal_madlib_id__')
+    col_types = ('SERIAL PRIMARY KEY', 'JSON', 'bytea', 'TEXT', 'TEXT', 'TEXT')
+    (MODEL_ID, MODEL_ARCH, MODEL_WEIGHTS, NAME, DESCRIPTION,
+     __INTERNAL_MADLIB_ID__) = col_names
 
-@MinWarning("warning")
-def _execute(sql,max_rows=0):
-    return plpy.execute(sql,max_rows)
-
-def load_keras_model(schema_madlib, keras_model_arch_table,
-                     model_arch, **kwargs):
+def load_keras_model(keras_model_arch_table, model_arch, model_weights,
+                     name, description, **kwargs):
     model_arch_table = quote_ident(keras_model_arch_table)
     if not table_exists(model_arch_table):
         col_defs = get_col_name_type_sql_string(Format.col_names,
@@ -71,7 +69,7 @@ def load_keras_model(schema_madlib, keras_model_arch_table,
         sql = "CREATE TABLE {model_arch_table} ({col_defs})" \
               .format(**locals())
 
-        _execute(sql)
+        plpy.execute(sql, 0)
         plpy.info("Keras Model Arch: Created new keras model arch table {0}." \
             .format(model_arch_table))
     else:
@@ -83,27 +81,28 @@ def load_keras_model(schema_madlib, keras_model_arch_table,
                                                       missing_cols))
 
     unique_str = unique_string(prefix_has_temp=False)
+    insert_query = plpy.prepare("INSERT INTO {model_arch_table} "
+                                "VALUES(DEFAULT, $1, $2, $3, $4, $5);".format(**locals()),
+                                Format.col_types[1:])
+    insert_res = plpy.execute(insert_query,[model_arch, model_weights, name, description,
+                               unique_str], 0)
 
-    sql = """INSERT INTO {model_arch_table} ({model_arch_col}, {internal_id_col})
-                                    VALUES({model_arch}, '{unique_str}');
-             SELECT {model_id_col}, {model_arch_col}
-                 FROM {model_arch_table} WHERE {internal_id_col} = '{unique_str}'
-    """.format(model_arch_table=model_arch_table,
-               model_arch_col=Format.MODEL_ARCH,
-               unique_str=unique_str,
-               model_arch=quote_literal(model_arch),
-               model_id_col=Format.MODEL_ID,
-               internal_id_col=Format.__INTERNAL_MADLIB_ID__)
-    res = _execute(sql,1)
+    select_query = "SELECT {model_id_col}, {model_arch_col} FROM {model_arch_table} " \
+                   "WHERE {internal_id_col} = '{unique_str}'".format(
+                    model_id_col=Format.MODEL_ID,
+                    model_arch_col=Format.MODEL_ARCH,
+                    model_arch_table=model_arch_table,
+                    internal_id_col=Format.__INTERNAL_MADLIB_ID__,
+                    unique_str=unique_str)
+    select_res = plpy.execute(select_query,1)
 
-    if len(res) != 1 or res[0][Format.MODEL_ARCH] != model_arch:
+    if len(select_res) != 1 or select_res[0][Format.MODEL_ARCH] != model_arch:
         raise Exception("Failed to insert new row in {0} table--try again?"
                        .format(model_arch_table))
     plpy.info("Keras Model Arch: Added model id {0} to {1} table".
-        format(res[0][Format.MODEL_ID], model_arch_table))
+        format(select_res[0][Format.MODEL_ID], model_arch_table))
 
-def delete_keras_model(schema_madlib, keras_model_arch_table,
-                       model_id, **kwargs):
+def delete_keras_model(keras_model_arch_table, model_id, **kwargs):
     model_arch_table = quote_ident(keras_model_arch_table)
     input_tbl_valid(model_arch_table, "Keras Model Arch")
 
@@ -116,7 +115,7 @@ def delete_keras_model(schema_madlib, keras_model_arch_table,
            DELETE FROM {model_arch_table} WHERE {model_id_col}={model_id}
           """.format(model_arch_table=model_arch_table, model_id_col=Format.MODEL_ID,
                      model_id=model_id)
-    res = _execute(sql)
+    res = plpy.execute(sql, 0)
 
     if res.nrows() > 0:
         plpy.info("Keras Model Arch: Model id {0} has been deleted from {1}.".
@@ -125,16 +124,12 @@ def delete_keras_model(schema_madlib, keras_model_arch_table,
         plpy.error("Keras Model Arch: Model id {0} not found".format(model_id))
 
     sql = "SELECT {0} FROM {1}".format(Format.MODEL_ID, model_arch_table)
-    res = _execute(sql)
+    res = plpy.execute(sql, 0)
     if not res:
         plpy.info("Keras Model Arch: Dropping empty keras model arch "\
             "table {model_arch_table}".format(model_arch_table=model_arch_table))
         sql = "DROP TABLE {0}".format(model_arch_table)
-        try:
-            _execute(sql)
-        except plpy.SPIError, e:
-            plpy.warning("Keras Model Arch: Unable to drop empty keras model "\
-                "arch table {0}".format(model_arch_table))
+        plpy.execute(sql, 0)
 
 class KerasModelArchDocumentation:
     @staticmethod
@@ -185,8 +180,7 @@ class KerasModelArchDocumentation:
 
         'model_id'                -- SERIAL PRIMARY KEY. Model ID.
         'model_arch'              -- JSON. JSON blob of the model architecture.
-        'model_weights'           -- DOUBLE PRECISION[]. weights of the model for warm start.
-                                  -- This is currently NULL.
+        'model_weights'           -- bytea. weights of the model for warm start.
         '__internal_madlib_id__'  -- TEXT. Unique id for model arch.
 
         """.format(**locals())

--- a/src/ports/postgres/modules/deep_learning/keras_model_arch_table.sql_in
+++ b/src/ports/postgres/modules/deep_learning/keras_model_arch_table.sql_in
@@ -302,14 +302,55 @@ SELECT * FROM model_arch_library;
 </pre>
 */
 
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.load_keras_model(
+    keras_model_arch_table VARCHAR,
+    model_arch             JSON,
+    model_weights          bytea,
+    name                   TEXT,
+    description            TEXT
+)
+    RETURNS VOID AS $$
+    PythonFunctionBodyOnlyNoSchema(`deep_learning', `keras_model_arch_table')
+    from utilities.control import AOControl
+    with AOControl(False):
+        keras_model_arch_table.load_keras_model(**globals())
+$$ LANGUAGE plpythonu VOLATILE;
+
 -- Function to add a keras model to arch table
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.load_keras_model(
     keras_model_arch_table VARCHAR,
     model_arch             JSON
 )
 RETURNS VOID AS $$
-    PythonFunction(`deep_learning',`keras_model_arch_table',`load_keras_model')
-$$ LANGUAGE plpythonu VOLATILE;
+    SELECT MADLIB_SCHEMA.load_keras_model($1, $2, NULL, NULL, NULL)
+$$ LANGUAGE sql VOLATILE
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA');
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.load_keras_model(
+    keras_model_arch_table VARCHAR,
+    model_arch             JSON,
+    model_weights          bytea
+)
+    RETURNS VOID AS $$
+    SELECT MADLIB_SCHEMA.load_keras_model($1, $2, $3, NULL, NULL)
+$$ LANGUAGE sql VOLATILE
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA');
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.load_keras_model(
+    keras_model_arch_table VARCHAR,
+    model_arch             JSON,
+    model_weights          bytea,
+    name                   TEXT
+)
+    RETURNS VOID AS $$
+    SELECT MADLIB_SCHEMA.load_keras_model($1, $2, $3, $4, NULL)
+$$ LANGUAGE sql VOLATILE
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA');
+
+
+
+
+
 
 -- Functions for online help
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.load_keras_model(
@@ -333,7 +374,10 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.delete_keras_model(
     model_id INTEGER
 )
 RETURNS VOID AS $$
-    PythonFunction(`deep_learning',`keras_model_arch_table',`delete_keras_model')
+    PythonFunctionBodyOnlyNoSchema(`deep_learning',`keras_model_arch_table')
+    from utilities.control import AOControl
+    with AOControl(False):
+        keras_model_arch_table.delete_keras_model(**globals())
 $$ LANGUAGE plpythonu VOLATILE;
 
 -- Functions for online help

--- a/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
@@ -43,7 +43,7 @@ from madlib_keras_helper import DEPENDENT_VARTYPE_COLNAME
 from madlib_keras_helper import NORMALIZING_CONST_COLNAME
 from madlib_keras_validator import FitInputValidator
 from madlib_keras_wrapper import *
-from keras_model_arch_table import Format
+from keras_model_arch_table import ModelArchSchema
 
 from utilities.model_arch_info import get_input_shape
 from utilities.model_arch_info import get_num_classes
@@ -112,19 +112,19 @@ def fit(schema_madlib, source_table, model,model_arch_table,
     # Get the serialized master model
     start_deserialization = time.time()
     model_arch_query = "SELECT {0}, {1} FROM {2} WHERE {3} = {4}".format(
-                                        Format.MODEL_ARCH, Format.MODEL_WEIGHTS,
-                                        model_arch_table, Format.MODEL_ID,
+                                        ModelArchSchema.MODEL_ARCH, ModelArchSchema.MODEL_WEIGHTS,
+                                        model_arch_table, ModelArchSchema.MODEL_ID,
                                         model_arch_id)
-    query_result = plpy.execute(model_arch_query)
-    if not  query_result:
+    model_arch_result = plpy.execute(model_arch_query)
+    if not  model_arch_result:
         plpy.error("no model arch found in table {0} with id {1}".format(
             model_arch_table, model_arch_id))
-    query_result = query_result[0]
-    model_arch = query_result[Format.MODEL_ARCH]
+    model_arch_result = model_arch_result[0]
+    model_arch = model_arch_result[ModelArchSchema.MODEL_ARCH]
     input_shape = get_input_shape(model_arch)
     num_classes = get_num_classes(model_arch)
     fit_validator.validate_input_shapes(input_shape)
-    model_weights_serialized = query_result[Format.MODEL_WEIGHTS]
+    model_weights_serialized = model_arch_result[ModelArchSchema.MODEL_WEIGHTS]
 
     #TODO: Refactor the pg related logic in a future PR when we think
     # about making the fit function easier to read and maintain.
@@ -322,7 +322,7 @@ def fit(schema_madlib, source_table, model,model_arch_table,
     create_output_table = plpy.prepare("""
         CREATE TABLE {0} AS SELECT
         $1 as model_data,
-        $2 as {1}""".format(model, Format.MODEL_ARCH), ["bytea", "json"])
+        $2 as {1}""".format(model, ModelArchSchema.MODEL_ARCH), ["bytea", "json"])
     plpy.execute(create_output_table, [model_state, model_arch])
 
     if is_platform_pg():
@@ -571,7 +571,7 @@ def evaluate1(schema_madlib, model_table, test_table, id_col, model_arch_table,
         plpy.error("no model arch found in table {0} with id {1}".format(
             model_arch_table, model_arch_id))
     query_result = query_result[0]
-    model_arch = query_result[Format.MODEL_ARCH]
+    model_arch = query_result[ModelArchSchema.MODEL_ARCH]
     compile_params = "$madlib$" + compile_params + "$madlib$"
 
     loss_acc = get_loss_acc_from_keras_eval(schema_madlib, test_table, dependent_varname,

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_serializer.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_serializer.py_in
@@ -144,6 +144,7 @@ def deserialize_weights_orig(model_weights_serialized, model_shapes):
     from query at the top of this file
     """
     i, j, model_weights = 0, 0, []
+    model_weights_serialized = np.fromstring(model_weights_serialized, dtype=np.float32)
     while j < len(model_shapes):
         next_pointer = i + reduce(lambda x, y: x * y, model_shapes[j])
         weight_arr_portion = model_weights_serialized[i:next_pointer]

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_validator.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_validator.py_in
@@ -18,7 +18,7 @@
 # under the License.
 
 import plpy
-from keras_model_arch_table import Format
+from keras_model_arch_table import ModelArchSchema
 from madlib_keras_helper import CLASS_VALUES_COLNAME
 from madlib_keras_helper import COMPILE_PARAMS_COLNAME
 from madlib_keras_helper import DEPENDENT_VARNAME_COLNAME
@@ -113,11 +113,11 @@ class PredictInputValidator:
                     module_name=self.module_name,
                     model_data=MODEL_DATA_COLNAME,
                     table=self.model_table))
-        _assert(is_var_valid(self.model_table, Format.MODEL_ARCH),
+        _assert(is_var_valid(self.model_table, ModelArchSchema.MODEL_ARCH),
                 "{module_name} error: column '{model_arch}' "
                 "does not exist in model table '{table}'.".format(
                     module_name=self.module_name,
-                    model_arch=Format.MODEL_ARCH,
+                    model_arch=ModelArchSchema.MODEL_ARCH,
                     table=self.model_table))
 
     def _validate_test_tbl_cols(self):

--- a/src/ports/postgres/modules/deep_learning/predict_input_params.py_in
+++ b/src/ports/postgres/modules/deep_learning/predict_input_params.py_in
@@ -18,7 +18,7 @@
 # under the License.
 
 import plpy
-from keras_model_arch_table import Format
+from keras_model_arch_table import ModelArchSchema
 from utilities.utilities import add_postfix
 from utilities.validate_args import input_tbl_valid
 
@@ -50,7 +50,7 @@ class PredictParamsProcessor:
         return self.model_summary_dict[DEPENDENT_VARTYPE_COLNAME]
 
     def get_model_arch(self):
-        return self.model_arch_dict[Format.MODEL_ARCH]
+        return self.model_arch_dict[ModelArchSchema.MODEL_ARCH]
 
     def get_model_data(self):
         return self.model_arch_dict[MODEL_DATA_COLNAME]

--- a/src/ports/postgres/modules/deep_learning/test/keras_model_arch_table.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/keras_model_arch_table.sql_in
@@ -33,8 +33,8 @@ SELECT assert(UPPER(atttypid::regtype::TEXT) = 'INTEGER', 'model_id column shoul
         AND attname = 'model_id';
 SELECT assert(UPPER(atttypid::regtype::TEXT) = 'JSON', 'model_arch column should be JSON type' ) FROM pg_attribute WHERE attrelid = 'test_keras_model_arch_table'::regclass
         AND attname = 'model_arch';
-SELECT assert(UPPER(atttypid::regtype::TEXT) =
-    'DOUBLE PRECISION[]', 'model_weights column should be DOUBLE PRECISION[] type')
+SELECT assert(UPPER(atttypid::regtype::TEXT) = 'BYTEA',
+    'model_weights column should be bytea type')
     FROM pg_attribute WHERE attrelid = 'test_keras_model_arch_table'::regclass
         AND attname = 'model_weights';
 
@@ -84,8 +84,8 @@ SELECT assert(COUNT(model_id) = 0, 'model id 3 should have been deleted!')
        *  It should archrt to the user that the model_id wasn't found but not
        *  raise an exception or change anything. */
 SELECT delete_keras_model('test_keras_model_arch_table', 1);
-SELECT assert(COUNT(relname) = 0, 'Table test_keras_model_arch_table should have been deleted.')
-    FROM pg_class where relname = 'test_keras_model_arch_table';
+SELECT assert(trap_error($$SELECT * from test_keras_model_arch_table$$) = 1,
+              'Table test_keras_model_arch_table should have been deleted.');
 
 SELECT load_keras_model('test_keras_model_arch_table', '{"config" : [1,2,3]}');
 DELETE FROM test_keras_model_arch_table;
@@ -104,6 +104,22 @@ SELECT assert(trap_error($$SELECT delete_keras_model('test_keras_model_arch_tabl
 SELECT assert(trap_error($$SELECT load_keras_model('test_keras_model_arch_table', '{"config" : 1}')$$) = 1, 'Passing an invalid table to load_keras_model() should raise exception.');
 
 /* Test deletion where no table exists */
-DROP TABLE test_keras_model_arch_table;
+DROP TABLE IF EXISTS test_keras_model_arch_table;
 SELECT assert(trap_error($$SELECT delete_keras_model('test_keras_model_arch_table', 3)$$) = 1,
               'Deleting a non-existent table should raise exception.');
+
+DROP TABLE IF EXISTS test_keras_model_arch_table;
+SELECT load_keras_model('test_keras_model_arch_table', '{"config" : [1,2,3]}', 'dummy weights'::bytea);
+SELECT load_keras_model('test_keras_model_arch_table', '{"config" : [1,2,3]}', NULL, 'my name', 'my desc');
+
+/* Test model weights */
+SELECT assert(model_weights = 'dummy weights', 'Incorrect model_weights in the model arch table.')
+FROM test_keras_model_arch_table WHERE model_id = 1;
+SELECT assert(model_weights IS NULL, 'model_weights is not NULL')
+FROM test_keras_model_arch_table WHERE model_id = 2;
+
+/* Test name and description */
+SELECT assert(name IS NULL AND description IS NULL, 'Name or description is not NULL.')
+FROM test_keras_model_arch_table WHERE model_id = 1;
+SELECT assert(name = 'my name' AND description = 'my desc', 'Incorrect name or description in the model arch table.')
+FROM test_keras_model_arch_table WHERE model_id = 2;

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras.sql_in
@@ -758,3 +758,58 @@ SELECT madlib_keras_predict(
     'cifar10_predict',
     'prob',
     0);
+
+
+-- Test for transfer learning
+CREATE OR REPLACE FUNCTION test_load_keras_model() RETURNS VOID AS $$
+from keras.layers import *
+from keras import Sequential
+import numpy as np
+import plpy
+
+model = Sequential()
+model.add(Conv2D(32, kernel_size=(3, 3), activation='relu', input_shape=(32,32,3,)))
+model.add(MaxPooling2D(pool_size=(2, 2)))
+model.add(Dropout(0.25))
+model.add(Flatten())
+model.add(Dense(2, activation='softmax'))
+
+# we don't really need to get the weights from the model and the flatten them since
+# we are using np.ones_like to replace all the weights with 1.
+# We want to keep the flatten code and the concatenation code just for reference
+weights = model.get_weights()
+weights_flat = [ w.flatten() for w in weights ]
+weights1d = np.array([j for sub in weights_flat for j in sub])
+weights1d = np.ones_like(weights1d)
+weights_bytea = weights1d.tostring()
+
+model_config = model.to_json()
+
+plan1 = plpy.prepare(""" SELECT load_keras_model(
+                        'test_keras_model_arch_table',
+                        $1, $2)
+                    """, ['json','bytea'])
+plpy.execute(plan1, [model_config, weights_bytea])
+
+$$ LANGUAGE plpythonu VOLATILE;
+
+DROP TABLE IF EXISTS test_keras_model_arch_table;
+SELECT test_load_keras_model();
+
+DROP TABLE IF EXISTS keras_saved_out, keras_saved_out_summary;
+SELECT madlib_keras_fit(
+    'cifar_10_sample_batched',
+    'keras_saved_out',
+    'test_keras_model_arch_table',
+    1,
+    $$ optimizer=SGD(lr=0.01, decay=1e-6, nesterov=True), loss='categorical_crossentropy', metrics=['accuracy']$$::text,
+    $$ batch_size=2, epochs=1, verbose=0 $$::text,
+    1);
+SELECT training_loss_final FROM keras_saved_out_summary;
+SELECT assert(relative_error(training_loss_final, 8.4056215) < 1e-4,
+           -- TODO use a different metric that does not return 0
+           -- AND relative_error(training_metrics_final, 0.0000001) < 1e-4,
+              'Transfer learning test failed.' )
+FROM keras_saved_out_summary;
+
+DROP FUNCTION test_load_keras_model();


### PR DESCRIPTION
JIRA: MADLIB-1348

This commit add three optional params to the model arch interface to
enable transfer learning
1. model weights in bytea format
2. name
3. description

Additionally
1. Use plpy prepare to format the model weight as bytea.
2. Also had to modify the deserialize code to accept a bytea string
instead of a double precision[]
3. Modified madpack code so that install check user can create python
UDFs
4. Add dev check test to test for transfer learning by creating a UDF
that calls the load_arch_table with some pre defined weights so that the
first iteration of fit always returns the same loss and metric.
5. Rename Format class with a more meaningful name.
