### PR TITLE
Decrease the learning rate for transfer learning test

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache MADlib
-Copyright 2016-2019 The Apache Software Foundation.
+Copyright 2016-2020 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_transfer_learning.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_transfer_learning.sql_in
@@ -290,8 +290,8 @@ SELECT load_model_selection_table(
     'mst_table',
     ARRAY[1,3],
     ARRAY[
-        $$loss='categorical_crossentropy',optimizer='Adam(lr=0.01)',metrics=['accuracy']$$,
-        $$loss='categorical_crossentropy', optimizer='Adam(lr=0.001)',metrics=['accuracy']$$
+        $$loss='categorical_crossentropy',optimizer='Adam(lr=0.00001)',metrics=['accuracy']$$,
+        $$loss='categorical_crossentropy', optimizer='Adam(lr=0.00002)',metrics=['accuracy']$$
     ],
     ARRAY[
         $$batch_size=5,epochs=1$$


### PR DESCRIPTION
A dev-check test for transfer learning was failing every once in a while.

This helps smooth out the learning curve, making the test be more
predictable... much less likely to fail due to a random fluctuation.

Co-authored-by: Orhan Kislal <okislal@apache.org>

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [ ] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

