### PR TITLE
Build: Check -mno-sse2 is available for GNU CXX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ project(MADlib)
 cmake_minimum_required(VERSION 2.8.4 FATAL_ERROR)
 
 include(ExternalProject)
+include(CheckCXXCompilerFlag)
 
 # -- Local definitions (filenames, paths, etc.) --------------------------------
 
@@ -92,13 +93,20 @@ if(CMAKE_COMPILER_IS_GNUCXX)
         OUTPUT_VARIABLE GNUCXX_VERSION
         OUTPUT_STRIP_TRAILING_WHITESPACE)
 
+    # This flag is specific for i386 and x86-64 families
+    # https://gcc.gnu.org/onlinedocs/gcc-4.8.5/gcc/i386-and-x86-64-Options.html
+    CHECK_CXX_COMPILER_FLAG(-mno-sse2 SSE_DISABLE_OPTIONS_AVAILABLE)
+    if (SSE_DISABLE_OPTIONS_AVAILABLE)
+        set(SSE_DISABLE_OPTIONS "-mno-sse2")
+    endif()
+
     # We need the 1998 standard plus amendments (ISO/IEC 14882:2003) plus TR1
     # Unfortunately, we only get this with gnu++98
     # Special notes:
     # - long long is not part of the C++ 1998/2003 standard, but it is such a
     # common (and useful) extension that we do not want to hear warnings about
     # it.
-    set(CMAKE_CXX_FLAGS "-std=gnu++98 -D_GLIBCXX_USE_CXX11_ABI=0 -fdiagnostics-show-option -Wall -Wextra -pedantic -Wconversion -Wno-long-long -Wno-clobbered -mno-sse2 -fstrict-aliasing"
+    set(CMAKE_CXX_FLAGS "-std=gnu++98 -D_GLIBCXX_USE_CXX11_ABI=0 -fdiagnostics-show-option -Wall -Wextra -pedantic -Wconversion -Wno-long-long -Wno-clobbered ${SSE_DISABLE_OPTIONS} -fstrict-aliasing"
         CACHE STRING
         "Flags used by the compiler during all build types." FORCE)
 


### PR DESCRIPTION
**Jira**: [MADLIB-1410](https://issues.apache.org/jira/browse/MADLIB-1410)

Implement a check that `-mno-sse2` option is available for the chosen GNU CXX compiler. This [is a platform-specific option](https://gcc.gnu.org/onlinedocs/gcc-4.8.5/gcc/i386-and-x86-64-Options.html) and should not be set on machines with architectures that do not support it.

This requires a new CMake module `CheckCXXCompilerFlag`. It [is available in CMake 2.8.4](https://cmake.org/cmake/help/v2.8.4/cmake.html), which is the lowest currently supported CMake version.

An extra CMake variable, `SSE_DISABLE_OPTIONS`, is introduced to hold options required for GNU CXX compilers that support SSE-specific options.

### Notes
The implemented mechanism is just one of multiple possible implementations. For example, one could check the target system architecture instead of using `CHECK_CXX_COMPILER_FLAG`. In addition, CMake itself has several implementation options, with the same result.