### PR TITLE
DL Infra: Update jenkins to install keras 2.2.4

### DIFF
--- a/tool/docker/base/Dockerfile_postgres_10_Jenkins
+++ b/tool/docker/base/Dockerfile_postgres_10_Jenkins
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y  wget \
                        build-essential \
                        cmake
 
-RUN pip install tensorflow keras
+RUN pip install tensorflow keras==2.2.4
 
 ## To build an image from this docker file, from madlib folder, run:
 # docker build -t madlib/postgres_10:jenkins -f tool/docker/base/Dockerfile_postgres_10_Jenkins .


### PR DESCRIPTION
With recent jenkins failure for DL module, keras(2.2.5) broke
the api such that the tf module within keras backend is not
available directly by:

```
from keras import backend as K
with K.tf. ....
```

This PR updates the Dockerfile to install keras v2.2.4