### PR TITLE
DL: Enable transfer learning for multi model training

### DIFF
--- a/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.py_in
@@ -286,7 +286,10 @@ class FitMultipleModel():
                                                      )
             model = model_from_json(model_arch)
 
-            serialized_state = madlib_keras_serializer.serialize_nd_weights(model.get_weights())
+            serialized_state = model_weights if model_weights else \
+                madlib_keras_serializer.serialize_state_with_nd_weights(
+                    0, model.get_weights())
+
             model_size = sys.getsizeof(serialized_weights) / 1024.0
             metrics_list = get_metrics_from_compile_param(
                 mst[self.compile_params_col])

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_transfer_learning.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_transfer_learning.sql_in
@@ -19,6 +19,8 @@
  *
  *//* ---------------------------------------------------------------------*/
 
+m4_include(`SQLCommon.m4')
+
 \i m4_regexp(MODULE_PATHNAME,
              `\(.*\)libmadlib\.so',
              `\1../../modules/deep_learning/test/madlib_keras_iris.setup.sql_in'
@@ -114,3 +116,93 @@ SELECT assert(
   abs(first.training_metrics_final-second.training_metrics[2]) < 1e-10,
   'Transfer learning test failed because training loss and metrics don''t match the expected value.')
 FROM iris_model_first_run AS first, iris_model_transfer_summary AS second;
+
+-- Rerun the iris setup to discard the changes
+\i m4_regexp(MODULE_PATHNAME,
+             `\(.*\)libmadlib\.so',
+             `\1../../modules/deep_learning/test/madlib_keras_iris.setup.sql_in'
+)
+
+m4_changequote(`<!', `!>')
+m4_ifdef(<!__POSTGRESQL__!>, <!!>, <!
+-- Load the same arch again so that we can compare transfer learning results
+SELECT load_keras_model('iris_model_arch',  -- Output table,
+$$
+{
+"class_name": "Sequential",
+"keras_version": "2.1.6",
+"config":
+    [{"class_name": "Dense", "config": {"kernel_initializer": {"class_name": "VarianceScaling",
+    "config": {"distribution": "uniform", "scale": 1.0, "seed": 0, "mode": "fan_avg"}},
+    "name": "dense_1", "kernel_constraint": null, "bias_regularizer": null,
+    "bias_constraint": null, "dtype": "float32", "activation": "relu", "trainable": true,
+    "kernel_regularizer": null, "bias_initializer": {"class_name": "Zeros",
+    "config": {}}, "units": 10, "batch_input_shape": [null, 4], "use_bias": true,
+    "activity_regularizer": null}}, {"class_name": "Dense",
+    "config": {"kernel_initializer": {"class_name": "VarianceScaling",
+    "config": {"distribution": "uniform", "scale": 1.0, "seed": 0, "mode": "fan_avg"}},
+    "name": "dense_2", "kernel_constraint": null, "bias_regularizer": null,
+    "bias_constraint": null, "activation": "relu", "trainable": true, "kernel_regularizer": null,
+    "bias_initializer": {"class_name": "Zeros", "config": {}}, "units": 10, "use_bias": true,
+    "activity_regularizer": null}}, {"class_name": "Dense", "config": {"kernel_initializer":
+    {"class_name": "VarianceScaling", "config": {"distribution": "uniform", "scale": 1.0,
+    "seed": 0, "mode": "fan_avg"}}, "name": "dense_3", "kernel_constraint": null,
+    "bias_regularizer": null, "bias_constraint": null, "activation": "softmax",
+    "trainable": true, "kernel_regularizer": null, "bias_initializer": {"class_name": "Zeros",
+    "config": {}}, "units": 3, "use_bias": true, "activity_regularizer": null}}],
+    "backend": "tensorflow"}
+$$
+);
+
+DROP TABLE IF EXISTS mst_table, mst_table_summary;
+SELECT load_model_selection_table(
+    'iris_model_arch',
+    'mst_table',
+    ARRAY[1,3],
+    ARRAY[
+        $$loss='categorical_crossentropy',optimizer='Adam(lr=0.01)',metrics=['accuracy']$$,
+        $$loss='categorical_crossentropy', optimizer='Adam(lr=0.001)',metrics=['accuracy']$$
+    ],
+    ARRAY[
+        $$batch_size=5,epochs=1$$
+    ]
+);
+
+DROP TABLE if exists iris_multiple_model, iris_multiple_model_summary, iris_multiple_model_info;
+SELECT setseed(0);
+SELECT madlib_keras_fit_multiple_model(
+  'iris_data_packed',
+  'iris_multiple_model',
+  'mst_table',
+  3,
+  0
+);
+
+DROP TABLE IF EXISTS iris_model_first_run;
+CREATE TABLE iris_model_first_run AS
+SELECT mst_key, model_id, training_loss, training_metrics,
+    training_loss_final, training_metrics_final
+FROM iris_multiple_model_info;
+
+UPDATE iris_model_arch
+SET model_weights = (SELECT model_weights FROM iris_multiple_model WHERE mst_key=1)
+WHERE model_id = 1;
+
+DROP TABLE if exists iris_multiple_model, iris_multiple_model_summary, iris_multiple_model_info;
+SELECT madlib_keras_fit_multiple_model(
+  'iris_data_packed',
+  'iris_multiple_model',
+  'mst_table',
+  3,
+  0
+);
+
+SELECT assert(
+  abs(first.training_loss_final-second.training_loss[1]) < 1e-6 AND
+  abs(first.training_loss_final-second.training_loss[2]) < 1e-6 AND
+  abs(first.training_metrics_final-second.training_metrics[1]) < 1e-10 AND
+  abs(first.training_metrics_final-second.training_metrics[2]) < 1e-10,
+  'Transfer learning test failed because training loss and metrics don''t match the expected value.')
+FROM iris_model_first_run AS first, iris_multiple_model_info AS second
+WHERE first.mst_key = second.mst_key AND first.model_id = 2;
+!>)


### PR DESCRIPTION
JIRA: MADLIB-1389

This commit enables transfer learning for multi-model training by
copying the weights from the model arch table.

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [x] Add the module name, JIRA# to PR/commit and description.
- [x] Add tests for the change. 

