### PR TITLE
Fix Design Doc

### DIFF
--- a/doc/design/modules/graph.tex
+++ b/doc/design/modules/graph.tex
@@ -125,7 +125,7 @@ negative cycle in the graph.
 
 
 \begin{algorithm}[SSSP$(V,E,start)$] \label{alg:sssp}
-\alginput{Vertex set $v$, edge set $E$, starting vertex $start$}
+\alginput{Vertex set $V$, edge set $E$, starting vertex $start$}
 \algoutput{Distance and parent set for every vertex $cur$}
 \begin{algorithmic}[1]
 	\State $toupdate(0) \set (start,0,start)$
@@ -600,7 +600,8 @@ WHERE newupdate.id = toupdate.id
 Finally, the $message$ table is updated with potential new
 component IDs for active vertices using the following query:
 
-\begin{algorithm}[Update oldupdate table] \label{wcc:message}
+\begin{algorithm}[Update message table$(toupdate, edge)$]
+\label{alg:wcc:message}
 \begin{lstlisting}
 CREATE TEMP TABLE message AS
 SELECT id, MIN(component_id) AS component_id
@@ -631,7 +632,7 @@ potential performance drawback in Greenplum systems. In general, we advise
 that the edge tables should be distributed by their source columns. However,
 in WCC, we use both source and destination columns of the edge table in JOIN
 clauses. In addition, we employ a GROUP BY clause using the column that did
-not serve as the join key. Algorithm~\ref{wcc:message} shows that when $dest$
+not serve as the join key. Algorithm~\ref{alg:wcc:message} shows that when $dest$
 is used for the JOIN clause, $src$ is renamed to $id$ to be used for GROUP BY
 and vice versa. This query forces multiple redistribute motions in the
 database which might cause performance degradation. To address this issue, we


### PR DESCRIPTION
The `\algorithm` macro can optionally have input params specified.  But for some reason, they become mandatory if you want to `\label` the algorithm.

Leaving off the input params from a labelled algorithm block results in pdflatex thinking there is an extra unmatched `}` found, and failing to recover from the confusion.  (At least in the version of pdflatex I have, not sure if this happens in all LaTex environments.)

Changes:

- Add input params to last part of WCC impl.

- Add `alg:` prefix to label, for consistency with rest of doc

- Change name of algorithm from "Update oldupdate table" to
"Update message table" to match rest of text.

- Minor typo correction (uppercase).