### PR TITLE
DL: Add new helper function for gpu_configuration

### DIFF
--- a/doc/mainpage.dox.in
+++ b/doc/mainpage.dox.in
@@ -290,6 +290,7 @@ Interface and implementation are subject to change.
     @brief A collection of modules for deep learning.
     @details A collection of modules for deep learning.
     @{
+        @defgroup grp_gpu_configuration GPU Configuration
         @defgroup grp_keras Keras
         @defgroup grp_keras_model_arch Load Model
         @defgroup grp_input_preprocessor_dl Preprocessor for Images

--- a/src/ports/postgres/modules/deep_learning/gpu_info_from_tf.py_in
+++ b/src/ports/postgres/modules/deep_learning/gpu_info_from_tf.py_in
@@ -1,0 +1,39 @@
+# coding=utf-8
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+@file gpu_info_from_tf.py_in
+
+@brief This file prints out the gpu descriptions using tensorflow API. This file
+is intended to be called using subprocess. See madlib_keras_gpu_info.py_in
+for more details.
+"""
+
+from tensorflow.python.client import device_lib
+from keras import backend as K
+
+config = K.tf.ConfigProto()
+config.gpu_options.allow_growth = True
+sess = K.tf.Session(config=config)
+local_device_protos = device_lib.list_local_devices()
+K.clear_session()
+sess.close()
+if local_device_protos:
+    for x in local_device_protos:
+        if x.device_type == 'GPU':
+            print x.physical_device_desc

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.py_in
@@ -1,0 +1,203 @@
+# coding=utf-8
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+@file madlib_keras_gpu_info.py_in
+
+@brief GPU configuration helper function
+
+@namespace madlib_keras_gpu_info
+"""
+
+import plpy
+from utilities.utilities import is_platform_pg
+from utilities.utilities import unique_string
+import subprocess
+import os
+
+class OutputInfoSchema:
+    INFO_TABLE = unique_string(desp='gpu_info')
+    SEG_ID_COL = 'gp_seg_id'
+    GPU_DESCR_COL = 'gpu_descr'
+
+
+class Source:
+    NVIDIA = 'nvidia'
+    TENSORFLOW = 'tensorflow'
+
+
+class GPUInfoFunctions:
+    @staticmethod
+    def get_gpu_info_from_nvidia():
+        """
+        This function will run only on segment(s). Make sure not to run any non
+        select plpy execute.
+        :return: list of gpu descriptions as returned by nvidia-smi -L.
+        """
+        try:
+            return subprocess.check_output(["nvidia-smi", "-L"]).splitlines()
+        except OSError:  # Handle case when nvidia-smi is not found
+            return []
+        except Exception as ex:  # Raise exception for all other cases
+            plpy.error("Running nvidia-smi failed with exception {0}".format(str(ex)))
+
+    @staticmethod
+    def get_gpu_info_from_tensorflow():
+        """
+        This function will run only on segment(s). Make sure not to run any non
+        select plpy execute.
+        :return: list of gpu descriptions as returned by tensorflow
+        """
+        current_working_dir = os.path.dirname(os.path.realpath(__file__))
+        gpus = subprocess.check_output(["python", "gpu_info_from_tf.py"],
+                                       cwd=current_working_dir).splitlines()
+        return gpus
+
+
+def gpu_configuration(schema_madlib, source):
+    """
+    :return: List of gpus along with their hostname in the format
+        gpu_descr         |       hostname
+        ------------------+--------------------------
+        NVIDIA Tesla P100 | pm-demo-machine-keras1
+        NVIDIA Tesla P100 | pm-demo-machine-keras1
+        Super Duper GPU   | pm-demo-machine-keras2
+        Super Duper GPU   | pm-demo-machine-keras2
+    1. We use gp_dist_random to run either the nvidia smi UDF or the tensorflow UDF
+        on all the hosts.
+    2. Also we do not need to run the tf/nvidia UDF on all the segments, just
+        one segment per host. That's why we group the output of
+        gp_segment_configuration by hostname and get the min segment from each host.
+    3. To get the hostname along with the gpu description, we have to join the
+        output of nvidia/tf UDF with gp_segment_configuration and filter out the
+        following
+        * master
+        * mirror segments
+        * empty/null gpu description
+    Workflow for gpdb
+    1. Run query to get min seg ids on each host. This is so that we can run
+    the gpu UDF on just one segment per host.
+    2. Create a table by running the tf/nvidia UDF on the segment ids returned
+    from the previous step. Note that this table will only contain the output
+    of the UDF and the segment id itself. This table does not contain hostnames
+    3. To get the hostname associated with the segment id, we need to join the
+    table created in step with gp_segment_configuration.
+    It's important to note that we can merge all these 3 queries into one but
+    the problem with that is that a redistribution happens before running the UDF
+    which means the UDF does not run on the segments that we pass in to the query.
+    To avoid this, we broke down the query into 3 parts so that the UDF is always
+    run on the intended segments.
+    """
+    if not source:
+        source = Source.TENSORFLOW
+    source = source.lower()
+    if source != Source.TENSORFLOW and source != Source.NVIDIA:
+        plpy.error("DL: source has to be one of {0} or {1}".format(
+            Source.TENSORFLOW, Source.NVIDIA))
+
+    gpu_fn_name = 'gpu_info_{0}'.format(source)
+    if is_platform_pg():
+        return gpu_for_postgres(schema_madlib, gpu_fn_name)
+    else:
+        return gpu_for_gpdb(schema_madlib, gpu_fn_name)
+
+
+def gpu_for_postgres(schema_madlib, gpu_fn_name):
+    gpu_info_query = """
+     SELECT 'localhost' as hostname, {0} from (SELECT unnest({1}.{2}()) AS {0}) s1
+     where {0} is NOT NULL AND {0} != ''
+        """.format(OutputInfoSchema.GPU_DESCR_COL, schema_madlib, gpu_fn_name)
+    gpus = plpy.execute(gpu_info_query)
+    if not gpus or len(gpus) == 0:
+        return []
+    return gpus
+
+
+def gpu_for_gpdb(schema_madlib, gpu_fn_name):
+    min_seg_on_each_host = get_min_seg_ids_on_each_host()
+    create_gpu_info_table(schema_madlib, gpu_fn_name, min_seg_on_each_host)
+    gpus_per_host = get_gpu_info_with_hostname()
+
+    plpy.execute("DROP TABLE IF EXISTS {0}".format(OutputInfoSchema.INFO_TABLE))
+
+    if not gpus_per_host or len(gpus_per_host) == 0:
+        return []
+    return gpus_per_host
+
+
+def get_min_seg_ids_on_each_host():
+    """
+    Run query to get min seg ids on each host. This is so that we can run
+    the gpu UDF on just one segment per host.
+    :return: List of min seg id per host
+    """
+    min_seg_id_alias = 'min_seg_id'
+    min_seg_query = """
+    SELECT {min_seg_id_alias} FROM 
+    (select hostname, min(content) AS {min_seg_id_alias} 
+    FROM gp_segment_configuration WHERE content != -1 AND role='p' 
+    GROUP BY hostname) min_seg_id_subquery
+    """.format(**locals())
+    min_seg_on_each_host = plpy.execute(min_seg_query)
+    if not min_seg_on_each_host:
+        plpy.error('TBD')
+
+    min_seg_on_each_host = ','.join([str(seg[min_seg_id_alias])
+                                     for seg in min_seg_on_each_host])
+    return min_seg_on_each_host
+
+
+def create_gpu_info_table(schema_madlib, gpu_fn_name, min_seg_on_each_host):
+    """
+    Create a table by running the tf/nvidia UDF on the segment ids returned
+    from the previous step. Note that this table will only contain the output
+    of the UDF and the segment id itself. This table does not contain hostnames
+    :param schema_madlib:
+    :param gpu_fn_name:
+    :param min_seg_on_each_host:
+    """
+    gpu_info_per_host_query = """
+    CREATE TEMP TABLE {0} AS SELECT gp_segment_id AS {1}, {2}.{3}()
+    AS {4} FROM gp_dist_random('gp_id') WHERE gp_segment_id IN ({5})
+    """.format(OutputInfoSchema.INFO_TABLE,
+               OutputInfoSchema.SEG_ID_COL,
+               schema_madlib, gpu_fn_name,
+               OutputInfoSchema.GPU_DESCR_COL,
+               min_seg_on_each_host)
+    plpy.execute(gpu_info_per_host_query)
+
+
+def get_gpu_info_with_hostname():
+    """
+    To get the hostname associated with the segment id, we need to join the
+    table created in step with gp_segment_configuration.
+    :return: List of gpus and their associated hostname
+    """
+    final_join_query = """
+    SELECT hostname, {0} FROM
+    (
+    SELECT hostname, unnest({0}) AS {0} FROM {1}
+    JOIN
+    gp_segment_configuration ON {2}=content WHERE content != -1 AND role='p'
+    ) s1
+    WHERE {0} != '' AND {0} is NOT NULL ORDER BY 1,2;
+    """.format(OutputInfoSchema.GPU_DESCR_COL,
+               OutputInfoSchema.INFO_TABLE,
+               OutputInfoSchema.SEG_ID_COL)
+    gpus_per_host = plpy.execute(final_join_query)
+    return gpus_per_host

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.py_in
@@ -53,10 +53,8 @@ class GPUInfoFunctions:
         """
         try:
             return subprocess.check_output(["nvidia-smi", "-L"]).splitlines()
-        except OSError:  # Handle case when nvidia-smi is not found
+        except Exception:  # Handle case when nvidia-smi -L fails
             return []
-        except Exception as ex:  # Raise exception for all other cases
-            plpy.error("Running nvidia-smi failed with exception {0}".format(str(ex)))
 
     @staticmethod
     def get_gpu_info_from_tensorflow():

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.py_in
@@ -210,3 +210,49 @@ def create_gpu_info_table_with_hostname(output_table):
                OutputInfoSchema.TEMP_INFO_TABLE,
                OutputInfoSchema.SEG_ID_COL)
     plpy.execute(final_join_query)
+
+
+def gpu_configuration_help(schema_madlib):
+    """
+        Help function for gpu configuration
+
+        Args:
+            @param schema_madlib
+
+        Returns:
+            String. Help/usage information
+        """
+
+    help_string = """
+    Utility function to report number and type of GPUs on the database cluster.
+    -----------------------------------------------------------------------
+                                USAGE
+    -----------------------------------------------------------------------
+     SELECT {schema_madlib}.gpu_configuration(
+        output_table,            -- Name of the output table to write out the 
+                                    GPU information.  
+        source                   -- Default: 'tensorflow'. Source for determining
+                                    GPU configuration.
+                                    Using 'tensorflow' returns a description based
+                                    on what TensorFlow reports.
+                                    Using 'nvidia' returns a description based 
+                                    on what the Nvidia Systems Management Interface
+                                    (nvidia-smi) reports [1].  
+                                    Note that MADlib and Keras will use the TensorFlow
+                                    information; the lower level nvidia-smi info 
+                                    is provided for convenience.
+        )
+    );
+
+    -----------------------------------------------------------------------
+                                OUTPUT
+    -----------------------------------------------------------------------
+    The output table ('output_table' above) contains the following columns:
+
+    hostname:   Name of the host machine in the cluster.
+                Does not include master or mirrors.  For PostgreSQL this will
+                always return 'localhost'.
+    gpu_descr:  String reported by TensorFlow or nvidia-smi.
+    """
+
+    return help_string.format(schema_madlib=schema_madlib)

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.py_in
@@ -162,8 +162,6 @@ def get_min_seg_ids_on_each_host():
     GROUP BY hostname) min_seg_id_subquery
     """.format(**locals())
     min_seg_on_each_host = plpy.execute(min_seg_query)
