### PR TITLE
Updated the code, state_size was pointing to the wrong value

### DIFF
--- a/src/ports/postgres/modules/convex/mlp_igd.py_in
+++ b/src/ports/postgres/modules/convex/mlp_igd.py_in
@@ -334,7 +334,7 @@ def mlp(schema_madlib, source_table, output_table, independent_varname,
                         """
                 it.update(train_sql)
                 if it_args['state_size'] == -1:
-                    it_args['state_size'] = it.get_state_size()
+                    it.kwargs['state_size'] = it.get_state_size()
 
                 if it.test("""
                         {iteration} >= {n_iterations}

--- a/src/ports/postgres/modules/convex/mlp_igd.py_in
+++ b/src/ports/postgres/modules/convex/mlp_igd.py_in
@@ -333,8 +333,9 @@ def mlp(schema_madlib, source_table, output_table, independent_varname,
                         )
                         """
                 it.update(train_sql)
-                if it_args['state_size'] == -1:
+                if it.kwargs['state_size'] == -1:
                     it.kwargs['state_size'] = it.get_state_size()
+
 
                 if it.test("""
                         {iteration} >= {n_iterations}


### PR DESCRIPTION
JIRA: **MADLIB-1325**

`state_size` was not updating and always has the wrong value ( -1)
Updated the code to point it to the correct value. 

**Description** : 
As per MADLIB-1325, in  `mlp_classification` when a tolerance value if provided and the Loss generated reaches the below the tolerance value, the iteration should stop. But as of now, it doesn't consider the tolerance value and keep running to all the iterations. 

This PR fixes the above issue. As the `state_size` not points to the correct array index. 