### PR TITLE
LDA: Turn off create table notices

### DIFF
--- a/src/ports/postgres/modules/lda/lda.sql_in
+++ b/src/ports/postgres/modules/lda/lda.sql_in
@@ -1056,7 +1056,8 @@ MADLIB_SCHEMA.lda_train
 )
 RETURNS SETOF MADLIB_SCHEMA.lda_result AS $$
     PythonFunctionBodyOnly(`lda', `lda')
-    with AOControl(False):
+    from utilities.control import MinWarning
+    with AOControl(False) and MinWarning("error"):
         lda.lda_train(schema_madlib, data_table, model_table, output_data_table,
                       voc_size, topic_num, iter_num, alpha, beta, None, None)
     return [[model_table, 'model table'],
@@ -1133,7 +1134,8 @@ MADLIB_SCHEMA.lda_predict
 )
 RETURNS SETOF MADLIB_SCHEMA.lda_result AS $$
     PythonFunctionBodyOnly(`lda', `lda')
-    with AOControl(False):
+    from utilities.control import MinWarning
+    with AOControl(False) and MinWarning("error"):
         lda.lda_predict(schema_madlib, data_table, model_table, output_table)
     return [[
         output_table,
@@ -1194,7 +1196,8 @@ MADLIB_SCHEMA.lda_get_word_topic_count
 )
 RETURNS SETOF MADLIB_SCHEMA.lda_result AS $$
     PythonFunctionBodyOnly(`lda', `lda')
-    with AOControl(False):
+    from utilities.control import MinWarning
+    with AOControl(False) and MinWarning("error"):
         lda.get_word_topic_count(schema_madlib, model_table, output_table)
     return [[output_table, 'per-word topic counts']]
 $$ LANGUAGE plpythonu STRICT
@@ -1217,7 +1220,8 @@ MADLIB_SCHEMA.lda_get_topic_desc
 )
 RETURNS SETOF MADLIB_SCHEMA.lda_result AS $$
     PythonFunctionBodyOnly(`lda', `lda')
-    with AOControl(False):
+    from utilities.control import MinWarning
+    with AOControl(False) and MinWarning("error"):
         lda.get_topic_desc(schema_madlib, model_table, vocab_table, desc_table, top_k)
     return [[
         desc_table,
@@ -1239,7 +1243,8 @@ MADLIB_SCHEMA.lda_get_word_topic_mapping
 )
 RETURNS SETOF MADLIB_SCHEMA.lda_result AS $$
     PythonFunctionBodyOnly(`lda', `lda')
-    with AOControl(False):
+    from utilities.control import MinWarning
+    with AOControl(False) and MinWarning("error"):
         lda.get_word_topic_mapping(schema_madlib, lda_output_table, mapping_table)
     return [[mapping_table, 'wordid - topicid mapping']]
 $$ LANGUAGE plpythonu STRICT

--- a/src/ports/postgres/modules/utilities/text_utilities.sql_in
+++ b/src/ports/postgres/modules/utilities/text_utilities.sql_in
@@ -324,7 +324,8 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.term_frequency(
 RETURNS TEXT
 AS $$
     PythonFunctionBodyOnly(`utilities', `text_utilities')
-    with AOControl(False):
+    from utilities.control import MinWarning
+    with AOControl(False) and MinWarning("error"):
         return text_utilities.term_frequency(input_table, doc_id_col, word_vec_col,
                                              output_table, compute_vocab=compute_vocab)
 $$


### PR DESCRIPTION
JIRA: MADLIB-1395

Set client_min_messages to 'error' for all lda related functions to
silence postgres notice messages.

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [x] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

