### PR TITLE
Fix fit_multiple() warm start

### DIFF
--- a/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
@@ -334,7 +334,7 @@ def fit(schema_madlib, source_table, model, model_arch_table,
     reset_cuda_env(original_cuda_env)
 
 def get_initial_weights(model_table, model_arch, serialized_weights, warm_start,
-                        use_gpus, accessible_gpus_for_seg):
+                        use_gpus, accessible_gpus_for_seg, mst_filter=''):
     """
         If warm_start is True, return back initial weights from model table.
         If warm_start is False, first try to get the weights from model_arch
@@ -359,8 +359,8 @@ def get_initial_weights(model_table, model_arch, serialized_weights, warm_start,
 
     if warm_start:
         serialized_weights = plpy.execute("""
-            SELECT model_weights FROM {0}
-        """.format(model_table))[0]['model_weights']
+            SELECT model_weights FROM {model_table} {mst_filter} LIMIT 1
+        """.format(**locals()))[0]['model_weights']
     else:
         if not serialized_weights:
             model = model_from_json(model_arch)

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.py_in
@@ -341,13 +341,23 @@ class FitMultipleModel():
             # used, even if a particular model doesn't have warm start weigths.
             if self.warm_start:
                 model_weights = None
+                mst_filter = """
+                    WHERE {mst_col}={mst_key}
+                """.format(
+                        mst_col=self.mst_key_col,
+                        mst_key=mst['mst_key']
+                    )
+ 
+            else:
+                mst_filter = ''
 
             serialized_weights = get_initial_weights(self.model_output_table,
                                                      model_arch,
                                                      model_weights,
                                                      mst['mst_key'] in warm_start_msts,
                                                      self.use_gpus,
-                                                     self.accessible_gpus_for_seg
+                                                     self.accessible_gpus_for_seg,
+                                                     mst_filter
                                                      )
             model_size = sys.getsizeof(serialized_weights) / 1024.0
 


### PR DESCRIPTION
The `get_initial_weights()` function in `madlib_keras.py_in` is shared by both `madlib_keras_fit()` and `madlib_keras_fit_multiple()`.  But until now the code was
not updated to support fit_multiple().  When called with warm-start=TRUE, this was causing improper initialization of weights for small datasets, and out-of-memory errors for larger datasets.

This adds a parameter to this internal helper function, that is used to select the appropriate `mst_key` while querying the previous model output table for the weights belonging to that model.