### PR TITLE
Update sql.yy for Bison 3

### DIFF
--- a/doc/src/sql.yy
+++ b/doc/src/sql.yy
@@ -16,7 +16,8 @@
  */
 
 /* The %code directive needs bison >= 2.4 */
-%require "2.4"
+/* api.parser.class requires bison >= 3.3 */
+%require "3.3"
 
 %code requires {
     #include <map>
@@ -151,7 +152,7 @@
 };
 
 /* The name of the parser class. */
-%define "parser_class_name" "SQLParser"
+%define api.parser.class {SQLParser}
 
 /* Declare that an argument declared by the braced-code `argument-declaration'
  * is an additional yyparse argument. The `argument-declaration' is used when
@@ -164,7 +165,7 @@
 %lex-param   { SQLDriver *driver }
 
 /* namespace to enclose parser in */
-%name-prefix="bison"
+%define api.prefix {bison}
 
 %union
 {


### PR DESCRIPTION
This line:
```
  %define "parser_class_name" "SQLParser"
```
in `sql.yy` does not compile in Bison 3.x  Putting quotes around the variable
being defined has been deprecated since Bison 2.3b (2008). But it
is no longer supported at all in the current versions of Bison that
you can install with standard package managers.

Removing the double quotes around the variable `parser_class_name`
will allow Bison 3.4 (current version you get by running
`brew install bison`) to compile the madlib docs successfully.

Additionally, even without the quotes, the syntax of this line (as well as another in the same file) has been deprecated in recent Bison versions.   This part doesn't actually generate errors yet, just warnings.  I've updated those in this PR by running `bison --update` on `sql.yy`.  This
will break backward compatibility and require someone to have at least bison 3.3 to compile the madlib docs.  If that's an issue, we can just remove the quotes for now, and postpone the rest until it's actually generating errors.