### PR TITLE
DL: Add preprocessor specific error message

### DIFF
--- a/src/ports/postgres/modules/deep_learning/input_data_preprocessor.py_in
+++ b/src/ports/postgres/modules/deep_learning/input_data_preprocessor.py_in
@@ -370,7 +370,11 @@ class ValidationDataPreprocessorDL(InputDataPreprocessorDL):
         input_tbl_valid(self.training_preprocessor_table, self.module_name)
         training_summary_table = add_postfix(
             self.training_preprocessor_table, "_summary")
-        input_tbl_valid(training_summary_table, self.module_name)
+        input_tbl_valid(training_summary_table, self.module_name,
+                        error_suffix_str="Please ensure that table '{0}' "
+                                         "has been preprocessed using "
+                                         "training_preprocessor_dl()."
+                                        .format(self.training_preprocessor_table))
         summary_table = plpy.execute("SELECT * FROM {0} LIMIT 1".format(
             training_summary_table))[0]
         _assert(NORMALIZING_CONST_COLNAME in summary_table,

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_validator.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_validator.py_in
@@ -157,7 +157,10 @@ class EvaluateInputValidator(InputValidator):
                                 output_table, module_name)
 
     def _validate_input_args(self):
-        input_tbl_valid(self.test_summary_table, self.module_name)
+        input_tbl_valid(self.test_summary_table, self.module_name,
+                        error_suffix_str="Please ensure that the test table ({0}) "
+                                         "has been preprocessed by "
+                                         "the image preprocessor.".format(self.test_table))
         self._validate_test_summary_tbl_cols()
         InputValidator._validate_input_args(self)
         validate_dependent_var_for_minibatch(self.test_table,
@@ -236,16 +239,18 @@ class FitInputValidator:
     def _validate_input_table(self, table):
         _assert(is_var_valid(table, self.independent_varname),
                 "{module_name}: invalid independent_varname "
-                "('{independent_varname}') for table "
-                "({table}).".format(
+                "('{independent_varname}') for table ({table}). "
+                "Please ensure that the input table ({table}) "
+                "has been preprocessed by the image preprocessor.".format(
                     module_name=self.module_name,
                     independent_varname=self.independent_varname,
                     table=table))
 
         _assert(is_var_valid(table, self.dependent_varname),
                 "{module_name}: invalid dependent_varname "
-                "('{dependent_varname}') for table "
-                "({table}).".format(
+                "('{dependent_varname}') for table ({table}). "
+                "Please ensure that the input table ({table}) "
+                "has been preprocessed by the image preprocessor.".format(
                     module_name=self.module_name,
                     dependent_varname=self.dependent_varname,
                     table=table))
@@ -262,7 +267,10 @@ class FitInputValidator:
             "{0}: metrics_compute_frequency must be in the range (1 - {1}).".format(
                 self.module_name, self.num_iterations))
         input_tbl_valid(self.source_table, self.module_name)
-        input_tbl_valid(self.source_summary_table, self.module_name)
+        input_tbl_valid(self.source_summary_table, self.module_name,
+                        error_suffix_str="Please ensure that the source table ({0}) "
+                                         "has been preprocessed by "
+                                         "the image preprocessor.".format(self.source_table))
         cols_in_tbl_valid(self.source_summary_table, [CLASS_VALUES_COLNAME,
             NORMALIZING_CONST_COLNAME, DEPENDENT_VARTYPE_COLNAME,
             'dependent_varname', 'independent_varname'], self.module_name)

--- a/src/ports/postgres/modules/utilities/test/unit_tests/test_validate_args.py_in
+++ b/src/ports/postgres/modules/utilities/test/unit_tests/test_validate_args.py_in
@@ -100,5 +100,18 @@ class ValidateArgsTestCase(unittest.TestCase):
         self.subject.table_exists = Mock(return_value=False)
         self.subject.output_tbl_valid("foo", "unittest_module")
 
+    def test_input_tbl_valid_table_not_exists_raises_custom_error(self):
+        self.subject.table_exists = Mock(return_value=False)
+        with self.assertRaises(plpy.PLPYException) as error:
+            self.subject.input_tbl_valid("foo", "unittest_module",
+                                         error_suffix_str="custom exception")
+        self.assertIn('custom exception', str(error.exception))
+
+    def test_input_tbl_valid_table_not_exists_raises_custom_error_none(self):
+        self.subject.table_exists = Mock(return_value=False)
+        with self.assertRaises(plpy.PLPYException) as error:
+            self.subject.input_tbl_valid("foo", "unittest_module")
+        self.assertNotIn('custom exception', str(error.exception))
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/ports/postgres/modules/utilities/validate_args.py_in
+++ b/src/ports/postgres/modules/utilities/validate_args.py_in
@@ -662,18 +662,21 @@ def is_var_valid(tbl, var, order_by=None):
 # -------------------------------------------------------------------------
 
 
-def input_tbl_valid(tbl, module, check_empty=True):
+def input_tbl_valid(tbl, module, check_empty=True, error_suffix_str=None):
+    # Add a space in the beginning here instead of at the error message for
+    # backward compatibility.
+    error_suffix_str = ' {0}'.format(error_suffix_str) if error_suffix_str else ''
     if tbl is None or tbl.strip() == '':
-        plpy.error(
-            "{module} error: NULL/empty input table name!".format(**locals()))
+        plpy.error("{0} error: NULL/empty input table name!{1}".format(
+            module, error_suffix_str))
 
     if not table_exists(tbl):
-        plpy.error(
-            "{module} error: Input table '{tbl}' does not exist".format(**locals()))
+        plpy.error("{0} error: Input table '{1}' does not exist.{2}".format(
+            module, tbl, error_suffix_str))
 
     if check_empty and table_is_empty(tbl):
-        plpy.error(
-            "{module} error: Input table '{tbl}' is empty!".format(**locals()))
+        plpy.error("{0} error: Input table '{1}' is empty!{2}".format(
+            module, tbl, error_suffix_str))
 # -------------------------------------------------------------------------
 
 


### PR DESCRIPTION
JIRA: MADLIB-1364

This PR adds specific error messages if user forgets to preprocess source tables.  
In addition to the error messages listed out in the above JIRA, this PR also updates the error message for`validation_preprocessor_dl()`.

Co-authored-by: Nandish Jayaram <njayaram@apache.org>