### PR TITLE
DL: Update tests calling trap_error()

### DIFF
--- a/src/ports/postgres/modules/deep_learning/madlib_keras_helper.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_helper.py_in
@@ -274,6 +274,8 @@ def get_accessible_gpus_for_seg(schema_madlib, segments_per_host, module_name):
 
     if is_platform_pg():
         gpus = GPUInfoFunctions.get_gpu_info_from_tensorflow()
+        if not gpus:
+            plpy.error("{0} error: No GPUs configured on host.".format(module_name))
         return [len(gpus)]
     else:
         gpu_table_name = unique_string(desp = 'gpu_table')

--- a/src/ports/postgres/modules/deep_learning/test/input_data_preprocessor.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/input_data_preprocessor.sql_in
@@ -341,13 +341,14 @@ SELECT assert (dependent_vartype   = 'text' AND
 -- data_preprocessor_input_batch was created for boolean dependent var,
 -- trying to create validation data using this table for reference, but
 -- passing a non-boolean dep var should error out.
-select assert(trap_error($TRAP$validation_preprocessor_dl(
+DROP TABLE IF EXISTS validation_out, validation_out_summary;
+select assert(trap_error($TRAP$SELECT validation_preprocessor_dl(
   'validation_input',
   'validation_out',
   'y_new',
   'x_new',
   'data_preprocessor_input_batch');$TRAP$) = 1,
-    'Passing integer dep var while expecting boolean dep var should error out.');
+    'Passing boolean dep var while expecting text dep var should error out.');
 
 
 -- test double precision type
@@ -582,7 +583,7 @@ CREATE TABLE data_preprocessor_input_validation_null(id serial, x double precisi
 INSERT INTO data_preprocessor_input_validation_null(x, label) VALUES
 (ARRAY[11,2,3,4,5,6], 'bbbb');
 DROP TABLE IF EXISTS validation_out_batch, validation_out_batch_summary;
-select assert(trap_error($TRAP$validation_preprocessor_dl(
+select assert(trap_error($TRAP$SELECT validation_preprocessor_dl(
   'data_preprocessor_input_validation_null',
   'validation_out_batch',
   'label',

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_fit.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_fit.sql_in
@@ -114,7 +114,7 @@ FROM (SELECT * FROM keras_saved_out_summary) summary;
 -- that don't have GPUs. Since Jenkins builds are run on docker containers
 -- that don't have GPUs, these queries must error out.
 DROP TABLE IF EXISTS keras_saved_out_gpu, keras_saved_out_gpu_summary;
-SELECT assert(trap_error($TRAP$madlib_keras_fit(
+SELECT assert(trap_error($TRAP$SELECT madlib_keras_fit(
     'cifar_10_sample_batched',
     'keras_saved_out_gpu',
     'model_arch',
@@ -307,7 +307,7 @@ CREATE TABLE cifar_10_sample_val_failure AS SELECT * FROM cifar_10_sample_val;
 ALTER TABLE cifar_10_sample_val_failure rename dependent_var to dependent_var_original;
 ALTER TABLE cifar_10_sample_val_failure rename buffer_id to dependent_var;
 DROP TABLE IF EXISTS keras_out, keras_out_summary;
-SELECT assert(trap_error($TRAP$madlib_keras_fit(
+SELECT assert(trap_error($TRAP$SELECT madlib_keras_fit(
            'cifar_10_sample_batched',
            'keras_out',
            'model_arch',

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_predict.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_predict.sql_in
@@ -47,7 +47,7 @@ SELECT madlib_keras_fit(
 -- non-existent model table, while we want to trap failure due to
 -- gpus_per_host=2
 DROP TABLE IF EXISTS cifar10_predict_gpu;
-SELECT assert(trap_error($TRAP$madlib_keras_predict(
+SELECT assert(trap_error($TRAP$SELECT madlib_keras_predict(
     'keras_saved_out',
     'cifar_10_sample',
     'id',
@@ -85,11 +85,11 @@ SELECT assert(estimated_y IN (0,1),
 FROM cifar10_predict;
 
 DROP TABLE IF EXISTS cifar10_predict;
-SELECT assert(trap_error($TRAP$madlib_keras_predict(
+SELECT assert(trap_error($TRAP$SELECT madlib_keras_predict(
     'keras_saved_out',
     'cifar_10_sample_batched',
-    'id',
-    'x',
+    'buffer_id',
+    'independent_var',
     'cifar10_predict',
     NULL,
     FALSE);$TRAP$) = 1,
@@ -341,7 +341,7 @@ SELECT madlib_keras_predict(
 
 -- Prediction with incorrectly shaped data must error out.
 DROP TABLE IF EXISTS cifar10_predict;
-SELECT assert(trap_error($TRAP$madlib_keras_predict(
+SELECT assert(trap_error($TRAP$SELECT madlib_keras_predict(
         'keras_saved_out',
         'cifar_10_sample',
         'id',


### PR DESCRIPTION
Prior to this PR, due to the missing `SELECT`, call to
`trap_error()` would always return 1, irrespective of whether
the execution of the query would error out or not. This commit
updates such tests to pass in an executable SQL query.
This PR also fixes a bug in predict that was missed due to
the missing `SELECT` in the query param passed to trap_error().

