### PR TITLE
Build: Add cmake variable for gppkg filename

### DIFF
--- a/deploy/gppkg/gppkg_spec.yml.in
+++ b/deploy/gppkg/gppkg_spec.yml.in
@@ -1,6 +1,6 @@
 Pkgname: madlib
 Architecture: @CPACK_RPM_PACKAGE_ARCHITECTURE@
-Version: @MADLIB_VERSION_STRING_NO_HYPHEN@-@GPDB_VARIANT_SHORT@@GPDB_VERSION_LC@
+Version: @MADLIB_VERSION_STRING_NO_HYPHEN@@GPPKG_VER@-@GPDB_VARIANT_SHORT@@GPDB_VERSION_LC@
 OS: rhel@RH_MAJOR_VERSION@
 GPDBVersion: @GPDB_VERSION_LC@
 Description: Madlib is an open source library which provides scalable in-database analytics. It provides data-parallel implementations of mathematical, statistical and machine learning methods for structured and unstructured data.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,10 @@
 
 set(MADLIB_REDIRECT_PREFIX "")
 
+if(NOT GPPKG_VER)
+    set(GPPKG_VER '')
+endif (NOT GPPKG_VER)
+
 # For in-house testing, we might want to change the base URLs of code-hosting
 # sites to something local
 # "-DSOURCEFORGE_BASE_URL=http://test.local/projects"


### PR DESCRIPTION
Currently, the madlib gppkg that gets generated only contains the MADlib
version.  For GPDB6, we want to add a suffix to the MADlib version i.e.
madlib-1.16-gp6-rhel6-x86_64.gppkg will now be madlib-1.16+1-gp6-rhel6-x86_64.gppkg.

If the CMAKE option is passed in as `+build+1`, the gppkg artifact
should be named `madlib-1.17+build+1-gp6-rhel6-x86_64.gppkg`

Co-authored-by: Orhan Kislal <okislal@apache.org>