### PR TITLE
DL: Fix failure on GPDB6 for preprocessor

### DIFF
--- a/src/ports/postgres/modules/deep_learning/input_data_preprocessor.py_in
+++ b/src/ports/postgres/modules/deep_learning/input_data_preprocessor.py_in
@@ -528,9 +528,10 @@ class InputDataPreprocessorDL(object):
 
         # Disable optimizer (ORCA) for platforms that use it
         # since we want to use a groupagg instead of hashagg
-        with OptimizerControl(False) and HashaggControl(False):
-            # Run actual batching query
-            plpy.execute(batching_query.format(**locals()))
+        with OptimizerControl(False):
+            with HashaggControl(False):
+                # Run actual batching query
+                plpy.execute(batching_query.format(**locals()))
 
         plpy.execute("DROP TABLE {0}".format(normalized_tbl))
 


### PR DESCRIPTION
Prior to this PR, on GPDB6, running the preprocessor on a large
dataset would crash GPDB with the following error:
`ERROR:  DTX RollbackAndReleaseCurrentSubTransaction dispatch failed`
This was only an issue on GPDB6 not on GPDB5/Postgres. This PR fixes the issue on GPDB6.
