### PR TITLE
DL: Update jenkins to install tensorflow 1.14.

### DIFF
--- a/tool/docker/base/Dockerfile_postgres_10_Jenkins
+++ b/tool/docker/base/Dockerfile_postgres_10_Jenkins
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y  wget \
                        build-essential \
                        cmake
 
-RUN pip install tensorflow keras==2.2.4
+RUN pip install tensorflow==1.14 keras==2.2.4
 
 ## To build an image from this docker file, from madlib folder, run:
 # docker build -t madlib/postgres_10:jenkins -f tool/docker/base/Dockerfile_postgres_10_Jenkins .


### PR DESCRIPTION
The latest version of tensorflow (2.0 as of this commit) is not compatible with the version of keras that we install i.e. 2.2.4.

This is the error we get
```
AttributeError: 'module' object has no attribute 'get_default_graph'
```

This commit installs a compatible version of tensorflow i.e. 1.14.