### PR TITLE
DL: Fix miscellaneous bugs

### DIFF
--- a/src/ports/postgres/modules/deep_learning/input_data_preprocessor.py_in
+++ b/src/ports/postgres/modules/deep_learning/input_data_preprocessor.py_in
@@ -272,7 +272,7 @@ class InputDataPreprocessorDL(object):
         self._create_output_summary_table()
 
     def _create_output_summary_table(self):
-        class_level_str='NULL::TEXT'
+        class_level_str='NULL::{0}[]'.format(self.dependent_vartype)
         if self.dependent_levels:
             # Update dependent_levels to include NULL when
             # num_classes > len(self.dependent_levels)
@@ -285,7 +285,7 @@ class InputDataPreprocessorDL(object):
                 self.dependent_levels, array_type=self.dependent_vartype,
                 long_format=True)
         if self.num_classes is None:
-            self.num_classes = 'NULL'
+            self.num_classes = 'NULL::INTEGER'
         query = """
             CREATE TABLE {self.output_summary_table} AS
             SELECT

--- a/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
@@ -626,16 +626,17 @@ def validate_evaluate(module_name, model_table, model_summary_table, test_table,
             NORMALIZING_CONST_COLNAME, DEPENDENT_VARTYPE_COLNAME,
             DEPENDENT_VARNAME_COLNAME, INDEPENDENT_VARNAME_COLNAME], module_name)
 
+    input_tbl_valid(model_table, module_name)
+    if is_mult_model and not columns_exist_in_table(model_table, ['mst_key']):
+        plpy.error("{module_name}: Single model should not pass mst_key".format(**locals()))
+    if not is_mult_model and columns_exist_in_table(model_table, ['mst_key']):
+        plpy.error("{module_name}: Multi-model needs to pass mst_key".format(**locals()))
     InputValidator.validate_predict_evaluate_tables(
         module_name, model_table, model_summary_table,
         test_table, output_table, MINIBATCH_OUTPUT_INDEPENDENT_COLNAME_DL)
     _validate_test_summary_tbl()
     validate_bytea_var_for_minibatch(test_table,
                                      MINIBATCH_OUTPUT_DEPENDENT_COLNAME_DL)
-    if is_mult_model and not columns_exist_in_table(model_table, ['mst_key']):
-        plpy.error("{module_name}: Multi-model needs mst_key".format(**locals()))
-    if not is_mult_model and columns_exist_in_table(model_table, ['mst_key']):
-        plpy.error("{module_name}: Single model should not pass mst_key".format(**locals()))
 
 def get_loss_metric_from_keras_eval(schema_madlib, table, compile_params,
                                     model_arch, serialized_weights, gpus_per_host,

--- a/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
@@ -116,7 +116,7 @@ def fit(schema_madlib, source_table, model, model_arch_table,
     num_classes = get_num_classes(model_arch)
     input_shape = get_input_shape(model_arch)
     fit_validator.validate_input_shapes(input_shape)
-    gp_segment_id_col = '0' if is_platform_pg() else 'gp_segment_id'
+    dist_key_col = '0' if is_platform_pg() else DISTRIBUTION_KEY_COLNAME
 
     serialized_weights = get_initial_weights(model, model_arch, model_weights,
                                              warm_start, gpus_per_host)
@@ -142,7 +142,7 @@ def fit(schema_madlib, source_table, model, model_arch_table,
             $MAD${model_arch}$MAD$::TEXT,
             {compile_params_to_pass}::TEXT,
             {fit_params_to_pass}::TEXT,
-            {gp_segment_id_col},
+            {dist_key_col},
             ARRAY{seg_ids_train},
             ARRAY{images_per_seg_train},
             {gpus_per_host},
@@ -642,7 +642,7 @@ def get_loss_metric_from_keras_eval(schema_madlib, table, compile_params,
                                     segments_per_host, seg_ids, images_per_seg,
                                     is_final_iteration=True):
 
-    gp_segment_id_col = '0' if is_platform_pg() else 'gp_segment_id'
+    dist_key_col = '0' if is_platform_pg() else DISTRIBUTION_KEY_COLNAME
 
     mb_dep_var_col = MINIBATCH_OUTPUT_DEPENDENT_COLNAME_DL
     mb_indep_var_col = MINIBATCH_OUTPUT_INDEPENDENT_COLNAME_DL
@@ -664,7 +664,7 @@ def get_loss_metric_from_keras_eval(schema_madlib, table, compile_params,
                                             $MAD${model_arch}$MAD$,
                                             $1,
                                             {compile_params},
-                                            {gp_segment_id_col},
+                                            {dist_key_col},
                                             ARRAY{seg_ids},
                                             ARRAY{images_per_seg},
                                             {gpus_per_host},

--- a/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
@@ -588,7 +588,7 @@ def evaluate(schema_madlib, model_table, test_table, output_table,
 
     input_shape = get_input_shape(model_arch)
     InputValidator.validate_input_shape(
-        test_table, MINIBATCH_OUTPUT_INDEPENDENT_COLNAME_DL, input_shape, 2)
+        test_table, MINIBATCH_OUTPUT_INDEPENDENT_COLNAME_DL, input_shape, 2, True)
 
     compile_params_query = "SELECT compile_params, metrics_type FROM {0}".format(model_summary_table)
     res = plpy.execute(compile_params_query)[0]

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.py_in
@@ -452,7 +452,7 @@ class FitMultipleModel():
                                                       {self.mst_weights_tbl}.{self.model_arch_col}::TEXT,
                                                       {self.mst_weights_tbl}.{self.compile_params_col}::TEXT,
                                                       {self.mst_weights_tbl}.{self.fit_params_col}::TEXT,
-                                                      src.gp_segment_id,
+                                                      src.{dist_key_col},
                                                       ARRAY{self.seg_ids_train},
                                                       ARRAY{self.images_per_seg_train},
                                                       {self.gpus_per_host},

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.py_in
@@ -333,7 +333,15 @@ class FitMultipleModel():
         independent_varname = \
             src_summary_dict['independent_varname_in_source_table']
         norm_const = src_summary_dict['norm_const']
-        num_classes = len(class_values)
+        self.validation_table = 'NULL' if self.validation_table is None \
+            else '$MAD${0}$MAD$'.format(self.validation_table)
+        if class_values is None:
+            class_values_str = 'NULL::{0}'.format(src_summary_dict['class_values_type'])
+            num_classes = 'NULL'
+        else:
+            class_values_str = 'ARRAY{0}::{1}'.format(class_values,
+                                                      src_summary_dict['class_values_type'])
+            num_classes = len(class_values)
         class_values_colname = CLASS_VALUES_COLNAME
         dependent_vartype_colname = DEPENDENT_VARTYPE_COLNAME
         normalizing_const_colname = NORMALIZING_CONST_COLNAME
@@ -342,7 +350,9 @@ class FitMultipleModel():
                 CREATE TABLE {self.model_summary_table} AS
                 SELECT
                     $MAD${self.source_table}$MAD$::TEXT AS source_table,
-                    $MAD${self.validation_table}$MAD$::TEXT AS validation_table,
+                    {self.validation_table}::TEXT AS validation_table,
+                    $MAD${self.model_output_table}$MAD$::TEXT AS model,
+                    $MAD${self.model_info_table}$MAD$::TEXT AS model_info,
                     $MAD${dependent_varname}$MAD$::TEXT AS dependent_varname,
                     $MAD${independent_varname}$MAD$::TEXT AS independent_varname,
                     $MAD${self.model_arch_table}$MAD$::TEXT AS model_arch_table,
@@ -351,7 +361,7 @@ class FitMultipleModel():
                     '{self.end_training_time}'::TIMESTAMP AS end_training_time,
                     '{self.version}'::TEXT AS madlib_version,
                     {num_classes}::INTEGER AS num_classes,
-                    ARRAY{class_values}::TEXT[] AS {class_values_colname},
+                    {class_values_str} AS {class_values_colname},
                     $MAD${dep_vartype}$MAD$::TEXT AS {dependent_vartype_colname},
                     {norm_const}::{float32_sql_type} AS {normalizing_const_colname}
             """.format(**locals())

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.py_in
@@ -216,7 +216,7 @@ class FitMultipleModel():
 
     def create_mst_schedule_table(self, mst_row):
         mst_temp_query = """
-                         CREATE TEMP TABLE {self.mst_current_schedule_tbl}
+                         CREATE TABLE {self.mst_current_schedule_tbl}
                                 ({self.model_id_col} INTEGER,
                                  {self.compile_params_col} VARCHAR,
                                  {self.fit_params_col} VARCHAR,
@@ -418,8 +418,19 @@ class FitMultipleModel():
                 self.update_info_table(mst, False)
 
     def run_training(self):
+        # NOTE: In the DL module, we want to avoid CREATING TEMP tables
+        # (creates a slice which stays until the session is disconnected)
+        # or minimize writing queries that generate plans with Motions (creating
+        # multiple slices on segments).
+        # This is mainly to avoid any GPU memory allocation failures. Since GPU
+        # memory allocation is tied to the process where it is initialized, failures
+        # may occur when a newly created slice(process) tries allocating GPU memory
+        # which is already allocated by a previously created slice(process).
+        # Therefore we want to have queries that do not add motions and all the
+        # sub-queries running Keras/tensorflow operations reuse the same slice(process)
+        # that was used for initializing GPU memory.
         mst_weights_query = """
