### PR TITLE
Summary: Fix defaults when the user passes NULL

### DIFF
--- a/src/ports/postgres/modules/summary/Summarizer.py_in
+++ b/src/ports/postgres/modules/summary/Summarizer.py_in
@@ -11,8 +11,8 @@ class Summarizer:
 
     def __init__(self, schema_madlib, source_table, output_table,
                  target_cols, grouping_cols, distinctify, get_quartiles,
-                 xtileify='Exact', ntile_array=None, how_many_mfv=10,
-                 get_mfv_quick=False, n_cols_per_run=15):
+                 xtileify, ntile_array, how_many_mfv, get_mfv_quick,
+                 n_cols_per_run):
         self._schema_madlib = schema_madlib
         self._source_table = source_table
         self._output_table = output_table
@@ -20,11 +20,11 @@ class Summarizer:
         self._target_cols = target_cols
         self._distinctify = distinctify
         self._get_quartiles = get_quartiles
-        self._xtileify = xtileify
+        self._xtileify = xtileify if xtileify else 'Exact'
         self._ntile_array = ntile_array
-        self._how_many_mfv = how_many_mfv
-        self._get_mfv_quick = get_mfv_quick
-        self._n_cols_per_run = n_cols_per_run
+        self._how_many_mfv = how_many_mfv if how_many_mfv is not None else 10
+        self._get_mfv_quick = get_mfv_quick if get_mfv_quick is not None else False
+        self._n_cols_per_run = n_cols_per_run if n_cols_per_run is not None else 15
         self._columns = None
         self._column_names = None
         self._delimiter = '_.*.&.!.!.&.*_'


### PR DESCRIPTION
JIRA: MADLIB-1413

Summarizer used python defaults for setting up the optional parameters.
If the user passes a NULL, these values get overwritten. This commit
fixes this issue by moving the defaults inside the code.

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [ ] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