-    if not min_seg_on_each_host:
-        plpy.error('TBD')
 
     min_seg_on_each_host = ','.join([str(seg[min_seg_id_alias])
                                      for seg in min_seg_on_each_host])

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.py_in
@@ -179,7 +179,7 @@ def create_gpu_info_table_without_hostname(schema_madlib, gpu_fn_name,
     :param min_seg_on_each_host:
     """
     gpu_info_per_host_query = """
-    CREATE TEMP TABLE {0} AS SELECT gp_segment_id AS {1}, {2}.{3}()
+    CREATE TABLE {0} AS SELECT gp_segment_id AS {1}, {2}.{3}()
     AS {4} FROM gp_dist_random('gp_id') WHERE gp_segment_id IN ({5})
     """.format(OutputInfoSchema.TEMP_INFO_TABLE,
                OutputInfoSchema.SEG_ID_COL,

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.py_in
@@ -24,14 +24,16 @@
 @namespace madlib_keras_gpu_info
 """
 
+import os
+import subprocess
+
 import plpy
 from utilities.utilities import is_platform_pg
 from utilities.utilities import unique_string
-import subprocess
-import os
+from utilities.validate_args import output_tbl_valid
 
 class OutputInfoSchema:
-    INFO_TABLE = unique_string(desp='gpu_info')
+    TEMP_INFO_TABLE = unique_string(desp='gpu_info')
     SEG_ID_COL = 'gp_seg_id'
     GPU_DESCR_COL = 'gpu_descr'
 
@@ -69,40 +71,50 @@ class GPUInfoFunctions:
         return gpus
 
 
-def gpu_configuration(schema_madlib, source):
+def gpu_configuration(schema_madlib, output_table, source):
     """
     :return: List of gpus along with their hostname in the format
+        GPDB
         gpu_descr         |       hostname
         ------------------+--------------------------
-        NVIDIA Tesla P100 | pm-demo-machine-keras1
-        NVIDIA Tesla P100 | pm-demo-machine-keras1
-        Super Duper GPU   | pm-demo-machine-keras2
-        Super Duper GPU   | pm-demo-machine-keras2
-    1. We use gp_dist_random to run either the nvidia smi UDF or the tensorflow UDF
-        on all the hosts.
-    2. Also we do not need to run the tf/nvidia UDF on all the segments, just
-        one segment per host. That's why we group the output of
-        gp_segment_configuration by hostname and get the min segment from each host.
-    3. To get the hostname along with the gpu description, we have to join the
-        output of nvidia/tf UDF with gp_segment_configuration and filter out the
-        following
-        * master
-        * mirror segments
-        * empty/null gpu description
-    Workflow for gpdb
-    1. Run query to get min seg ids on each host. This is so that we can run
-    the gpu UDF on just one segment per host.
-    2. Create a table by running the tf/nvidia UDF on the segment ids returned
-    from the previous step. Note that this table will only contain the output
-    of the UDF and the segment id itself. This table does not contain hostnames
-    3. To get the hostname associated with the segment id, we need to join the
-    table created in step with gp_segment_configuration.
-    It's important to note that we can merge all these 3 queries into one but
-    the problem with that is that a redistribution happens before running the UDF
-    which means the UDF does not run on the segments that we pass in to the query.
-    To avoid this, we broke down the query into 3 parts so that the UDF is always
-    run on the intended segments.
+        NVIDIA Tesla P100 | host1
+        NVIDIA Tesla P100 | host1
+        Super Duper GPU   | host2
+        Super Duper GPU   | host2
+        1. We use gp_dist_random to run either the nvidia smi UDF or the tensorflow UDF
+            on all the hosts. (see gpu_info_nvidia/gpu_info_tensorflow)
+        2. Also we do not need to run the tf/nvidia UDF on all the segments,
+            just one segment per host. That's why we group the output of
+            gp_segment_configuration by hostname and get the min segment from
+            each host.
+        3. To get the hostname along with the gpu description, we have to join
+            the output of nvidia/tf UDF with gp_segment_configuration and filter
+            out the following
+            * master
+            * mirror segments
+            * empty/null gpu description
+        Workflow for gpdb
+        1. Run query to get min seg ids on each host. This is so that we can run
+        the gpu UDF on just one segment per host.
+        2. Create a table by running the tf/nvidia UDF on the segment ids returned
+        from the previous step. Note that this table will only contain the output
+        of the UDF and the segment id itself. This table does not contain hostnames
+        3. To get the hostname associated with the segment id, we need to join the
+        table created in step with gp_segment_configuration.
+        It's important to note that we can merge all these 3 queries into one but
+        the problem with that is that a redistribution happens before running the UDF
+        which means the UDF does not run on the segments that we pass in to the query.
+        To avoid this, we broke down the query into 3 parts so that the UDF is always
+        run on the intended segments.
+
+        POSTGRES
+        gpu_descr         |       hostname
+        ------------------+--------------------------
+        NVIDIA Tesla P100 | localhost
     """
+    module_name = 'madlib_keras_gpu_info'
+    output_tbl_valid(output_table, module_name)
+
     if not source:
         source = Source.TENSORFLOW
     source = source.lower()
@@ -112,32 +124,30 @@ def gpu_configuration(schema_madlib, source):
 
     gpu_fn_name = 'gpu_info_{0}'.format(source)
     if is_platform_pg():
-        return gpu_for_postgres(schema_madlib, gpu_fn_name)
+        gpu_for_postgres(schema_madlib, output_table, gpu_fn_name)
     else:
-        return gpu_for_gpdb(schema_madlib, gpu_fn_name)
+        gpu_for_gpdb(schema_madlib, output_table, gpu_fn_name)
 
 
-def gpu_for_postgres(schema_madlib, gpu_fn_name):
+def gpu_for_postgres(schema_madlib, output_table, gpu_fn_name):
     gpu_info_query = """
-     SELECT 'localhost' as hostname, {0} from (SELECT unnest({1}.{2}()) AS {0}) s1
-     where {0} is NOT NULL AND {0} != ''
-        """.format(OutputInfoSchema.GPU_DESCR_COL, schema_madlib, gpu_fn_name)
-    gpus = plpy.execute(gpu_info_query)
-    if not gpus or len(gpus) == 0:
-        return []
-    return gpus
+    CREATE TABLE {0} AS
+    SELECT 'localhost' as hostname, {1} from (SELECT unnest({2}.{3}()) AS {1}) s1
+    where {1} is NOT NULL AND {1} != ''
+        """.format(output_table, OutputInfoSchema.GPU_DESCR_COL,
+                   schema_madlib, gpu_fn_name)
+    plpy.execute(gpu_info_query)
 
 
-def gpu_for_gpdb(schema_madlib, gpu_fn_name):
+def gpu_for_gpdb(schema_madlib, output_table, gpu_fn_name):
     min_seg_on_each_host = get_min_seg_ids_on_each_host()
-    create_gpu_info_table(schema_madlib, gpu_fn_name, min_seg_on_each_host)
-    gpus_per_host = get_gpu_info_with_hostname()
 
-    plpy.execute("DROP TABLE IF EXISTS {0}".format(OutputInfoSchema.INFO_TABLE))
+    create_gpu_info_table_without_hostname(schema_madlib, gpu_fn_name,
+                                           min_seg_on_each_host)
 
-    if not gpus_per_host or len(gpus_per_host) == 0:
-        return []
-    return gpus_per_host
+    create_gpu_info_table_with_hostname(output_table)
+
+    plpy.execute("DROP TABLE IF EXISTS {0}".format(OutputInfoSchema.TEMP_INFO_TABLE))
 
 
 def get_min_seg_ids_on_each_host():
@@ -162,8 +172,9 @@ def get_min_seg_ids_on_each_host():
     return min_seg_on_each_host
 
 
-def create_gpu_info_table(schema_madlib, gpu_fn_name, min_seg_on_each_host):
-    """
+def create_gpu_info_table_without_hostname(schema_madlib, gpu_fn_name,
+                                           min_seg_on_each_host):
+    """ output_table,
     Create a table by running the tf/nvidia UDF on the segment ids returned
     from the previous step. Note that this table will only contain the output
     of the UDF and the segment id itself. This table does not contain hostnames
@@ -174,7 +185,7 @@ def create_gpu_info_table(schema_madlib, gpu_fn_name, min_seg_on_each_host):
     gpu_info_per_host_query = """
     CREATE TEMP TABLE {0} AS SELECT gp_segment_id AS {1}, {2}.{3}()
     AS {4} FROM gp_dist_random('gp_id') WHERE gp_segment_id IN ({5})
-    """.format(OutputInfoSchema.INFO_TABLE,
+    """.format(OutputInfoSchema.TEMP_INFO_TABLE,
                OutputInfoSchema.SEG_ID_COL,
                schema_madlib, gpu_fn_name,
                OutputInfoSchema.GPU_DESCR_COL,
@@ -182,22 +193,22 @@ def create_gpu_info_table(schema_madlib, gpu_fn_name, min_seg_on_each_host):
     plpy.execute(gpu_info_per_host_query)
 
 
-def get_gpu_info_with_hostname():
+def create_gpu_info_table_with_hostname(output_table):
     """
-    To get the hostname associated with the segment id, we need to join the
-    table created in step with gp_segment_configuration.
-    :return: List of gpus and their associated hostname
+    Create the final output table that contains the hostname and the gpu description.
+    To create this table, we need to join the table created in
+    create_gpu_info_table_without_hostname with gp_segment_configuration.
     """
     final_join_query = """
-    SELECT hostname, {0} FROM
+    CREATE TABLE {0} AS
+    SELECT hostname, {1} FROM
     (
-    SELECT hostname, unnest({0}) AS {0} FROM {1}
+    SELECT hostname, unnest({1}) AS {1} FROM {2}
     JOIN
-    gp_segment_configuration ON {2}=content WHERE content != -1 AND role='p'
+    gp_segment_configuration ON {3}=content WHERE content != -1 AND role='p'
     ) s1
-    WHERE {0} != '' AND {0} is NOT NULL ORDER BY 1,2;
-    """.format(OutputInfoSchema.GPU_DESCR_COL,
-               OutputInfoSchema.INFO_TABLE,
+    WHERE {1} != '' AND {1} is NOT NULL ORDER BY 1,2;
+    """.format(output_table, OutputInfoSchema.GPU_DESCR_COL,
+               OutputInfoSchema.TEMP_INFO_TABLE,
                OutputInfoSchema.SEG_ID_COL)
-    gpus_per_host = plpy.execute(final_join_query)
-    return gpus_per_host
+    plpy.execute(final_join_query)

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.sql_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.sql_in
@@ -1,0 +1,66 @@
+/* ----------------------------------------------------------------------- *//**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *
+ * @file madlib_keras_gpu_info.sql_in
+ *
+ * @brief SQL functions for GPU configuration.
+ * @date Nov 2019
+ *
+ *
+ *//* ----------------------------------------------------------------------- */
+
+m4_include(`SQLCommon.m4')
+
+DROP TYPE IF EXISTS MADLIB_SCHEMA.gpu_info CASCADE;
+CREATE TYPE MADLIB_SCHEMA.gpu_info as(
+hostname TEXT,
+gpu_descr TEXT);
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.gpu_info_tensorflow() RETURNS TEXT[] as
+$$
+    PythonFunctionBodyOnlyNoSchema(`deep_learning', `madlib_keras_gpu_info')
+    return madlib_keras_gpu_info.GPUInfoFunctions.get_gpu_info_from_tensorflow()
+$$ LANGUAGE plpythonu IMMUTABLE
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `NO SQL', `');
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.gpu_info_nvidia() RETURNS TEXT[] as
+$$
+    PythonFunctionBodyOnlyNoSchema(`deep_learning', `madlib_keras_gpu_info')
+    return madlib_keras_gpu_info.GPUInfoFunctions.get_gpu_info_from_nvidia()
+$$ LANGUAGE plpythonu IMMUTABLE
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `NO SQL', `');
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.gpu_configuration(source text)
+RETURNS SETOF MADLIB_SCHEMA.gpu_info AS
+$$
+    PythonFunctionBodyOnly(`deep_learning', `madlib_keras_gpu_info')
+    from utilities.control import MinWarning
+    with AOControl(False) and MinWarning("error"):
+        return madlib_keras_gpu_info.gpu_configuration(schema_madlib, source)
+$$
+LANGUAGE plpythonu
+m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `NO SQL', `');
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.gpu_configuration()
+RETURNS SETOF MADLIB_SCHEMA.gpu_info AS
+$$
+    SELECT MADLIB_SCHEMA.gpu_configuration(NULL);
+$$
+LANGUAGE sql;

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.sql_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.sql_in
@@ -28,6 +28,204 @@
 
 m4_include(`SQLCommon.m4')
 
+/**
+@addtogroup grp_gpu_configuration
+
+@brief Utility function to report number and type of GPUs on the database cluster.
+
+\warning <em> This MADlib method is still in early stage development.
+Interface and implementation are subject to change. </em>
+
+<div class="toc"><b>Contents</b><ul>
+<li class="level1"><a href="#get_gpu_config">GPU Configuration</a></li>
+<li class="level1"><a href="#example">Examples</a></li>
+<li class="level1"><a href="#references">References</a></li>
+<li class="level1"><a href="#related">Related Topics</a></li>
+</ul></div>
+
+This utility function reports the number and type of GPUs
+attached to hosts on the database cluster.
+This can be useful when determining which segments to use for
+training deep neural nets.  For example, for economic reasons
+you may wish to set up a heterogeneous clusters with GPUs only
+on some of the hosts, not all of them. This utility
+can help you identify where the GPUS are and direct the compute
+to those locations only in subsequent training and evaluation steps.
+
+@anchor get_gpu_config
+@par GPU Confuguration
+
+<pre class="syntax">
+gpu_configuration(
+	source
+	)
+</pre>
+\b Arguments
+<dl class="arglist">
+  <dt>source (optional)</dt>
+  <dd>TEXT, default: 'tensorflow'. Source for determining GPU configuration.
+  Using 'tensorflow' returns a description based on what TensorFlow reports.
+  Using 'nvidia' returns a description based on what the Nvidia Systems
+  Management Interface (nvidia-smi) reports [1].  Note that MADlib and Keras will use the
+  TensorFlow information; the lower level nvidia-smi info is provided for convenience.
+  </dd>
+</dl>
+
+<b>Output</b>
+<br>
+    The output contains the following:
+    <table class="output">
+      <tr>
+        <th>hostname</th>
+        <td>TEXT. Name of the host machine in the cluster.
+        Does not include master or mirrors.  For PostgreSQL
+        this will always return 'localhost'.
+        </td>
+      </tr>
+      <tr>
+        <th>gpu_info</th>
+        <td>TEXT. String reported by TensorFlow or nvidia-smi.
+        The formats are different and shown in the examples below.
+        </td>
+      </tr>
+    </table>
+</br>
+
+
+@anchor example
+@par Examples
+
+-# Get GPU configuration as per TensorFlow:
+<pre class="example">
+SELECT * FROM madlib.gpu_configuration();
+</pre>
+<pre class="result">
+ hostname |                                        gpu_descr
+----------+------------------------------------------------------------------------------------------
+ phoenix0 | device: 0, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:04.0, compute capability: 6.0
+ phoenix0 | device: 1, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:05.0, compute capability: 6.0
+ phoenix0 | device: 2, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:06.0, compute capability: 6.0
+ phoenix0 | device: 3, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:07.0, compute capability: 6.0
+ phoenix1 | device: 0, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:04.0, compute capability: 6.0
+ phoenix1 | device: 1, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:05.0, compute capability: 6.0
+ phoenix1 | device: 2, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:06.0, compute capability: 6.0
+ phoenix1 | device: 3, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:07.0, compute capability: 6.0
+ phoenix2 | device: 0, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:04.0, compute capability: 6.0
+ phoenix2 | device: 1, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:05.0, compute capability: 6.0
+ phoenix2 | device: 2, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:06.0, compute capability: 6.0
+ phoenix2 | device: 3, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:07.0, compute capability: 6.0
+ phoenix3 | device: 0, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:04.0, compute capability: 6.0
+ phoenix3 | device: 1, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:05.0, compute capability: 6.0
+ phoenix3 | device: 2, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:06.0, compute capability: 6.0
+ phoenix3 | device: 3, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:07.0, compute capability: 6.0
+ phoenix4 | device: 0, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:04.0, compute capability: 6.0
+ phoenix4 | device: 1, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:05.0, compute capability: 6.0
+ phoenix4 | device: 2, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:06.0, compute capability: 6.0
+ phoenix4 | device: 3, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:07.0, compute capability: 6.0
+(20 rows)
+</pre>
+
+-# Get GPU configuration as per nvidia-smi:
+<pre class="example">
+SELECT * FROM madlib.gpu_configuration('nvidia');
+</pre>
+<pre class="result">
+ hostname |                                  gpu_descr
+----------+------------------------------------------------------------------------------
+ phoenix0 | GPU 0: Tesla P100-PCIE-16GB (UUID: GPU-120672ff-0527-6340-14c1-ac6400103a69)
+ phoenix0 | GPU 1: Tesla P100-PCIE-16GB (UUID: GPU-063a5803-a4cb-44b3-818e-b72886b75a7f)
+ phoenix0 | GPU 2: Tesla P100-PCIE-16GB (UUID: GPU-a44f8948-f944-ddb9-ea90-e28bc14c176a)
+ phoenix0 | GPU 3: Tesla P100-PCIE-16GB (UUID: GPU-11aebd04-b7fe-0a13-b18f-52e41c901956)
+ phoenix1 | GPU 0: Tesla P100-PCIE-16GB (UUID: GPU-120672ff-0527-6340-14c1-ac6400103a69)
+ phoenix1 | GPU 1: Tesla P100-PCIE-16GB (UUID: GPU-063a5803-a4cb-44b3-818e-b72886b75a7f)
+ phoenix1 | GPU 2: Tesla P100-PCIE-16GB (UUID: GPU-a44f8948-f944-ddb9-ea90-e28bc14c176a)
+ phoenix1 | GPU 3: Tesla P100-PCIE-16GB (UUID: GPU-11aebd04-b7fe-0a13-b18f-52e41c901956)
+ phoenix2 | GPU 0: Tesla P100-PCIE-16GB (UUID: GPU-120672ff-0527-6340-14c1-ac6400103a69)
+ phoenix2 | GPU 1: Tesla P100-PCIE-16GB (UUID: GPU-063a5803-a4cb-44b3-818e-b72886b75a7f)
+ phoenix2 | GPU 2: Tesla P100-PCIE-16GB (UUID: GPU-a44f8948-f944-ddb9-ea90-e28bc14c176a)
+ phoenix2 | GPU 3: Tesla P100-PCIE-16GB (UUID: GPU-11aebd04-b7fe-0a13-b18f-52e41c901956)
+ phoenix3 | GPU 0: Tesla P100-PCIE-16GB (UUID: GPU-120672ff-0527-6340-14c1-ac6400103a69)
+ phoenix3 | GPU 1: Tesla P100-PCIE-16GB (UUID: GPU-063a5803-a4cb-44b3-818e-b72886b75a7f)
+ phoenix3 | GPU 2: Tesla P100-PCIE-16GB (UUID: GPU-a44f8948-f944-ddb9-ea90-e28bc14c176a)
+ phoenix3 | GPU 3: Tesla P100-PCIE-16GB (UUID: GPU-11aebd04-b7fe-0a13-b18f-52e41c901956)
+ phoenix4 | GPU 0: Tesla P100-PCIE-16GB (UUID: GPU-120672ff-0527-6340-14c1-ac6400103a69)
+ phoenix4 | GPU 1: Tesla P100-PCIE-16GB (UUID: GPU-063a5803-a4cb-44b3-818e-b72886b75a7f)
+ phoenix4 | GPU 2: Tesla P100-PCIE-16GB (UUID: GPU-a44f8948-f944-ddb9-ea90-e28bc14c176a)
+ phoenix4 | GPU 3: Tesla P100-PCIE-16GB (UUID: GPU-11aebd04-b7fe-0a13-b18f-52e41c901956)
+(20 rows)
+</pre>
+
+-# To get a fuller picture, combine with Greenplum catalog
+table gp_segment_configuration which contains information about
+segment instance configuration [2].  Here is an example of this table
+filtering out master and mirrors:
+<pre class="example">
+SELECT * FROM gp_segment_configuration WHERE role='p' AND content>=0 ORDER BY hostname, dbid;
+</pre>
+<pre class="result">
+ dbid | content | role | preferred_role | mode | status | port  | hostname | address  | replication_port
+------+---------+------+----------------+------+--------+-------+----------+----------+------------------
+    2 |       0 | p    | p              | c    | u      | 40000 | phoenix0 | phoenix0 |            70000
+    3 |       1 | p    | p              | c    | u      | 40001 | phoenix0 | phoenix0 |            70001
+    4 |       2 | p    | p              | c    | u      | 40002 | phoenix0 | phoenix0 |            70002
+    5 |       3 | p    | p              | c    | u      | 40003 | phoenix0 | phoenix0 |            70003
+    6 |       4 | p    | p              | c    | u      | 40000 | phoenix1 | phoenix1 |            70000
+    7 |       5 | p    | p              | c    | u      | 40001 | phoenix1 | phoenix1 |            70001
+    8 |       6 | p    | p              | c    | u      | 40002 | phoenix1 | phoenix1 |            70002
+    9 |       7 | p    | p              | c    | u      | 40003 | phoenix1 | phoenix1 |            70003
+   10 |       8 | p    | p              | c    | u      | 40000 | phoenix2 | phoenix2 |            70000
+   11 |       9 | p    | p              | c    | u      | 40001 | phoenix2 | phoenix2 |            70001
+   12 |      10 | p    | p              | c    | u      | 40002 | phoenix2 | phoenix2 |            70002
+   13 |      11 | p    | p              | c    | u      | 40003 | phoenix2 | phoenix2 |            70003
+   14 |      12 | p    | p              | c    | u      | 40000 | phoenix3 | phoenix3 |            70000
+   15 |      13 | p    | p              | c    | u      | 40001 | phoenix3 | phoenix3 |            70001
+   16 |      14 | p    | p              | c    | u      | 40002 | phoenix3 | phoenix3 |            70002
+   17 |      15 | p    | p              | c    | u      | 40003 | phoenix3 | phoenix3 |            70003
+   18 |      16 | p    | p              | c    | u      | 40000 | phoenix4 | phoenix4 |            70000
+   19 |      17 | p    | p              | c    | u      | 40001 | phoenix4 | phoenix4 |            70001
+   20 |      18 | p    | p              | c    | u      | 40002 | phoenix4 | phoenix4 |            70002
+   21 |      19 | p    | p              | c    | u      | 40003 | phoenix4 | phoenix4 |            70003
+(20 rows)
+</pre>
+To create a table showing segments with all available
+GPU resources:
+<pre class="example">
+TBD
+</pre>
+<pre class="result">
+TBD
+</pre>
+To create a table showing segments with a certain type of
+GPU resource:
+<pre class="example">
+TBD
+</pre>
+<pre class="result">
+TBD
+</pre>
+To create a table limiting the number of segments
+on hosts with GPU resource:
+<pre class="example">
+TBD
+</pre>
+<pre class="result">
+TBD
+</pre>
+
+@anchor references
+@par References
+
+[1] Nvidia Systems Management Interface (nvidia-smi) https://developer.nvidia.com/nvidia-system-management-interface
+
+[2] Greenplum 'gp_segment_configuration' table https://gpdb.docs.pivotal.io/latest/ref_guide/system_catalogs/gp_segment_configuration.html
+
+@anchor related
+@par Related Topics
+
+See madlib_keras_gpu_info.sql_in
+
+*/
+
 DROP TYPE IF EXISTS MADLIB_SCHEMA.gpu_info CASCADE;
 CREATE TYPE MADLIB_SCHEMA.gpu_info as(
 hostname TEXT,

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.sql_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.sql_in
@@ -269,3 +269,11 @@ $$
     SELECT MADLIB_SCHEMA.gpu_configuration($1, NULL);
 $$
 LANGUAGE sql;
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.gpu_configuration()
+    RETURNS VARCHAR AS $$
+    PythonFunctionBodyOnly(`deep_learning', `madlib_keras_gpu_info')
+    return madlib_keras_gpu_info.gpu_configuration_help(schema_madlib)
+$$ LANGUAGE plpythonu IMMUTABLE
+    m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `CONTAINS SQL', `');

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.sql_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.sql_in
@@ -226,11 +226,6 @@ See madlib_keras_gpu_info.sql_in
 
 */
 
-DROP TYPE IF EXISTS MADLIB_SCHEMA.gpu_info CASCADE;
-CREATE TYPE MADLIB_SCHEMA.gpu_info as(
-hostname TEXT,
-gpu_descr TEXT);
-
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.gpu_info_tensorflow() RETURNS TEXT[] as
 $$
     PythonFunctionBodyOnlyNoSchema(`deep_learning', `madlib_keras_gpu_info')
@@ -245,20 +240,20 @@ $$
 $$ LANGUAGE plpythonu IMMUTABLE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `NO SQL', `');
 
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.gpu_configuration(source text)
-RETURNS SETOF MADLIB_SCHEMA.gpu_info AS
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.gpu_configuration(output_table text, source text)
+RETURNS VOID AS
 $$
     PythonFunctionBodyOnly(`deep_learning', `madlib_keras_gpu_info')
     from utilities.control import MinWarning
     with AOControl(False) and MinWarning("error"):
-        return madlib_keras_gpu_info.gpu_configuration(schema_madlib, source)
+        madlib_keras_gpu_info.gpu_configuration(schema_madlib, output_table, source)
 $$
 LANGUAGE plpythonu
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `NO SQL', `');
 
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.gpu_configuration()
-RETURNS SETOF MADLIB_SCHEMA.gpu_info AS
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.gpu_configuration(output_table text)
+RETURNS VOID AS
 $$
-    SELECT MADLIB_SCHEMA.gpu_configuration(NULL);
+    SELECT MADLIB_SCHEMA.gpu_configuration($1, NULL);
 $$
 LANGUAGE sql;

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.sql_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.sql_in
@@ -230,14 +230,14 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.gpu_info_tensorflow() RETURNS TEXT[] as
 $$
     PythonFunctionBodyOnlyNoSchema(`deep_learning', `madlib_keras_gpu_info')
     return madlib_keras_gpu_info.GPUInfoFunctions.get_gpu_info_from_tensorflow()
-$$ LANGUAGE plpythonu IMMUTABLE
+$$ LANGUAGE plpythonu
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `NO SQL', `');
 
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.gpu_info_nvidia() RETURNS TEXT[] as
 $$
     PythonFunctionBodyOnlyNoSchema(`deep_learning', `madlib_keras_gpu_info')
     return madlib_keras_gpu_info.GPUInfoFunctions.get_gpu_info_from_nvidia()
-$$ LANGUAGE plpythonu IMMUTABLE
+$$ LANGUAGE plpythonu
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `NO SQL', `');
 
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.gpu_configuration(output_table text, source text)

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.sql_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_gpu_info.sql_in
@@ -56,24 +56,35 @@ to those locations only in subsequent training and evaluation steps.
 @par GPU Confuguration
 
 <pre class="syntax">
-gpu_configuration(
-	source
-	)
+gpu_configuration( output_table,
+                   source
+	               )
 </pre>
 \b Arguments
 <dl class="arglist">
+  <dt>output_table</dt>
+  <dd>TEXT. Name of the output table to write out the GPU information.
+  </dd>
+
   <dt>source (optional)</dt>
   <dd>TEXT, default: 'tensorflow'. Source for determining GPU configuration.
   Using 'tensorflow' returns a description based on what TensorFlow reports.
   Using 'nvidia' returns a description based on what the Nvidia Systems
   Management Interface (nvidia-smi) reports [1].  Note that MADlib and Keras will use the
   TensorFlow information; the lower level nvidia-smi info is provided for convenience.
+
+  @note
+  If the command 'nvidia-smi -L' returns an error, we do not pass through
+  the error message, but instead will show no GPUs for that host in the output table.
+  You may want to run nvidia-smi from the command line to see error
+  and informational messages.
+
   </dd>
 </dl>
 
 <b>Output</b>
 <br>
-    The output contains the following:
+    The output table contains the following:
     <table class="output">
       <tr>
         <th>hostname</th>
@@ -83,7 +94,7 @@ gpu_configuration(
         </td>
       </tr>
       <tr>
-        <th>gpu_info</th>
+        <th>gpu_descr</th>
         <td>TEXT. String reported by TensorFlow or nvidia-smi.
         The formats are different and shown in the examples below.
         </td>
@@ -91,13 +102,14 @@ gpu_configuration(
     </table>
 </br>
 
-
 @anchor example
 @par Examples
 
 -# Get GPU configuration as per TensorFlow:
 <pre class="example">
-SELECT * FROM madlib.gpu_configuration();
+DROP TABLE IF EXISTS host_gpu_mapping_tf;
+SELECT * FROM madlib.gpu_configuration('host_gpu_mapping_tf');
+SELECT * FROM host_gpu_mapping_tf ORDER BY hostname, gpu_descr;
 </pre>
 <pre class="result">
  hostname |                                        gpu_descr
@@ -108,12 +120,6 @@ SELECT * FROM madlib.gpu_configuration();
  phoenix0 | device: 3, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:07.0, compute capability: 6.0
  phoenix1 | device: 0, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:04.0, compute capability: 6.0
  phoenix1 | device: 1, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:05.0, compute capability: 6.0
- phoenix1 | device: 2, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:06.0, compute capability: 6.0
- phoenix1 | device: 3, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:07.0, compute capability: 6.0
- phoenix2 | device: 0, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:04.0, compute capability: 6.0
- phoenix2 | device: 1, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:05.0, compute capability: 6.0
- phoenix2 | device: 2, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:06.0, compute capability: 6.0
- phoenix2 | device: 3, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:07.0, compute capability: 6.0
  phoenix3 | device: 0, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:04.0, compute capability: 6.0
  phoenix3 | device: 1, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:05.0, compute capability: 6.0
  phoenix3 | device: 2, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:06.0, compute capability: 6.0
@@ -122,41 +128,41 @@ SELECT * FROM madlib.gpu_configuration();
  phoenix4 | device: 1, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:05.0, compute capability: 6.0
  phoenix4 | device: 2, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:06.0, compute capability: 6.0
  phoenix4 | device: 3, name: Tesla P100-PCIE-16GB, pci bus id: 0000:00:07.0, compute capability: 6.0
-(20 rows)
+(14 rows)
 </pre>
+In this heterogeneous cluster there are 4 GPUs attached to hosts 0, 3 and 4.  There are 2 GPUs
+attached to host 1 and no GPUs attached to host 2.
 
 -# Get GPU configuration as per nvidia-smi:
 <pre class="example">
-SELECT * FROM madlib.gpu_configuration('nvidia');
+DROP TABLE IF EXISTS host_gpu_mapping_nvidia;
+SELECT * FROM madlib.gpu_configuration('host_gpu_mapping_nvidia', -- output table
+                                       'nvidia'                   -- source for GPU info
+                                       );
+SELECT * FROM host_gpu_mapping_nvidia ORDER BY hostname, gpu_descr;
 </pre>
 <pre class="result">
  hostname |                                  gpu_descr
 ----------+------------------------------------------------------------------------------
- phoenix0 | GPU 0: Tesla P100-PCIE-16GB (UUID: GPU-120672ff-0527-6340-14c1-ac6400103a69)
- phoenix0 | GPU 1: Tesla P100-PCIE-16GB (UUID: GPU-063a5803-a4cb-44b3-818e-b72886b75a7f)
- phoenix0 | GPU 2: Tesla P100-PCIE-16GB (UUID: GPU-a44f8948-f944-ddb9-ea90-e28bc14c176a)
- phoenix0 | GPU 3: Tesla P100-PCIE-16GB (UUID: GPU-11aebd04-b7fe-0a13-b18f-52e41c901956)
- phoenix1 | GPU 0: Tesla P100-PCIE-16GB (UUID: GPU-120672ff-0527-6340-14c1-ac6400103a69)
- phoenix1 | GPU 1: Tesla P100-PCIE-16GB (UUID: GPU-063a5803-a4cb-44b3-818e-b72886b75a7f)
- phoenix1 | GPU 2: Tesla P100-PCIE-16GB (UUID: GPU-a44f8948-f944-ddb9-ea90-e28bc14c176a)
- phoenix1 | GPU 3: Tesla P100-PCIE-16GB (UUID: GPU-11aebd04-b7fe-0a13-b18f-52e41c901956)
- phoenix2 | GPU 0: Tesla P100-PCIE-16GB (UUID: GPU-120672ff-0527-6340-14c1-ac6400103a69)
- phoenix2 | GPU 1: Tesla P100-PCIE-16GB (UUID: GPU-063a5803-a4cb-44b3-818e-b72886b75a7f)
- phoenix2 | GPU 2: Tesla P100-PCIE-16GB (UUID: GPU-a44f8948-f944-ddb9-ea90-e28bc14c176a)
- phoenix2 | GPU 3: Tesla P100-PCIE-16GB (UUID: GPU-11aebd04-b7fe-0a13-b18f-52e41c901956)
- phoenix3 | GPU 0: Tesla P100-PCIE-16GB (UUID: GPU-120672ff-0527-6340-14c1-ac6400103a69)
- phoenix3 | GPU 1: Tesla P100-PCIE-16GB (UUID: GPU-063a5803-a4cb-44b3-818e-b72886b75a7f)
- phoenix3 | GPU 2: Tesla P100-PCIE-16GB (UUID: GPU-a44f8948-f944-ddb9-ea90-e28bc14c176a)
- phoenix3 | GPU 3: Tesla P100-PCIE-16GB (UUID: GPU-11aebd04-b7fe-0a13-b18f-52e41c901956)
- phoenix4 | GPU 0: Tesla P100-PCIE-16GB (UUID: GPU-120672ff-0527-6340-14c1-ac6400103a69)
- phoenix4 | GPU 1: Tesla P100-PCIE-16GB (UUID: GPU-063a5803-a4cb-44b3-818e-b72886b75a7f)
- phoenix4 | GPU 2: Tesla P100-PCIE-16GB (UUID: GPU-a44f8948-f944-ddb9-ea90-e28bc14c176a)
- phoenix4 | GPU 3: Tesla P100-PCIE-16GB (UUID: GPU-11aebd04-b7fe-0a13-b18f-52e41c901956)
-(20 rows)
+ phoenix0 | GPU 0: Tesla P100-PCIE-16GB (UUID: GPU-f2ccc77e-2501-f6ee-4754-069dda256fb2)
+ phoenix0 | GPU 1: Tesla P100-PCIE-16GB (UUID: GPU-b1fc40ca-c7c6-bc86-f20f-6e9a62cda3f8)
+ phoenix0 | GPU 2: Tesla P100-PCIE-16GB (UUID: GPU-d93bb21b-96f9-7c1d-3bab-cdd92b7bbc9d)
+ phoenix0 | GPU 3: Tesla P100-PCIE-16GB (UUID: GPU-2d79c4a8-479e-2f33-39f8-3ba80b63f830)
+ phoenix1 | GPU 0: Tesla P100-PCIE-16GB (UUID: GPU-0af6bb1e-5b5b-4988-ad3a-a917e9584702)
+ phoenix1 | GPU 1: Tesla P100-PCIE-16GB (UUID: GPU-d824c976-a8aa-ef26-a13c-9a9a7fe86bfd)
+ phoenix3 | GPU 0: Tesla P100-PCIE-16GB (UUID: GPU-3681d0b6-1ec6-0453-fd81-29d88e549cd9)
+ phoenix3 | GPU 1: Tesla P100-PCIE-16GB (UUID: GPU-d4b1f2e7-b238-ac9a-bbfe-918adeb69472)
+ phoenix3 | GPU 2: Tesla P100-PCIE-16GB (UUID: GPU-42a32ef1-a60c-e599-c8cf-0e669111ab6f)
+ phoenix3 | GPU 3: Tesla P100-PCIE-16GB (UUID: GPU-1cce09c4-6856-8031-be0b-8e8bbf9a10f3)
+ phoenix4 | GPU 0: Tesla P100-PCIE-16GB (UUID: GPU-a71bdc18-fdd5-ba25-617e-19b23cc8e827)
+ phoenix4 | GPU 1: Tesla P100-PCIE-16GB (UUID: GPU-f9d13688-7fe6-a029-24d1-985a5659f18f)
+ phoenix4 | GPU 2: Tesla P100-PCIE-16GB (UUID: GPU-06a7f54b-c07a-e87a-20d6-09bd99b19531)
+ phoenix4 | GPU 3: Tesla P100-PCIE-16GB (UUID: GPU-af3b32f3-8bd9-cb75-a8fb-25253b9da926)
+(14 rows)
 </pre>
 
--# To get a fuller picture, combine with Greenplum catalog
-table gp_segment_configuration which contains information about
+-# To get a fuller picture at the segment level, combine with the Greenplum catalog
+table 'gp_segment_configuration' which contains information about
 segment instance configuration [2].  Here is an example of this table
 filtering out master and mirrors:
 <pre class="example">
@@ -187,29 +193,35 @@ SELECT * FROM gp_segment_configuration WHERE role='p' AND content>=0 ORDER BY ho
    21 |      19 | p    | p              | c    | u      | 40003 | phoenix4 | phoenix4 |            70003
 (20 rows)
 </pre>
-To create a table showing segments with all available
-GPU resources:
+Now join this table with the GPU resources table to create a table containing a
+list of all segments on hosts with GPUs attached:
 <pre class="example">
-TBD
+DROP TABLE IF EXISTS segments_to_use;
+CREATE TABLE segments_to_use AS
+  SELECT DISTINCT dbid, hostname FROM gp_segment_configuration JOIN host_gpu_mapping_tf USING (hostname)
+  WHERE role='p' AND content>=0;
+SELECT * FROM segments_to_use ORDER BY hostname, dbid;
 </pre>
 <pre class="result">
-TBD
-</pre>
-To create a table showing segments with a certain type of
-GPU resource:
-<pre class="example">
-TBD
-</pre>
-<pre class="result">
-TBD
-</pre>
-To create a table limiting the number of segments
-on hosts with GPU resource:
-<pre class="example">
-TBD
-</pre>
-<pre class="result">
-TBD
+ dbid | hostname
+------+----------
+    2 | phoenix0
+    3 | phoenix0
+    4 | phoenix0
+    5 | phoenix0
+    6 | phoenix1
+    7 | phoenix1
+    8 | phoenix1
+    9 | phoenix1
+   14 | phoenix3
+   15 | phoenix3
+   16 | phoenix3
+   17 | phoenix3
+   18 | phoenix4
+   19 | phoenix4
+   20 | phoenix4
+   21 | phoenix4
+(16 rows)
 </pre>
 
 @anchor references

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_gpu_info.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_gpu_info.sql_in
@@ -1,0 +1,60 @@
+/* ---------------------------------------------------------------------*//**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *//* ---------------------------------------------------------------------*/
+
+SELECT assert(trap_error($$SELECT * from gpu_configuration('invalid_source')$$) = 1, 'Invalid source should not be allowed');
+
+CREATE OR REPLACE FUNCTION test_gpu_configuration()
+returns void AS
+$$
+import plpy
+# Default case
+res1 = plpy.execute("SELECT * from gpu_configuration()")
+if res1 or len(res1) > 0:
+    plpy.error('gpu_configuration unexpectedly returned >0 rows.')
+
+# Default case with NULL
+res11 = plpy.execute("SELECT * from gpu_configuration(NULL)")
+if res11 or len(res11) > 0:
+    plpy.error('gpu_configuration unexpectedly returned >0 rows.')
+
+# pass nvidia
+res2 = plpy.execute("SELECT * from gpu_configuration('NVIDIA')")
+if res2 or len(res2) > 0:
+    plpy.error('gpu_configuration unexpectedly returned >0 rows.')
+
+# pass tensorflow
+res3 = plpy.execute("SELECT * from gpu_configuration('tensorflow')")
+if res3 or len(res3) > 0:
+    plpy.error('gpu_configuration unexpectedly returned >0 rows.')
+
+# without 'select *'
+res4 = plpy.execute("SELECT gpu_configuration()")
+if res4 or len(res4) > 0:
+    plpy.error('gpu_configuration unexpectedly returned >0 rows.')
+
+# mixed case
+res5 = plpy.execute("SELECT * from gpu_configuration('TenSorFlOW')")
+if res5 or len(res5) > 0:
+    plpy.error('gpu_configuration unexpectedly returned >0 rows.')
+$$ language plpythonu;
+
+
+select test_gpu_configuration();

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_gpu_info.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_gpu_info.sql_in
@@ -19,42 +19,24 @@
  *
  *//* ---------------------------------------------------------------------*/
 
-SELECT assert(trap_error($$SELECT * from gpu_configuration('invalid_source')$$) = 1, 'Invalid source should not be allowed');
+SELECT assert(trap_error($$SELECT * from gpu_configuration('output_table', 'invalid_source')$$) = 1, 'Invalid source');
 
-CREATE OR REPLACE FUNCTION test_gpu_configuration()
-returns void AS
-$$
-import plpy
-# Default case
-res1 = plpy.execute("SELECT * from gpu_configuration()")
-if res1 or len(res1) > 0:
-    plpy.error('gpu_configuration unexpectedly returned >0 rows.')
+DROP TABLE IF EXISTS output_table_tf;
+SELECT gpu_configuration('output_table_tf');
+SELECT * FROM output_table_tf;
 
-# Default case with NULL
-res11 = plpy.execute("SELECT * from gpu_configuration(NULL)")
-if res11 or len(res11) > 0:
-    plpy.error('gpu_configuration unexpectedly returned >0 rows.')
+DROP TABLE IF EXISTS output_table_tf;
+SELECT gpu_configuration('output_table_tf', NULL);
+SELECT * FROM output_table_tf;
 
-# pass nvidia
-res2 = plpy.execute("SELECT * from gpu_configuration('NVIDIA')")
-if res2 or len(res2) > 0:
-    plpy.error('gpu_configuration unexpectedly returned >0 rows.')
+DROP TABLE IF EXISTS output_table_nvidia;
+SELECT gpu_configuration('output_table_nvidia','NVIDIA');
+SELECT * FROM output_table_nvidia;
 
-# pass tensorflow
-res3 = plpy.execute("SELECT * from gpu_configuration('tensorflow')")
-if res3 or len(res3) > 0:
-    plpy.error('gpu_configuration unexpectedly returned >0 rows.')
+DROP TABLE IF EXISTS output_table_tf;
+SELECT gpu_configuration('output_table_tf', 'tensorflow');
+SELECT * FROM output_table_tf;
 
-# without 'select *'
-res4 = plpy.execute("SELECT gpu_configuration()")
-if res4 or len(res4) > 0:
-    plpy.error('gpu_configuration unexpectedly returned >0 rows.')
-
-# mixed case
-res5 = plpy.execute("SELECT * from gpu_configuration('TenSorFlOW')")
-if res5 or len(res5) > 0:
-    plpy.error('gpu_configuration unexpectedly returned >0 rows.')
-$$ language plpythonu;
-
-
-select test_gpu_configuration();
+DROP TABLE IF EXISTS output_table_tf;
+SELECT * FROM gpu_configuration('output_table_tf');
+SELECT * FROM output_table_tf;

--- a/src/ports/postgres/modules/deep_learning/test/unit_tests/test_madlib_keras_gpu_info.py_in
+++ b/src/ports/postgres/modules/deep_learning/test/unit_tests/test_madlib_keras_gpu_info.py_in
@@ -1,0 +1,86 @@
+# coding=utf-8
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+m4_changequote(`<!', `!>')
+
+import sys
+import numpy as np
+import os
+from os import path
+# Add convex module to the pythonpath.
+sys.path.append(path.dirname(path.dirname(path.dirname(path.dirname(path.abspath(__file__))))))
+sys.path.append(path.dirname(path.dirname(path.dirname(path.abspath(__file__)))))
+
+import unittest
+from mock import *
+import plpy_mock as plpy
+
+
+
+class GPUInfoTestCase(unittest.TestCase):
+    def setUp(self):
+        self.plpy_mock = Mock(spec='error')
+        patches = {
+            'plpy': plpy
+        }
+
+        self.plpy_mock_execute = MagicMock()
+        plpy.execute = self.plpy_mock_execute
+
+        self.module_patcher = patch.dict('sys.modules', patches)
+        self.module_patcher.start()
+        import madlib_keras_gpu_info
+        self.module = madlib_keras_gpu_info
+
+    def tearDown(self):
+        self.module_patcher.stop()
+
+    def test_gpu_configuration_invalid_source(self):
+        with self.assertRaises(plpy.PLPYException):
+            self.module.gpu_configuration('schema', 'invalid_source')
+
+    def test_gpu_configuration_none_source(self):
+        self.module.gpu_configuration('schema', None)
+        self.assertIn('tensorflow', str(self.plpy_mock_execute.call_args_list))
+        self.assertNotIn('nvidia', str(self.plpy_mock_execute.call_args_list))
+
+    def test_gpu_configuration_tensorflow(self):
+        self.module.gpu_configuration('schema', 'tensorflow')
+        self.assertIn('tensorflow', str(self.plpy_mock_execute.call_args_list))
+        self.assertNotIn('nvidia', str(self.plpy_mock_execute.call_args_list))
+
+    def test_gpu_configuration_tensorflow(self):
+        self.module.gpu_configuration('schema', 'nvidia')
+        self.assertIn('nvidia', str(self.plpy_mock_execute.call_args_list))
+        self.assertNotIn('tensorflow', str(self.plpy_mock_execute.call_args_list))
+
+    def test_gpu_configuration_tensorflow_uppercase(self):
+        self.module.gpu_configuration('schema', 'TENSORFLOW')
+        self.assertIn('tensorflow', str(self.plpy_mock_execute.call_args_list))
+        self.assertNotIn('nvidia', str(self.plpy_mock_execute.call_args_list))
+
+    def test_gpu_configuration_nvidia_mixedcase(self):
+        self.module.gpu_configuration('schema', 'NVidIa')
+        self.assertIn('nvidia', str(self.plpy_mock_execute.call_args_list))
+        self.assertNotIn('tensorflow', str(self.plpy_mock_execute.call_args_list))
+
+
+if __name__ == '__main__':
+    unittest.main()
+# ---------------------------------------------------------------------

--- a/src/ports/postgres/modules/deep_learning/test/unit_tests/test_madlib_keras_gpu_info.py_in
+++ b/src/ports/postgres/modules/deep_learning/test/unit_tests/test_madlib_keras_gpu_info.py_in
@@ -23,7 +23,7 @@ import sys
 import numpy as np
 import os
 from os import path
-# Add convex module to the pythonpath.
+# Add dl module to the pythonpath.
 sys.path.append(path.dirname(path.dirname(path.dirname(path.dirname(path.abspath(__file__))))))
 sys.path.append(path.dirname(path.dirname(path.dirname(path.abspath(__file__)))))
 

--- a/src/ports/postgres/modules/deep_learning/test/unit_tests/test_madlib_keras_gpu_info.py_in
+++ b/src/ports/postgres/modules/deep_learning/test/unit_tests/test_madlib_keras_gpu_info.py_in
@@ -47,36 +47,38 @@ class GPUInfoTestCase(unittest.TestCase):
         self.module_patcher.start()
         import madlib_keras_gpu_info
         self.module = madlib_keras_gpu_info
+        self.module.output_tbl_valid = Mock()
+        self.table_name = 'does_not_matter'
 
     def tearDown(self):
         self.module_patcher.stop()
 
     def test_gpu_configuration_invalid_source(self):
         with self.assertRaises(plpy.PLPYException):
-            self.module.gpu_configuration('schema', 'invalid_source')
+            self.module.gpu_configuration('schema', self.table_name, 'invalid_source')
 
     def test_gpu_configuration_none_source(self):
-        self.module.gpu_configuration('schema', None)
+        self.module.gpu_configuration('schema', self.table_name, None)
         self.assertIn('tensorflow', str(self.plpy_mock_execute.call_args_list))
         self.assertNotIn('nvidia', str(self.plpy_mock_execute.call_args_list))
 
     def test_gpu_configuration_tensorflow(self):
-        self.module.gpu_configuration('schema', 'tensorflow')
+        self.module.gpu_configuration('schema', self.table_name, 'tensorflow')
         self.assertIn('tensorflow', str(self.plpy_mock_execute.call_args_list))
         self.assertNotIn('nvidia', str(self.plpy_mock_execute.call_args_list))
 
-    def test_gpu_configuration_tensorflow(self):
-        self.module.gpu_configuration('schema', 'nvidia')
+    def test_gpu_configuration_nvidia(self):
+        self.module.gpu_configuration('schema', self.table_name, 'nvidia')
         self.assertIn('nvidia', str(self.plpy_mock_execute.call_args_list))
         self.assertNotIn('tensorflow', str(self.plpy_mock_execute.call_args_list))
 
     def test_gpu_configuration_tensorflow_uppercase(self):
-        self.module.gpu_configuration('schema', 'TENSORFLOW')
+        self.module.gpu_configuration('schema', self.table_name, 'TENSORFLOW')
         self.assertIn('tensorflow', str(self.plpy_mock_execute.call_args_list))
         self.assertNotIn('nvidia', str(self.plpy_mock_execute.call_args_list))
 
     def test_gpu_configuration_nvidia_mixedcase(self):
-        self.module.gpu_configuration('schema', 'NVidIa')
+        self.module.gpu_configuration('schema', self.table_name, 'NVidIa')
         self.assertIn('nvidia', str(self.plpy_mock_execute.call_args_list))
         self.assertNotIn('tensorflow', str(self.plpy_mock_execute.call_args_list))
 


### PR DESCRIPTION
JIRA: MADLIB-1390

This commit adds a new helper function to query the gpu configuration of
the cluster. The purpose of this function is to list the state of the
cluster w.r.t GPUs, however it is configured. This will be useful in
case of supporting asymmetric clusters.

Also takes in a source param which can be one of 'tensorflow' or
'nvidia'. Defaults to 'tensorflow'.

Example for gpdb
```
List the state of the cluster, however it is configured:

SELECT * FROM madlib.gpu_configuration();
    gpu_descr     | hostname

-----------------+-------------------------

NVIDIA Tesla P100 | host1

NVIDIA Tesla P100 | host1

Super Duper GPU   | host2

Super Duper GPU   | host2

(4 rows)
```

Example for postgres
```
select * from madlib.gpu_configuration();

hostname | gpu_descr

---------+-----------

localhost | NVIDIA Tesla P100

(1 row)
```
Co-authored-by: Ekta Khanna <ekhanna@pivotal.io>

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [x] Add the module name, JIRA# to PR/commit and description.
- [x] Add tests for the change. 