-            CREATE TEMP TABLE {self.mst_weights_tbl} AS
+            CREATE TABLE {self.mst_weights_tbl} AS
                 SELECT mst_tbl.*, wgh_tbl.{self.model_weights_col},
                        model_arch_tbl.{self.model_arch_col}
                 FROM

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_helper.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_helper.py_in
@@ -120,7 +120,8 @@ def get_image_count_per_seg_for_minibatched_data_from_db(table_name):
     Query the given minibatch formatted table and return the total rows per segment.
     Since we cannot pass a dictionary to the keras fit step function we create
     arrays out of the segment numbers and the rows per segment values.
-    This function assumes that the table is not empty.
+    This function assumes that the table is not empty and is minibatched which means
+    that it would have been distributed by __dist_key__.
     :param table_name:
     :return: Returns two arrays
     1. An array containing all the segment numbers in ascending order
@@ -141,12 +142,24 @@ def get_image_count_per_seg_for_minibatched_data_from_db(table_name):
         seg_ids = [0]
     else:
         # The number of images in the buffer is the first dimension in the shape.
+        # Using __dist_key__ instead of gp_segment_id: Since gp_segment_id is
+        # not the actual distribution key column, the optimizer/planner
+        # generates a plan with Redistribute Motion, creating multiple slices on
+        # each segment. For DL, since GPU memory allocation is tied to the process
+        # where it is initialized, we want to minimize creating any additional
+        # slices per segment. This is mainly to avoid any GPU memory allocation
+        # failures which can occur when a newly created slice(process) tries
+        # allocating GPU memory which is already allocated by a previously
+        # created slice(process).
+        # Since the minibatch_preprocessor evenly distributes the data with __dist_key__
+        # as the input table's distribution key, using this for calculating
+        # total images on each segment will avoid creating unnecessary slices(processes).
         images_per_seg = plpy.execute(
-            """ SELECT gp_segment_id, sum({0}[1]) AS images_per_seg
-                FROM {1}
-                GROUP BY gp_segment_id
-            """.format(shape_col, table_name))
-        seg_ids = [int(each_segment["gp_segment_id"])
+            """ SELECT {0}, sum({1}[1]) AS images_per_seg
+                FROM {2}
+                GROUP BY {0}
+            """.format(DISTRIBUTION_KEY_COLNAME, shape_col, table_name))
+        seg_ids = [int(each_segment[DISTRIBUTION_KEY_COLNAME])
                    for each_segment in images_per_seg]
         images_per_seg = [int(each_segment["images_per_seg"])
                           for each_segment in images_per_seg]

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_predict.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_predict.py_in
@@ -170,6 +170,11 @@ class Predict(BasePredict):
             plpy.execute("DROP VIEW IF EXISTS {}".format(self.temp_summary_view))
 
     def validate(self):
