### PR TITLE
Quick fix for bison issue

### DIFF
--- a/doc/src/sql.yy
+++ b/doc/src/sql.yy
@@ -151,7 +151,7 @@
 };
 
 /* The name of the parser class. */
-%define "parser_class_name" "SQLParser"
+%define parser_class_name "SQLParser"
 
 /* Declare that an argument declared by the braced-code `argument-declaration'
  * is an additional yyparse argument. The `argument-declaration' is used when


### PR DESCRIPTION
This shouldn't break anything for old versions of bison (2.4+),
but will enable current versions of bison to be able to build madlib.

Current versions will still give some deprecation warnings, but no
errors.

(See [reductionista/bison-update](https://github.com/reductionista/madlib/tree/bison-update) branch for more aggressive update that will get
 rid of the warnings, but drops support for pre-3.3)