### PR TITLE
DL: modify the logic to get number of output units from model_arch table

### DIFF
--- a/src/ports/postgres/modules/utilities/model_arch_info.py_in
+++ b/src/ports/postgres/modules/utilities/model_arch_info.py_in
@@ -42,8 +42,11 @@ def get_input_shape(model_arch):
 
 def get_num_classes(model_arch):
     arch_layers = _get_layers(model_arch)
-    if 'units' in arch_layers[-1]['config']:
-        return arch_layers[-1]['config']['units']
+    i = len(arch_layers) - 1
+    while i >= 0:
+        if 'units' in arch_layers[i]['config']:
+            return arch_layers[i]['config']['units']
+        i -= 1
     plpy.error('Unable to get number of classes from model architecture.')
 
 def get_model_arch_layers_str(model_arch):


### PR DESCRIPTION
Previously, we always assume in model_arch the last layer contains the
num_classes(units), which is not necessarily true. An example can be:

```
...
model.add(Flatten())
model.add(Dense(512))
model.add(Activation('relu'))
model.add(Dropout(0.5))
model.add(Dense(num_classes))
model.add(Activation('softmax'))

```

where activation goes after dense layer and thus we can't get num_class
from the last layer and our get_num_classes will fail to get units. The right way to deal with it
is to assume the last dense layer contains the right num_classes(may
need to validate it), and change the logic in our code to start from the
last layer in model architecture, keep going above until we find the
dense layer with key 'units' inside.

Co-authored-by: Nandish Jayaram <njayaram@apache.org>