+        input_tbl_valid(self.model_table, self.module_name)
+        if self.is_mult_model and not columns_exist_in_table(self.model_table, ['mst_key']):
+            plpy.error("{self.module_name}: Single model should not pass mst_key".format(**locals()))
+        if not self.is_mult_model and columns_exist_in_table(self.model_table, ['mst_key']):
+            plpy.error("{self.module_name}: Multi-model needs to pass mst_key".format(**locals()))
         InputValidator.validate_predict_evaluate_tables(
             self.module_name, self.model_table, self.model_summary_table,
             self.test_table, self.output_table, self.independent_varname)

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_validator.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_validator.py_in
@@ -19,29 +19,24 @@
 
 import plpy
 from keras_model_arch_table import ModelArchSchema
-from model_arch_info import get_input_shape, get_num_classes
+from model_arch_info import get_num_classes
 from madlib_keras_helper import CLASS_VALUES_COLNAME
 from madlib_keras_helper import COMPILE_PARAMS_COLNAME
 from madlib_keras_helper import DEPENDENT_VARNAME_COLNAME
 from madlib_keras_helper import DEPENDENT_VARTYPE_COLNAME
-from madlib_keras_helper import INDEPENDENT_VARNAME_COLNAME
 from madlib_keras_helper import MODEL_ARCH_ID_COLNAME
 from madlib_keras_helper import MODEL_ARCH_TABLE_COLNAME
 from madlib_keras_helper import MODEL_WEIGHTS_COLNAME
 from madlib_keras_helper import NORMALIZING_CONST_COLNAME
-from madlib_keras_helper import MINIBATCH_OUTPUT_DEPENDENT_COLNAME_DL
-from madlib_keras_helper import MINIBATCH_OUTPUT_INDEPENDENT_COLNAME_DL
+from madlib_keras_helper import DISTRIBUTION_KEY_COLNAME
 from madlib_keras_helper import METRIC_TYPE_COLNAME
-from madlib_keras_helper import parse_shape
 from madlib_keras_helper import query_model_configs
 
 from utilities.minibatch_validation import validate_bytea_var_for_minibatch
 from utilities.utilities import _assert
 from utilities.utilities import add_postfix
+from utilities.utilities import is_platform_pg
 from utilities.utilities import is_var_valid
-from utilities.utilities import is_valid_psql_type
-from utilities.utilities import NUMERIC
-from utilities.utilities import ONLY_ARRAY
 from utilities.validate_args import cols_in_tbl_valid
 from utilities.validate_args import columns_exist_in_table
 from utilities.validate_args import get_expr_type
@@ -273,6 +268,8 @@ class FitCommonValidator(object):
         cols_in_tbl_valid(self.source_summary_table, [CLASS_VALUES_COLNAME,
             NORMALIZING_CONST_COLNAME, DEPENDENT_VARTYPE_COLNAME,
             'dependent_varname', 'independent_varname'], self.module_name)
+        if not is_platform_pg():
+            cols_in_tbl_valid(self.source_table, [DISTRIBUTION_KEY_COLNAME], self.module_name)
 
         # Source table and validation tables must have the same schema
         self._validate_input_table(self.source_table)

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_validator.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_validator.py_in
@@ -86,7 +86,8 @@ class InputValidator:
                 "either response or prob.".format(module_name, pred_type))
 
     @staticmethod
-    def validate_input_shape(table, independent_varname, input_shape, offset):
+    def validate_input_shape(table, independent_varname, input_shape, offset,
+                             is_minibatched=False):
         """
         Validate if the input shape specified in model architecture is the same
         as the shape of the image specified in the indepedent var of the input
@@ -100,9 +101,8 @@ class InputValidator:
         this case is 1 (start the index at 1).
         """
 
