### PR TITLE
Graph: Fix ambiguous column name in various functions

### DIFF
--- a/src/ports/postgres/modules/graph/apsp.py_in
+++ b/src/ports/postgres/modules/graph/apsp.py_in
@@ -220,10 +220,10 @@ def graph_apsp(schema_madlib, vertex_table, vertex_id, edge_table,
         # The source can be reached with 0 cost and next is itself.
         plpy.execute(
             """ UPDATE {out_table} SET
-            {weight} = 0, parent = {vertex_id}
+            {weight} = 0, parent = {vertex_table}.{vertex_id}
             FROM {vertex_table}
-            WHERE {out_table}.{src} = {vertex_id}
-            AND {out_table}.{dest} = {vertex_id}
+            WHERE {out_table}.{src} = {vertex_table}.{vertex_id}
+            AND {out_table}.{dest} = {vertex_table}.{vertex_id}
             """.format(**locals()))
 
         # Distance = 1: every edge means there is a path from src to dest

--- a/src/ports/postgres/modules/graph/bfs.py_in
+++ b/src/ports/postgres/modules/graph/bfs.py_in
@@ -286,7 +286,7 @@ def graph_bfs(schema_madlib, vertex_table, vertex_id, edge_table,
         toupdate = unique_string(desp='toupdate')
         insert_toupdate_table = """
             CREATE TEMP TABLE {toupdate} AS
-            SELECT {grp_sube_comma} {dest} AS {vertex_id}, {src} AS {parent_col}
+            SELECT {grp_sube_comma} {sube}.{dest} AS {vertex_id}, {sube}.{src} AS {parent_col}
             FROM (
                 SELECT {grp_comma} {src}, {dest}
                 FROM {edge_table}
@@ -303,8 +303,8 @@ def graph_bfs(schema_madlib, vertex_table, vertex_id, edge_table,
         if not directed:
             insert_toupdate_table += """
                 UNION ALL
-                SELECT {grp_sube1_comma} {src} AS {vertex_id},
-                        {dest} AS {parent_col}
+                SELECT {grp_sube1_comma} {sube1}.{src} AS {vertex_id},
+                        {sube1}.{dest} AS {parent_col}
                 FROM (
                     SELECT {grp_comma} {src}, {dest}
                     FROM {edge_table}

--- a/src/ports/postgres/modules/graph/graph_utils.py_in
+++ b/src/ports/postgres/modules/graph/graph_utils.py_in
@@ -101,7 +101,7 @@ def validate_graph_coding(vertex_table, vertex_id, edge_table, edge_params,
         **locals()))
 
     existing_cols = set(unquote_ident(i) for i in get_cols(vertex_table))
-    _assert(vertex_id in existing_cols,
+    _assert(unquote_ident(vertex_id) in existing_cols,
             """Graph {func_name}: The vertex column {vertex_id} is not present in vertex table ({vertex_table}) """.
             format(**locals()))
     _assert(columns_exist_in_table(edge_table, edge_params.values()),

--- a/src/ports/postgres/modules/graph/hits.py_in
+++ b/src/ports/postgres/modules/graph/hits.py_in
@@ -211,11 +211,11 @@ def hits(schema_madlib, vertex_table, vertex_id, edge_table, edge_args,
                     {authority_init_value}::DOUBLE PRECISION AS authority,
                     {hub_init_value}::DOUBLE PRECISION AS hub
             FROM (
-                SELECT {select_subquery1_grouping_cols_comma} {vertex_id}
+                SELECT {select_subquery1_grouping_cols_comma} {vertex_table}.{vertex_id}
                 FROM {edge_temp_table} JOIN {vertex_table}
                 ON {edge_temp_table}.{src}={vertex_table}.{vertex_id}
                 UNION
-                SELECT {select_subquery1_grouping_cols_comma} {vertex_id}
+                SELECT {select_subquery1_grouping_cols_comma} {vertex_table}.{vertex_id}
                 FROM {edge_temp_table} JOIN {vertex_table}
                 ON {edge_temp_table}.{dest}={vertex_table}.{vertex_id}
             ) {subquery1}
@@ -529,7 +529,7 @@ suffix '_summary' to the 'out_table' parameter.
 ----------------------------------------------------------------------------
                                 SUMMARY
 ----------------------------------------------------------------------------
-Given a directed graph, hits algorithm finds the authority and hub scores of 
+Given a directed graph, hits algorithm finds the authority and hub scores of
 all the vertices in the graph.
 --
 For an overview on usage, run:

--- a/src/ports/postgres/modules/graph/pagerank.py_in
+++ b/src/ports/postgres/modules/graph/pagerank.py_in
@@ -455,7 +455,7 @@ def pagerank(schema_madlib, vertex_table, vertex_id, edge_table, edge_args, out_
                             WHERE __t1__.{src}=__t2__.{dest}
                             AND {where_group_clause}
                         ) {vpg_where_clause_ins}
-                        GROUP BY {select_group_cols}, {vertex_id}, pagerank
+                        GROUP BY {select_group_cols}, __t1__.{src}, pagerank
                     """.format(
                     select_group_cols=get_table_qualified_col_str(
                         '__t1__', grouping_cols_list),

--- a/src/ports/postgres/modules/graph/test/apsp.sql_in
+++ b/src/ports/postgres/modules/graph/test/apsp.sql_in
@@ -97,3 +97,14 @@ SELECT assert(weight = 2, 'Wrong output in graph (APSP)')
 SELECT assert(parent = 2, 'Wrong output in graph (APSP)')
 	FROM out_gr WHERE src = 0 AND "DEST" = 5 AND grp = 1;
 
+DROP TABLE IF EXISTS out, out_summary;
+ALTER TABLE vertex RENAME COLUMN id TO src;
+
+SELECT graph_apsp('vertex','src','edge_gr','dest="DEST"','out','grp');
+SELECT * FROM out ORDER BY src,"DEST";
+
+DROP TABLE IF EXISTS out, out_summary;
+ALTER TABLE vertex RENAME COLUMN src TO "DEST";
+
+SELECT graph_apsp('vertex','"DEST"','edge_gr','dest="DEST"','out','grp');
+SELECT * FROM out ORDER BY src,"DEST";

--- a/src/ports/postgres/modules/graph/test/bfs.sql_in
+++ b/src/ports/postgres/modules/graph/test/bfs.sql_in
@@ -274,3 +274,15 @@ SELECT assert(
 SELECT assert(MIN(g1) = 100 AND MAX(g1) = 100,
 	'Wrong output in graph (BFS)') FROM out_frombfs GROUP BY g1,g2
 ;
+
+DROP TABLE IF EXISTS out, out_summary;
+ALTER TABLE vertex RENAME COLUMN id TO "SRC";
+
+SELECT graph_bfs('vertex','"SRC"','edge_grp','src="SRC"',3,'out',NULL,NULL,'g1');
+SELECT * FROM out;
+
+DROP TABLE IF EXISTS out, out_summary;
+ALTER TABLE vertex RENAME COLUMN "SRC" TO dest;
+
+SELECT graph_bfs('vertex','dest','edge_grp','src="SRC"',3,'out',NULL,NULL,'g1');
+SELECT * FROM out;

--- a/src/ports/postgres/modules/graph/test/hits.sql_in
+++ b/src/ports/postgres/modules/graph/test/hits.sql_in
@@ -156,3 +156,15 @@ SELECT assert(relative_error(hub , :expected_hub1) < :tolerance,
 SELECT assert(relative_error(hub , :expected_hub2) < :tolerance,
         'HITS: Incorrect value for hub score. Expected: ' || :expected_hub2 || ' Actual: ' || hub
     ) FROM hits_out WHERE id=5 and user_id = 2;
+
+DROP TABLE IF EXISTS out, out_summary;
+ALTER TABLE vertex RENAME COLUMN id TO src;
+
+SELECT hits('vertex','src','edge',NULL,'out',3,0.01,'user_id');
+SELECT * FROM out;
+
+DROP TABLE IF EXISTS out, out_summary;
+ALTER TABLE vertex RENAME COLUMN src TO dest;
+
+SELECT hits('vertex','dest','edge',NULL,'out',3,0.01,'user_id');
+SELECT * FROM out;

--- a/src/ports/postgres/modules/graph/test/pagerank.sql_in
+++ b/src/ports/postgres/modules/graph/test/pagerank.sql_in
@@ -192,3 +192,15 @@ NULL, -- Default Threshold
 SELECT assert(relative_error(SUM(pagerank), 1) < 0.00001,
         'PageRank: Scores do not sum up to 1 for group 1.'
     ) FROM pagerank_gr_out WHERE user_id=1;
+
+DROP TABLE IF EXISTS out, out_summary;
+ALTER TABLE vertex RENAME COLUMN id TO src;
+
+SELECT pagerank('vertex','src','"EDGE"',NULL,'out',NULL,NULL,NULL,'user_id');
+SELECT * FROM out;
+
+DROP TABLE IF EXISTS out, out_summary;
+ALTER TABLE vertex RENAME COLUMN src TO dest;
+
+SELECT pagerank('vertex','dest','"EDGE"',NULL,'out',NULL,NULL,NULL,'user_id');
+SELECT * FROM out;

--- a/src/ports/postgres/modules/graph/test/sssp.sql_in
+++ b/src/ports/postgres/modules/graph/test/sssp.sql_in
@@ -140,3 +140,15 @@ SELECT * FROM "out_Q_summary";
 SELECT graph_sssp_get_path('"out_Q"',5,'"out_Q_path"');
 
 SELECT * FROM "out_Q_path";
+
+DROP TABLE IF EXISTS out, out_summary;
+ALTER TABLE vertex RENAME COLUMN id TO src;
+
+SELECT graph_sssp('vertex','src','edge_gr',NULL,0,'out','grp');
+SELECT * FROM out;
+
+DROP TABLE IF EXISTS out, out_summary;
+ALTER TABLE vertex RENAME COLUMN src TO dest;
+
+SELECT graph_sssp('vertex','dest','edge_gr',NULL,0,'out','grp');
+SELECT * FROM out;

--- a/src/ports/postgres/modules/graph/test/wcc.sql_in
+++ b/src/ports/postgres/modules/graph/test/wcc.sql_in
@@ -158,3 +158,17 @@ SELECT assert(relative_error(num_components, 3) < 0.00001,
         'Weakly Connected Components: Incorrect largest component value.'
     ) FROM count_table WHERE user_id=1;
 
+
+DROP TABLE IF EXISTS out, out_summary;
+ALTER TABLE vertex RENAME COLUMN vertex_id TO src;
+
+SELECT weakly_connected_components('vertex','src','"EDGE"',
+    'src=src_node,dest=dest_node','out','user_id');
+SELECT * FROM out;
+
+DROP TABLE IF EXISTS out, out_summary;
+ALTER TABLE vertex RENAME COLUMN src TO dest;
+
+SELECT weakly_connected_components('vertex','dest','"EDGE"',
+    'src=src_node,dest=dest_node','out','user_id');
+SELECT * FROM out;


### PR DESCRIPTION
JIRA: MADLIB-1407

Some of the graph functions had a bug that surfaced when the vertex id column
had the same name as the edge src or dest columns. This commit fixes the issue
on apsp, bfs, hits and pagerank.

In addition, it adds tests for every graph function.

Closes #

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [ ] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

