### PR TITLE
Build: Determine architecture on Linux machines properly

### DIFF
--- a/src/ports/postgres/cmake/FindPostgreSQL.cmake
+++ b/src/ports/postgres/cmake/FindPostgreSQL.cmake
@@ -189,7 +189,7 @@ if(${PKG_NAME}_PG_CONFIG AND ${PKG_NAME}_SERVER_INCLUDE_DIR)
                 OUTPUT_STRIP_TRAILING_WHITESPACE
             )
 
-            architecture("${${PKG_NAME}_EXECUTABLE}" ${PKG_NAME}_ARCHITECTURE)
+            architecture(${PKG_NAME}_ARCHITECTURE)
         else()
 		  if(${PACKAGE_FIND_VERSION})
             message(FATAL_ERROR "Found \"${${PKG_NAME}_PG_CONFIG}\", "


### PR DESCRIPTION
**Jira**: [MADLIB-1410](https://issues.apache.org/jira/browse/MADLIB-1410)

[Current implementation of `file` output parsing](https://github.com/apache/madlib/blob/fc81374d4d280ab4454150cb126137775e0f7ae6/cmake/Utils.cmake#L71) does not parse the architecture names properly.

`file` command output is kernel-dependent. On Linux, the widest used implementation is http://www.darwinsys.com/file/. The definitions of its outputs for ELF files for the most recent version can be found at https://github.com/file/file/blob/master/magic/Magdir/elf.

This PR implements proper parsing of these outputs and their conversion to Mac OS `lipo` format.

### Notes
Not sure the `lipo` architecture format is the correct choice, but I suppose its values may currently be expected in various places.

I would propose the following:
* Introduce some "unknown" architecture in order not to limit architecture support. Not sure this is possible without extra changes, though.
* Remove [`word_length`](https://github.com/apache/madlib/blob/fc81374d4d280ab4454150cb126137775e0f7ae6/cmake/Utils.cmake#L99) CMake macro. As far as I understand, it is currently not used anywhere.
* Rewrite the architecture recognition CMake macro `architecture` and use `file` both on Mac OS and on Linux. This would simplify the parsing logic of the macro, and it would allow to determine word length directly (`file` output contains it) instead of hardcoding it in `word_length`.