-        ind_shape_col = add_postfix(independent_varname, "_shape")
-        minibatched = is_var_valid(table, ind_shape_col)
-        if minibatched:
+        if is_minibatched:
+            ind_shape_col = add_postfix(independent_varname, "_shape")
             query = """
                 SELECT {ind_shape_col} AS shape
                 FROM {table}
@@ -131,7 +131,7 @@ class InputValidator:
                 len(input_shape), independent_varname, table, len(result)))
 
         for i in range(len(input_shape)):
-            if minibatched:
+            if is_minibatched:
                 key_name = i
                 input_shape_from_table = [result[j]
                     for j in range(len(input_shape))]
@@ -321,6 +321,16 @@ class FitCommonValidator(object):
                     dep_shape_col=self.dep_shape_col,
                     table=table))
 
+        if not is_platform_pg():
+            _assert(is_var_valid(table, DISTRIBUTION_KEY_COLNAME),
+                    "{module_name}: missing distribution key "
+                    "('{dist_key_col}') for table ({table}). "
+                    "Please ensure that the input table ({table}) "
+                    "has been preprocessed by the image preprocessor.".format(
+                        module_name=self.module_name,
+                        dist_key_col=DISTRIBUTION_KEY_COLNAME,
+                        table=table))
+
     def _is_valid_metrics_compute_frequency(self):
         return self.metrics_compute_frequency is None or \
                (self.metrics_compute_frequency >= 1 and \
@@ -340,11 +350,11 @@ class FitCommonValidator(object):
 
     def validate_input_shapes(self, input_shape):
         InputValidator.validate_input_shape(self.source_table, self.independent_varname,
-                               input_shape, 2)
+                               input_shape, 2, True)
         if self.validation_table:
             InputValidator.validate_input_shape(
                 self.validation_table, self.independent_varname,
-                input_shape, 2)
+                input_shape, 2, True)
 
 
 class FitInputValidator(FitCommonValidator):

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_validator.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_validator.py_in
@@ -184,7 +184,6 @@ class InputValidator:
 
     @staticmethod
     def _validate_model_weights_tbl(module_name, model_table):
-        input_tbl_valid(model_table, module_name)
         _assert(is_var_valid(model_table, MODEL_WEIGHTS_COLNAME),
                 "{module_name} error: column '{model_weights}' "
                 "does not exist in model table '{table}'.".format(

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_cifar.setup.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_cifar.setup.sql_in
@@ -36,47 +36,6 @@ DROP TABLE IF EXISTS cifar_10_sample_val, cifar_10_sample_val_summary;
 SELECT validation_preprocessor_dl('cifar_10_sample','cifar_10_sample_val','y','x', 'cifar_10_sample_batched', 1);
 --- NOTE:  In order to test fit_merge, we need at least 2 rows in the batched table (1 on each segment).
 
--- Text class values.
-DROP TABLE IF EXISTS cifar_10_sample_text_batched;
--- Create a new table using the text based column for dep var.
-CREATE TABLE cifar_10_sample_text_batched AS
-    SELECT buffer_id, independent_var, dependent_var,
-    	independent_var_shape, dependent_var_shape
-    FROM cifar_10_sample_batched;
-
--- Insert a new row with NULL as the dependent var (one-hot encoded)
-UPDATE cifar_10_sample_text_batched
-	SET dependent_var = convert_array_to_bytea(ARRAY[0,0,1,0,0]::smallint[]) WHERE buffer_id=0;
-UPDATE cifar_10_sample_text_batched
-	SET dependent_var = convert_array_to_bytea(ARRAY[0,1,0,0,0]::smallint[]) WHERE buffer_id=1;
-INSERT INTO cifar_10_sample_text_batched(buffer_id, independent_var, dependent_var, independent_var_shape, dependent_var_shape)
-    SELECT 2 AS buffer_id, independent_var,
-        convert_array_to_bytea(ARRAY[0,1,0,0,0]::smallint[]) AS dependent_var,
-        independent_var_shape, dependent_var_shape
-    FROM cifar_10_sample_batched WHERE cifar_10_sample_batched.buffer_id=0;
-UPDATE cifar_10_sample_text_batched SET dependent_var_shape = ARRAY[1,5];
-
--- Create the necessary summary table for the batched input.
-DROP TABLE IF EXISTS cifar_10_sample_text_batched_summary;
-CREATE TABLE cifar_10_sample_text_batched_summary(
-    source_table text,
-    output_table text,
-    dependent_varname text,
-    independent_varname text,
-    dependent_vartype text,
-    class_values text[],
-    buffer_size integer,
-    normalizing_const numeric);
-INSERT INTO cifar_10_sample_text_batched_summary values (
-    'cifar_10_sample',
-    'cifar_10_sample_text_batched',
-    'y_text',
-    'x',
-    'text',
-    ARRAY[NULL,'cat','dog',NULL,NULL],
-    1,
-    255.0);
-
 DROP TABLE IF EXISTS cifar_10_sample_int_batched;
 DROP TABLE IF EXISTS cifar_10_sample_int_batched_summary;
 SELECT training_preprocessor_dl('cifar_10_sample','cifar_10_sample_int_batched','y','x', 2, 255, 5);

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_fit.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_fit.sql_in
@@ -24,6 +24,8 @@
              `\1../../modules/deep_learning/test/madlib_keras_cifar.setup.sql_in'
 )
 
+m4_include(`SQLCommon.m4')
+
 -- Please do not break up the compile_params string
 -- It might break the assertion
 DROP TABLE IF EXISTS keras_saved_out, keras_saved_out_summary;
@@ -319,6 +321,48 @@ SELECT assert(trap_error($TRAP$madlib_keras_fit(
 
 -- Tests with text class values:
 -- Modify input data to have text classes, and mini-batch it.
+-- Create a new table using the text based column for dep var.
+DROP TABLE IF EXISTS cifar_10_sample_text_batched;
+m4_changequote(`<!', `!>')
+CREATE TABLE cifar_10_sample_text_batched AS
+    SELECT buffer_id, independent_var, dependent_var,
+      independent_var_shape, dependent_var_shape
+      m4_ifdef(<!__POSTGRESQL__!>, <!!>, <!, __dist_key__ !>)
+    FROM cifar_10_sample_batched m4_ifdef(<!__POSTGRESQL__!>, <!!>, <! DISTRIBUTED BY (__dist_key__) !>);
+
+-- Insert a new row with NULL as the dependent var (one-hot encoded)
+UPDATE cifar_10_sample_text_batched
+	SET dependent_var = convert_array_to_bytea(ARRAY[0,0,1,0,0]::smallint[]) WHERE buffer_id=0;
+UPDATE cifar_10_sample_text_batched
+	SET dependent_var = convert_array_to_bytea(ARRAY[0,1,0,0,0]::smallint[]) WHERE buffer_id=1;
+INSERT INTO cifar_10_sample_text_batched(m4_ifdef(<!__POSTGRESQL__!>, <!!>, <! __dist_key__, !>) buffer_id, independent_var, dependent_var, independent_var_shape, dependent_var_shape)
+    SELECT m4_ifdef(<!__POSTGRESQL__!>, <!!>, <! __dist_key__, !>) 2 AS buffer_id, independent_var,
+        convert_array_to_bytea(ARRAY[0,1,0,0,0]::smallint[]) AS dependent_var,
+        independent_var_shape, dependent_var_shape
+    FROM cifar_10_sample_batched WHERE cifar_10_sample_batched.buffer_id=0;
+UPDATE cifar_10_sample_text_batched SET dependent_var_shape = ARRAY[1,5];
+
+-- Create the necessary summary table for the batched input.
+DROP TABLE IF EXISTS cifar_10_sample_text_batched_summary;
+CREATE TABLE cifar_10_sample_text_batched_summary(
+    source_table text,
+    output_table text,
+    dependent_varname text,
+    independent_varname text,
+    dependent_vartype text,
+    class_values text[],
+    buffer_size integer,
+    normalizing_const numeric);
+INSERT INTO cifar_10_sample_text_batched_summary values (
+    'cifar_10_sample',
+    'cifar_10_sample_text_batched',
+    'y_text',
+    'x',
+    'text',
+    ARRAY[NULL,'cat','dog',NULL,NULL],
+    1,
+    255.0);
+
 DROP TABLE IF EXISTS keras_saved_out, keras_saved_out_summary;
 SELECT madlib_keras_fit(
     'cifar_10_sample_text_batched',

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_iris.setup.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_iris.setup.sql_in
@@ -198,6 +198,22 @@ SELECT training_preprocessor_dl('iris_data_one_hot_encoded',         -- Source t
                                 'attributes'         -- Independent variable
            );
 
+DROP TABLE IF EXISTS iris_data_val, iris_data_val_summary;
+SELECT validation_preprocessor_dl('iris_data',    -- Source table
+                                'iris_data_val',  -- Output table
+                                'class_text',     -- Dependent variable
+                                'attributes',     -- Independent variable
+                                'iris_data_packed'-- Training preprocessed table
+                                );
+
+DROP TABLE IF EXISTS iris_data_one_hot_encoded_val, iris_data_one_hot_encoded_val_summary;
+SELECT validation_preprocessor_dl('iris_data_one_hot_encoded',    -- Source table
+                                'iris_data_one_hot_encoded_val',  -- Output table
+                                'class_one_hot_encoded',        -- Dependent variable
+                                'attributes',         -- Independent variable
+                                'iris_data_one_hot_encoded_packed'    -- Training preprocessed table
+           );
+
 DROP TABLE IF EXISTS iris_model_arch;
 -- NOTE: The seed is set to 0 for every layer.
 SELECT load_keras_model('iris_model_arch',  -- Output table,

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_iris.setup.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_iris.setup.sql_in
@@ -179,12 +179,24 @@ INSERT INTO iris_data(id, attributes, class_text) VALUES
 (149,ARRAY[6.2,3.4,5.4,2.3],'Iris-virginica'),
 (150,ARRAY[5.9,3.0,5.1,1.8],'Iris-virginica');
 
+
+CREATE TABLE iris_data_one_hot_encoded as select id, attributes, ARRAY[class_text is not distinct from 'Iris-setosa', class_text is not distinct from 'Iris-versicolor', class_text is not distinct from 'Iris-virginica']::int[] as class_one_hot_encoded
+from iris_data;
+
+
 DROP TABLE IF EXISTS iris_data_packed, iris_data_packed_summary;
 SELECT training_preprocessor_dl('iris_data',         -- Source table
                                 'iris_data_packed',  -- Output table
                                 'class_text',        -- Dependent variable
                                 'attributes'         -- Independent variable
                                 );
+
+DROP TABLE IF EXISTS iris_data_one_hot_encoded_packed, iris_data_one_hot_encoded_packed_summary;
+SELECT training_preprocessor_dl('iris_data_one_hot_encoded',         -- Source table
+                                'iris_data_one_hot_encoded_packed',  -- Output table
+                                'class_one_hot_encoded',        -- Dependent variable
+                                'attributes'         -- Independent variable
+           );
 
 DROP TABLE IF EXISTS iris_model_arch;
 -- NOTE: The seed is set to 0 for every layer.

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_model_averaging_e2e.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_model_averaging_e2e.sql_in
@@ -1,0 +1,140 @@
+/* ---------------------------------------------------------------------*//**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *//* ---------------------------------------------------------------------*/
+
+m4_include(`SQLCommon.m4')
+
+\i m4_regexp(MODULE_PATHNAME,
+             `\(.*\)libmadlib\.so',
+             `\1../../modules/deep_learning/test/madlib_keras_iris.setup.sql_in'
+)
+
+m4_changequote(`<!', `!>')
+m4_ifdef(<!__POSTGRESQL__!>, <!!>, <!
+-- Multiple models End-to-End test
+DROP TABLE if exists iris_model, iris_model_summary;
+SELECT madlib_keras_fit(
+	'iris_data_packed',
+	'iris_model',
+	'iris_model_arch',
+	1,
+	$$loss='categorical_crossentropy', optimizer='Adam(lr=0.01)', metrics=['accuracy']$$,
+  $$batch_size=16, epochs=1$$,
+	3,
+	0
+);
+
+SELECT assert(
+        model_arch_table = 'iris_model_arch' AND
+        validation_table is NULL AND
+        source_table = 'iris_data_packed' AND
+        model = 'iris_model' AND
+        dependent_varname = 'class_text' AND
+        independent_varname = 'attributes' AND
+        madlib_version is NOT NULL AND
+        num_iterations = 3 AND
+        start_training_time < now() AND
+        end_training_time < now() AND
+        num_classes = 3 AND
+        class_values = '{Iris-setosa,Iris-versicolor,Iris-virginica}' AND
+        dependent_vartype LIKE '%char%' AND
+        normalizing_const = 1,
+        'Keras Fit Multiple Output Summary Validation failed. Actual:' || __to_char(summary))
+FROM (SELECT * FROM iris_model_summary) summary;
+
+-- Run Predict
+DROP TABLE IF EXISTS iris_predict;
+SELECT madlib_keras_predict(
+    'iris_model',
+    'iris_data',
+    'id',
+    'attributes',
+    'iris_predict',
+    'prob',
+    0);
+
+-- Run Evaluate
+DROP TABLE IF EXISTS evaluate_out;
+SELECT madlib_keras_evaluate(
+    'iris_model',
+    'iris_data_val',
+    'evaluate_out',
+    0);
+
+SELECT assert(loss >= 0 AND
+        metric >= 0 AND
+        metrics_type = '{accuracy}', 'Evaluate output validation failed.  Actual:' || __to_char(evaluate_out))
+FROM evaluate_out;
+
+-- Test for one-hot encoded user input data
+DROP TABLE if exists iris_model, iris_model_summary, iris_model_info;
+SELECT madlib_keras_fit(
+	'iris_data_one_hot_encoded_packed',
+	'iris_model',
+	'iris_model_arch',
+	1,
+	$$loss='categorical_crossentropy', optimizer='Adam(lr=0.01)', metrics=['accuracy']$$,
+  $$batch_size=16, epochs=1$$,
+	3,
+	0
+);
+
+SELECT assert(
+        model_arch_table = 'iris_model_arch' AND
+        validation_table is NULL AND
+        source_table = 'iris_data_one_hot_encoded_packed' AND
+        model = 'iris_model' AND
+        dependent_varname = 'class_one_hot_encoded' AND
+        independent_varname = 'attributes' AND
+        madlib_version is NOT NULL AND
+        num_iterations = 3 AND
+        start_training_time < now() AND
+        end_training_time < now() AND
+        dependent_vartype = 'integer[]' AND
+        num_classes = NULL AND
+        class_values = NULL AND
+        normalizing_const = 1,
+        'Keras Fit Multiple Output Summary Validation failed when user passes in 1-hot encoded label vector. Actual:' || __to_char(summary))
+FROM (SELECT * FROM iris_model_summary) summary;
+
+-- Run Predict
+DROP TABLE IF EXISTS iris_predict;
+SELECT madlib_keras_predict(
+    'iris_model',
+    'iris_data_one_hot_encoded',
+    'id',
+    'attributes',
+    'iris_predict',
+    'prob',
+    0);
+
+-- Run Evaluate
+DROP TABLE IF EXISTS evaluate_out;
+SELECT madlib_keras_evaluate(
+    'iris_model',
+    'iris_data_one_hot_encoded_val',
+    'evaluate_out',
+    0);
+
+SELECT assert(loss >= 0 AND
+        metric >= 0 AND
+        metrics_type = '{accuracy}', 'Evaluate output validation failed.  Actual:' || __to_char(evaluate_out))
+FROM evaluate_out;
+!>)

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_model_selection.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_model_selection.sql_in
@@ -180,6 +180,35 @@ SELECT load_model_selection_table(
     ]
 );
 
+-- Test for one-hot encoded input data
+DROP TABLE if exists iris_multiple_model, iris_multiple_model_summary, iris_multiple_model_info;
+SELECT madlib_keras_fit_multiple_model(
+	'iris_data_one_hot_encoded_packed',
+	'iris_multiple_model',
+	'mst_table_4row',
+	3,
+	0
+);
+
+SELECT assert(
+        model_arch_table = 'iris_model_arch' AND
+        validation_table is NULL AND
+        model_info = 'iris_multiple_model_info' AND
+        source_table = 'iris_data_one_hot_encoded_packed' AND
+        model = 'iris_multiple_model' AND
+        dependent_varname = 'class_one_hot_encoded' AND
+        independent_varname = 'attributes' AND
+        madlib_version is NOT NULL AND
+        num_iterations = 3 AND
+        start_training_time < now() AND
+        end_training_time < now() AND
+        dependent_vartype = 'integer[]' AND
+        num_classes = NULL AND
+        class_values = NULL AND
+        normalizing_const = 1,
+        'Keras Fit Multiple Output Summary Validation failed when user passes in 1-hot encoded label vector. Actual:' || __to_char(summary))
+FROM (SELECT * FROM iris_multiple_model_summary) summary;
+
 -- Test when number of configs(3) equals number of segments(3)
 DROP TABLE IF EXISTS iris_multiple_model, iris_multiple_model_summary, iris_multiple_model_info;
 SELECT setseed(0);
@@ -188,18 +217,25 @@ SELECT madlib_keras_fit_multiple_model(
 	'iris_multiple_model',
 	'mst_table',
 	6,
-	0
+	0,
+	'iris_data_one_hot_encoded_packed'
 );
 
 SELECT assert(
-        model_arch_table = 'iris_model_arch' AND
         source_table = 'iris_data_packed' AND
+        validation_table = 'iris_data_one_hot_encoded_packed' AND
+        model = 'iris_multiple_model' AND
+        model_info = 'iris_multiple_model_info' AND
         dependent_varname = 'class_text' AND
         independent_varname = 'attributes' AND
-        madlib_version is NOT NULL AND
+        model_arch_table = 'iris_model_arch' AND
         num_iterations = 6 AND
+        start_training_time < now() AND
+        end_training_time < now() AND
+        madlib_version is NOT NULL AND
         num_classes = 3 AND
         class_values = '{Iris-setosa,Iris-versicolor,Iris-virginica}' AND
+        dependent_vartype LIKE '%char%' AND
         normalizing_const = 1,
         'Keras Fit Multiple Output Summary Validation failed. Actual:' || __to_char(summary))
 FROM (SELECT * FROM iris_multiple_model_summary) summary;
@@ -217,6 +253,10 @@ SELECT assert(
         training_loss_final  >= 0  AND
         array_upper(training_metrics, 1) = 6 AND
         array_upper(training_loss, 1) = 6 AND
+        validation_metrics_final >= 0  AND
+        validation_loss_final  >= 0  AND
+        array_upper(validation_metrics, 1) = 6 AND
+        array_upper(validation_loss, 1) = 6 AND
         array_upper(metrics_elapsed_time, 1) = 6,
         'Keras Fit Multiple Output Info Validation failed. Actual:' || __to_char(info))
 FROM (SELECT * FROM iris_multiple_model_info) info;

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_model_selection_e2e.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_model_selection_e2e.sql_in
@@ -1,0 +1,156 @@
+/* ---------------------------------------------------------------------*//**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *//* ---------------------------------------------------------------------*/
+
+m4_include(`SQLCommon.m4')
+
+\i m4_regexp(MODULE_PATHNAME,
+             `\(.*\)libmadlib\.so',
+             `\1../../modules/deep_learning/test/madlib_keras_iris.setup.sql_in'
+)
+
+m4_changequote(`<!', `!>')
+m4_ifdef(<!__POSTGRESQL__!>, <!!>, <!
+-- Multiple models End-to-End test
+-- Prepare model selection table with four rows
+DROP TABLE IF EXISTS mst_table, mst_table_summary;
+SELECT load_model_selection_table(
+    'iris_model_arch',
+    'mst_table',
+    ARRAY[1],
+    ARRAY[
+        $$loss='categorical_crossentropy', optimizer='Adam(lr=0.01)', metrics=['accuracy']$$,
+        $$loss='categorical_crossentropy', optimizer='Adam(lr=0.001)', metrics=['accuracy']$$,
+        $$loss='categorical_crossentropy', optimizer='Adam(lr=0.0001)', metrics=['accuracy']$$
+    ],
+    ARRAY[
+        $$batch_size=16, epochs=1$$
+    ]
+);
+
+DROP TABLE if exists iris_multiple_model, iris_multiple_model_summary, iris_multiple_model_info;
+SELECT madlib_keras_fit_multiple_model(
+	'iris_data_packed',
+	'iris_multiple_model',
+	'mst_table',
+	3,
+	0
+);
+
+SELECT assert(
+        model_arch_table = 'iris_model_arch' AND
+        validation_table is NULL AND
+        model_info = 'iris_multiple_model_info' AND
+        source_table = 'iris_data_packed' AND
+        model = 'iris_multiple_model' AND
+        dependent_varname = 'class_text' AND
+        independent_varname = 'attributes' AND
+        madlib_version is NOT NULL AND
+        num_iterations = 3 AND
+        start_training_time < now() AND
+        end_training_time < now() AND
+        num_classes = 3 AND
+        class_values = '{Iris-setosa,Iris-versicolor,Iris-virginica}' AND
+        dependent_vartype LIKE '%char%' AND
+        normalizing_const = 1,
+        'Keras Fit Multiple Output Summary Validation failed. Actual:' || __to_char(summary))
+FROM (SELECT * FROM iris_multiple_model_summary) summary;
+
+-- Run Predict
+DROP TABLE IF EXISTS iris_predict;
+SELECT madlib_keras_predict(
+    'iris_multiple_model',
+    'iris_data',
+    'id',
+    'attributes',
+    'iris_predict',
+    'prob',
+    NULL,
+    1);
+
+-- Run Evaluate
+DROP TABLE IF EXISTS evaluate_out;
+SELECT madlib_keras_evaluate(
+    'iris_multiple_model',
+    'iris_data_val',
+    'evaluate_out',
+    NULL,
+    1);
+
+SELECT assert(loss >= 0 AND
+        metric >= 0 AND
+        metrics_type = '{accuracy}', 'Evaluate output validation failed.  Actual:' || __to_char(evaluate_out))
+FROM evaluate_out;
+
+-- Test for one-hot encoded user input data
+DROP TABLE if exists iris_multiple_model, iris_multiple_model_summary, iris_multiple_model_info;
+SELECT madlib_keras_fit_multiple_model(
+	'iris_data_one_hot_encoded_packed',
+	'iris_multiple_model',
+	'mst_table',
+	3,
+	0
+);
+
+SELECT assert(
+        model_arch_table = 'iris_model_arch' AND
+        validation_table is NULL AND
+        model_info = 'iris_multiple_model_info' AND
+        source_table = 'iris_data_one_hot_encoded_packed' AND
+        model = 'iris_multiple_model' AND
+        dependent_varname = 'class_one_hot_encoded' AND
+        independent_varname = 'attributes' AND
+        madlib_version is NOT NULL AND
+        num_iterations = 3 AND
+        start_training_time < now() AND
+        end_training_time < now() AND
+        dependent_vartype = 'integer[]' AND
+        num_classes = NULL AND
+        class_values = NULL AND
+        normalizing_const = 1,
+        'Keras Fit Multiple Output Summary Validation failed when user passes in 1-hot encoded label vector. Actual:' || __to_char(summary))
+FROM (SELECT * FROM iris_multiple_model_summary) summary;
+
+-- Run Predict
+DROP TABLE IF EXISTS iris_predict;
+SELECT madlib_keras_predict(
+    'iris_multiple_model',
+    'iris_data_one_hot_encoded',
+    'id',
+    'attributes',
+    'iris_predict',
+    'prob',
+    NULL,
+    1);
+
+-- Run Evaluate
+DROP TABLE IF EXISTS evaluate_out;
+SELECT madlib_keras_evaluate(
+    'iris_multiple_model',
+    'iris_data_one_hot_encoded_val',
+    'evaluate_out',
+    NULL,
+    1);
+
+SELECT assert(loss >= 0 AND
+        metric >= 0 AND
+        metrics_type = '{accuracy}', 'Evaluate output validation failed.  Actual:' || __to_char(evaluate_out))
+FROM evaluate_out;
+!>)

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_predict.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_predict.sql_in
@@ -119,6 +119,49 @@ FROM pg_attribute
 WHERE attrelid='cifar10_predict'::regclass AND attnum>0;
 
 -- Tests with text class values:
+-- Create a new table using the text based column for dep var.
+DROP TABLE IF EXISTS cifar_10_sample_text_batched;
+m4_changequote(`<!', `!>')
+CREATE TABLE cifar_10_sample_text_batched AS
+    SELECT buffer_id, independent_var, dependent_var,
+      independent_var_shape, dependent_var_shape
+      m4_ifdef(<!__POSTGRESQL__!>, <!!>, <!, __dist_key__ !>)
+    FROM cifar_10_sample_batched m4_ifdef(<!__POSTGRESQL__!>, <!!>, <!DISTRIBUTED BY (__dist_key__)!>);
+
+-- Insert a new row with NULL as the dependent var (one-hot encoded)
+UPDATE cifar_10_sample_text_batched
+	SET dependent_var = convert_array_to_bytea(ARRAY[0,0,1,0,0]::smallint[]) WHERE buffer_id=0;
+UPDATE cifar_10_sample_text_batched
+	SET dependent_var = convert_array_to_bytea(ARRAY[0,1,0,0,0]::smallint[]) WHERE buffer_id=1;
+INSERT INTO cifar_10_sample_text_batched(m4_ifdef(<!__POSTGRESQL__!>, <!!>, <! __dist_key__, !>) buffer_id, independent_var, dependent_var, independent_var_shape, dependent_var_shape)
+    SELECT m4_ifdef(<!__POSTGRESQL__!>, <!!>, <! __dist_key__, !>) 2 AS buffer_id, independent_var,
+        convert_array_to_bytea(ARRAY[0,1,0,0,0]::smallint[]) AS dependent_var,
+        independent_var_shape, dependent_var_shape
+    FROM cifar_10_sample_batched WHERE cifar_10_sample_batched.buffer_id=0;
+UPDATE cifar_10_sample_text_batched SET dependent_var_shape = ARRAY[1,5];
+m4_changequote(<!`!>,<!'!>)
+
+-- Create the necessary summary table for the batched input.
+DROP TABLE IF EXISTS cifar_10_sample_text_batched_summary;
+CREATE TABLE cifar_10_sample_text_batched_summary(
+    source_table text,
+    output_table text,
+    dependent_varname text,
+    independent_varname text,
+    dependent_vartype text,
+    class_values text[],
+    buffer_size integer,
+    normalizing_const numeric);
+INSERT INTO cifar_10_sample_text_batched_summary values (
+    'cifar_10_sample',
+    'cifar_10_sample_text_batched',
+    'y_text',
+    'x',
+    'text',
+    ARRAY[NULL,'cat','dog',NULL,NULL],
+    1,
+    255.0);
+
 DROP TABLE IF EXISTS keras_saved_out, keras_saved_out_summary;
 SELECT madlib_keras_fit(
     'cifar_10_sample_text_batched',
@@ -376,5 +419,4 @@ FROM iris_multiple_model_info i,
      ON iris_train.id=iris_predict.id)q
      WHERE q.actual=q.estimated) q2
 WHERE i.mst_key = 2;
-
 !>)

--- a/src/ports/postgres/modules/deep_learning/test/unit_tests/test_madlib_keras.py_in
+++ b/src/ports/postgres/modules/deep_learning/test/unit_tests/test_madlib_keras.py_in
@@ -1122,24 +1122,28 @@ class InputValidatorTestCase(unittest.TestCase):
             self.module_name, None, 'response', self.model.to_json())
 
     def test_validate_input_shape_shapes_do_not_match(self):
-        self.plpy_mock_execute.return_value = [{'shape':[1,32,32]}]
-        with self.assertRaises(plpy.PLPYException):
-            self.subject.validate_input_shape(
-                self.test_table, self.ind_var, [32,32,3], 2)
-
+        # minibatched data
         self.plpy_mock_execute.return_value = [{'shape': [1,3,32,32]}]
         with self.assertRaises(plpy.PLPYException):
             self.subject.validate_input_shape(
-                self.test_table, self.ind_var, [32,32,3], 2)
-
-        self.plpy_mock_execute.return_value = [{'shape': [1,3]}]
+                self.test_table, self.ind_var, [32,32,3], 2, True)
+        # non-minibatched data
+        self.plpy_mock_execute.return_value = [{'n_0': 1,'n_1': 32,'n_2': 32,'n_3': 3}]
         with self.assertRaises(plpy.PLPYException):
             self.subject.validate_input_shape(
-                self.test_table, self.ind_var, [3,32], 2)
+                self.test_table, self.ind_var, [32,32,3], 1)
+        self.plpy_mock_execute.return_value = [{'n_0': 1,'n_1': 3}]
+        with self.assertRaises(plpy.PLPYException):
+            self.subject.validate_input_shape(
+                self.test_table, self.ind_var, [3,32], 1)
 
     def test_validate_input_shape_shapes_match(self):
-        self.subject.is_var_valid = Mock(return_value = False)
+        # minibatched data
         self.plpy_mock_execute.return_value = [{'shape': [1,32,32,3]}]
+        self.subject.validate_input_shape(
+            self.test_table, self.ind_var, [32,32,3], 2, True)
+        # non-minibatched data
+        self.plpy_mock_execute.return_value = [{'n_0': 32,'n_1': 32,'n_2': 3}]
         self.subject.validate_input_shape(
             self.test_table, self.ind_var, [32,32,3], 1)
 

--- a/src/ports/postgres/modules/utilities/minibatch_validation.py_in
+++ b/src/ports/postgres/modules/utilities/minibatch_validation.py_in
@@ -46,4 +46,5 @@ def validate_bytea_var_for_minibatch(table_name, var_name, expr_type=None):
         expr_type = get_expr_type(var_name, table_name)
     _assert(expr_type == 'bytea',
             "Dependent variable column {0} in table {1} "
-            "should be a bytea.".format(var_name, table_name))
+            "should be minibatched. You might need to re run "
+            "the preprocessor function.".format(var_name, table_name))


### PR DESCRIPTION
This PR fixes the following issues:
1. Fix crash in `madlib_keras_fit_multiple_model()` for user inputed one-hot encoded data(y)
2. Avoid GPU memory issues caused due to long lasting processes left from queries creating TEMP tables.
3. Avoid creating unnecessary multiple slices (which might lead to GPU memory issues) using distribution_key instead of gp_segment_id
4. Fix `madlib_keras_predict()` not to display the following warning: 
     ```
    WARNING:  column "attributes_shape" does not exist
   CONTEXT:  PL/Python function "madlib_keras_predict"
   madlib_keras_predict
   ----------------------
     ```
5. Add E2E test for `madlib_keras_fit()` and `madlib_keras_fit_multiple_model()`.

Note: Some tests in `madlib_keras_model_selection_e2e.sql_in` can be uncommented once PR #451 is merged

- [x] Add the module name, JIRA# to PR/commit and description.
- [x] Add tests for the change. 

