### PR TITLE
Graph: Filter out infinite paths

### DIFF
--- a/src/ports/postgres/modules/graph/apsp.py_in
+++ b/src/ports/postgres/modules/graph/apsp.py_in
@@ -381,10 +381,13 @@ def graph_apsp(schema_madlib, vertex_table, vertex_id, edge_table,
                     """Graph APSP: Detected a negative cycle in the """ +
                     """sub-graphs of following groups: {0}.""".
                     format(str(negs)[1:-1]))
-
         else:
             plpy.execute("DROP VIEW IF EXISTS {0}".format(tmp_view))
 
+
+    # Filter out the infinite paths (disconnected pairs)
+    plpy.execute(""" DELETE FROM {0} WHERE parent IS NULL
+        """.format(out_table))
     return None
 
 

--- a/src/ports/postgres/modules/graph/bfs.py_in
+++ b/src/ports/postgres/modules/graph/bfs.py_in
@@ -375,6 +375,14 @@ def graph_bfs(schema_madlib, vertex_table, vertex_id, edge_table,
             # stored in this iteration. This is used to check if the iterations
             # need to continue.
             vct = plpy.execute(count_qry.format(**locals()))[0]['count']
+
+        # Filter out the infinite paths (disconnected pairs)
+        plpy.execute(""" UPDATE {out_table} SET parent = {source_vertex}
+                         WHERE {vertex_id} = {source_vertex}
+                    """.format(**locals()))
+
+        plpy.execute(""" DELETE FROM {0} WHERE parent IS NULL
+            """.format(out_table))
         # Drop temp tables
         plpy.execute("DROP TABLE IF EXISTS {0},{1}".format(toupdate, message))
 

--- a/src/ports/postgres/modules/graph/bfs.sql_in
+++ b/src/ports/postgres/modules/graph/bfs.sql_in
@@ -200,7 +200,7 @@ SELECT * FROM out ORDER BY dist,id;
 <pre class="result">
  id | dist | parent
 ----+------+--------
-  3 |    0 |
+  3 |    0 |      3
   1 |    1 |      3
   4 |    1 |      3
   5 |    1 |      3
@@ -236,7 +236,7 @@ SELECT * FROM out_max ORDER BY dist,id;
 <pre class="result">
  id | dist | parent
 ----+------+--------
-  3 |    0 |
+  3 |    0 |      3
   1 |    1 |      3
   4 |    1 |      3
   5 |    1 |      3
@@ -269,7 +269,7 @@ SELECT * FROM out_alt ORDER BY v_id;
 <pre class="result">
  v_id | dist | parent
 ------+------+--------
-    8 |    0 |
+    8 |    0 |      8
     9 |    1 |      8
    10 |    1 |      8
    11 |    2 |      9
@@ -292,7 +292,7 @@ SELECT * FROM out_alt_dir ORDER BY v_id;
 <pre class="result">
  v_id | dist | parent
 ------+------+--------
-    8 |    0 |
+    8 |    0 |      8
     9 |    1 |      8
    10 |    2 |      9
    11 |    2 |      9
@@ -348,11 +348,11 @@ SELECT * FROM out_gr ORDER BY g1,g2,dist,id;
 <pre class="result">
  g1  | g2 | id | dist | parent
 -----+----+----+------+--------
- 100 | a  |  8 |    0 |
+ 100 | a  |  8 |    0 |      8
  100 | a  |  9 |    1 |      8
  100 | a  | 10 |    1 |      8
  100 | a  | 11 |    2 |      9
- 202 | c  |  8 |    0 |
+ 202 | c  |  8 |    0 |      8
  202 | c  |  9 |    1 |      8
  202 | c  | 10 |    1 |      8
  202 | c  | 11 |    2 |      9
@@ -378,7 +378,7 @@ SELECT * FROM out_gr ORDER BY g1,g2,dist,id;
 <pre class="result">
  g1  | g2 | id | dist | parent
 -----+----+----+------+--------
- 100 | a  |  3 |    0 |
+ 100 | a  |  3 |    0 |      3
  100 | a  |  1 |    1 |      3
  100 | a  |  4 |    1 |      3
  100 | a  |  5 |    1 |      3

--- a/src/ports/postgres/modules/graph/measures.py_in
+++ b/src/ports/postgres/modules/graph/measures.py_in
@@ -181,13 +181,7 @@ class Graph(object):
             CREATE TABLE {out_table} AS
             SELECT
                 {grouping_cols_comma}
-                -- Filtering 'Infinity' occurs in CASE instead of WHERE clause
-                -- so that the edge is part of the average value i.e. part of
-                -- the count of paths but zero addition to sum of distances.
-                AVG(CASE WHEN {e.weight} = 'Infinity'::double precision
-                            THEN 0::double precision
-                            ELSE {e.weight}::double precision
-                    END) as avg_path_length
+                AVG({e.weight}::double precision) as avg_path_length
             FROM {apsp_table}
             WHERE {e.src} != {e.dest}
                   {filter_clause}

--- a/src/ports/postgres/modules/graph/measures.sql_in
+++ b/src/ports/postgres/modules/graph/measures.sql_in
@@ -443,7 +443,10 @@ m4_ifdef(`\_\_HAS_FUNCTION_PROPERTIES\_\_', `CONTAINS SQL', `');
 
 This function computes the average of the shortest paths between each pair of
 vertices. Average path length is based on "reachable target vertices", so it
-ignores infinite-length paths between vertices that are not connected.
+ignores infinite-length paths between vertices that are not connected. This means
+the function will average the path lengths in each connected component. If the
+user requires the average path length of a particular component, the
+weakly_connected_components function may be used to isolate the relevant vertices.
 
 @note This function assumes a valid output from a prior APSP run - both the APSP
 table and the associated output summary table. APSP is a computationally
@@ -532,7 +535,7 @@ SELECT * FROM out_avg_path_length;
 <pre class="result">
  avg_path_length
 \------------------
- 2.01785714285714
+ 2.973684210526316
 (1 row)
 </pre>
 
@@ -570,9 +573,9 @@ SELECT * FROM out_gr_path ORDER BY grp;
 </pre>
 <pre class="result">
  grp |  avg_path_length
-\-------+--------------------
-   0 |  2.01785714285714
-   1 | 0.466666666666667
+\-------+----------------------
+   0 |  2.973684210526316
+   1 |               0.56
 (2 rows)
 </pre>
 */

--- a/src/ports/postgres/modules/graph/sssp.py_in
+++ b/src/ports/postgres/modules/graph/sssp.py_in
@@ -381,6 +381,10 @@ def graph_sssp(schema_madlib, vertex_table, vertex_id, edge_table,
                     """sub-graphs of following groups: {0}.""".
                     format(str(negs)[1:-1]))
 
+        # Filter out the infinite paths (disconnected pairs)
+        plpy.execute(""" DELETE FROM {0} WHERE parent IS NULL
+            """.format(out_table))
+
         plpy.execute("DROP TABLE IF EXISTS {0}".format(oldupdate))
     return None
 

--- a/src/ports/postgres/modules/graph/test/apsp.sql_in
+++ b/src/ports/postgres/modules/graph/test/apsp.sql_in
@@ -116,9 +116,9 @@ ALTER TABLE vertex RENAME COLUMN "DEST" TO id;
 CREATE TABLE v2 AS SELECT id::bigint FROM vertex;
 CREATE TABLE e2 AS SELECT src::bigint, "DEST"::bigint, weight FROM "EDGE";
 
-DROP TABLE IF EXISTS public.out2, public.out2_summary, public.out2_path;
-SELECT graph_apsp('v2',NULL,'e2','dest="DEST"','public.out2');
-SELECT graph_apsp_get_path('public.out2',0,7,'public.out2_path');
+DROP TABLE IF EXISTS pg_temp.out2, pg_temp.out2_summary, pg_temp.out2_path;
+SELECT graph_apsp('v2',NULL,'e2','dest="DEST"','pg_temp.out2');
+SELECT graph_apsp_get_path('pg_temp.out2',0,7,'pg_temp.out2_path');
 
 -- Test for infinite paths
 DROP TABLE IF EXISTS out, out_summary, out_path;

--- a/src/ports/postgres/modules/graph/test/apsp.sql_in
+++ b/src/ports/postgres/modules/graph/test/apsp.sql_in
@@ -119,3 +119,14 @@ CREATE TABLE e2 AS SELECT src::bigint, "DEST"::bigint, weight FROM "EDGE";
 DROP TABLE IF EXISTS public.out2, public.out2_summary, public.out2_path;
 SELECT graph_apsp('v2',NULL,'e2','dest="DEST"','public.out2');
 SELECT graph_apsp_get_path('public.out2',0,7,'public.out2_path');
+
+-- Test for infinite paths
+DROP TABLE IF EXISTS out, out_summary, out_path;
+DELETE FROM "EDGE" WHERE "DEST" = 7;
+
+SELECT graph_apsp('vertex',NULL,'"EDGE"','dest="DEST"','out');
+
+SELECT assert(count(*) = 0, 'Null parent in the out table') FROM
+(SELECT * FROM out WHERE parent IS NULL)q1;
+
+SELECT graph_apsp_get_path('out',0,5,'out_path');

--- a/src/ports/postgres/modules/graph/test/bfs.sql_in
+++ b/src/ports/postgres/modules/graph/test/bfs.sql_in
@@ -296,3 +296,12 @@ CREATE TABLE e2 AS SELECT "SRC"::bigint, dest::bigint, weight FROM "EDGE";
 
 DROP TABLE IF EXISTS public.out2, public.out2_summary;
 SELECT graph_bfs('v2',NULL,'e2','src="SRC"',3,'public.out2');
+
+-- Test for infinite paths
+DROP TABLE IF EXISTS out, out_summary, out_path;
+DELETE FROM "EDGE" WHERE dest = 7;
+
+SELECT graph_bfs('vertex',NULL,'"EDGE"','src="SRC"',3,'out');
+
+SELECT assert(count(*) = 0, 'Null parent in the out table')
+    FROM (SELECT * FROM out WHERE parent IS NULL)q1;

--- a/src/ports/postgres/modules/graph/test/bfs.sql_in
+++ b/src/ports/postgres/modules/graph/test/bfs.sql_in
@@ -294,8 +294,8 @@ ALTER TABLE vertex RENAME COLUMN dest TO id;
 CREATE TABLE v2 AS SELECT id::bigint FROM vertex;
 CREATE TABLE e2 AS SELECT "SRC"::bigint, dest::bigint, weight FROM "EDGE";
 
-DROP TABLE IF EXISTS public.out2, public.out2_summary;
-SELECT graph_bfs('v2',NULL,'e2','src="SRC"',3,'public.out2');
+DROP TABLE IF EXISTS pg_temp.out2, pg_temp.out2_summary;
+SELECT graph_bfs('v2',NULL,'e2','src="SRC"',3,'pg_temp.out2');
 
 -- Test for infinite paths
 DROP TABLE IF EXISTS out, out_summary, out_path;

--- a/src/ports/postgres/modules/graph/test/hits.sql_in
+++ b/src/ports/postgres/modules/graph/test/hits.sql_in
@@ -176,5 +176,5 @@ ALTER TABLE vertex RENAME COLUMN dest TO id;
 CREATE TABLE v2 AS SELECT id::bigint FROM vertex;
 CREATE TABLE e2 AS SELECT src::bigint, dest::bigint FROM edge;
 
-DROP TABLE IF EXISTS public.out2, public.out2_summary;
-SELECT hits('v2',NULL,'e2',NULL,'public.out2');
+DROP TABLE IF EXISTS pg_temp.out2, pg_temp.out2_summary;
+SELECT hits('v2',NULL,'e2',NULL,'pg_temp.out2');

--- a/src/ports/postgres/modules/graph/test/measures.sql_in
+++ b/src/ports/postgres/modules/graph/test/measures.sql_in
@@ -86,7 +86,7 @@ SELECT assert(diameter=14, 'Invalid value for diameter') FROM public.__madlib__o
 DROP TABLE IF EXISTS public.__madlib__out_avg_path_length;
 SELECT graph_avg_path_length('out_apsp', 'public.__madlib__out_avg_path_length');
 SELECT * FROM public.__madlib__out_avg_path_length;
-SELECT assert(relative_error(avg_path_length, 2.0178) < 1e-2,
+SELECT assert(relative_error(avg_path_length, 2.97) < 1e-2,
               'Invalid value for avg_path_length') FROM public.__madlib__out_avg_path_length;
 
 -- Compute the in and out degrees

--- a/src/ports/postgres/modules/graph/test/measures.sql_in
+++ b/src/ports/postgres/modules/graph/test/measures.sql_in
@@ -64,51 +64,46 @@ SELECT graph_apsp('vertex',      -- Vertex table
                   'out_apsp');   -- Output table of shortest paths
 
 -- Compute the closeness measure for all nodes:
-DROP TABLE IF EXISTS public.__madlib__out_closeness;
-SELECT graph_closeness('out_apsp', 'public.__madlib__out_closeness');
-SELECT * FROM public.__madlib__out_closeness;
+SELECT graph_closeness('out_apsp', 'pg_temp.__madlib__out_closeness');
+SELECT * FROM pg_temp.__madlib__out_closeness;
 
 SELECT assert(relative_error(inverse_sum_dist, 0.04347) < 1e-2 and
               relative_error(inverse_avg_dist, 0.3043) < 1e-2 and
               relative_error(sum_inverse_dist, 3.6833) < 1e-2 and
               k_degree = 7,
               'Incorrect value for closeness')
-FROM public.__madlib__out_closeness
+FROM pg_temp.__madlib__out_closeness
 WHERE src_id = 0;
 
 -- Compute the diameter measure for graph
-DROP TABLE IF EXISTS public.__madlib__out_diameter;
-SELECT graph_diameter('out_apsp', 'public.__madlib__out_diameter');
-SELECT * FROM public.__madlib__out_diameter;
-SELECT assert(diameter=14, 'Invalid value for diameter') FROM public.__madlib__out_diameter;
+SELECT graph_diameter('out_apsp', 'pg_temp.__madlib__out_diameter');
+SELECT * FROM pg_temp.__madlib__out_diameter;
+SELECT assert(diameter=14, 'Invalid value for diameter') FROM pg_temp.__madlib__out_diameter;
 
 -- Compute the average path length measure for graph
-DROP TABLE IF EXISTS public.__madlib__out_avg_path_length;
-SELECT graph_avg_path_length('out_apsp', 'public.__madlib__out_avg_path_length');
-SELECT * FROM public.__madlib__out_avg_path_length;
+SELECT graph_avg_path_length('out_apsp', 'pg_temp.__madlib__out_avg_path_length');
+SELECT * FROM pg_temp.__madlib__out_avg_path_length;
 SELECT assert(relative_error(avg_path_length, 2.97) < 1e-2,
-              'Invalid value for avg_path_length') FROM public.__madlib__out_avg_path_length;
+              'Invalid value for avg_path_length') FROM pg_temp.__madlib__out_avg_path_length;
 
 -- Compute the in and out degrees
-DROP TABLE IF EXISTS public.__madlib__out_degrees;
 SELECT graph_vertex_degrees('vertex',      -- Vertex table
                      'id',          -- Vertix id column (NULL means use default naming)
                      '"EDGE"',        -- "EDGE" table
                      'src=src_id, dest="DEST_ID", weight=edge_weight',
                                  -- "EDGE" arguments (NULL means use default naming)
-                     'public.__madlib__out_degrees');
-SELECT * FROM public.__madlib__out_degrees;
+                     'pg_temp.__madlib__out_degrees');
+SELECT * FROM pg_temp.__madlib__out_degrees;
 SELECT assert(indegree = 2 and outdegree = 3, 'Invalid value for degrees')
-FROM public.__madlib__out_degrees
+FROM pg_temp.__madlib__out_degrees
 WHERE id = 0;
 
 SELECT assert(COUNT(*)=1, 'Invalid value for node with only one incoming edge.')
-FROM public.__madlib__out_degrees
+FROM pg_temp.__madlib__out_degrees
 WHERE id = 7;
 
 DELETE FROM "EDGE" WHERE "DEST_ID"=7;
 INSERT INTO "EDGE" VALUES (7,6,1);
-DROP TABLE IF EXISTS public.out_degrees;
 SELECT graph_vertex_degrees('vertex',      -- Vertex table
                      'id',          -- Vertix id column (NULL means use default naming)
                      '"EDGE"',        -- "EDGE" table

--- a/src/ports/postgres/modules/graph/test/pagerank.sql_in
+++ b/src/ports/postgres/modules/graph/test/pagerank.sql_in
@@ -212,5 +212,5 @@ ALTER TABLE vertex RENAME COLUMN dest TO id;
 CREATE TABLE v2 AS SELECT id::bigint FROM vertex;
 CREATE TABLE e2 AS SELECT src::bigint, dest::bigint FROM "EDGE";
 
-DROP TABLE IF EXISTS public.out2, public.out2_summary;
-SELECT pagerank('v2',NULL,'e2',NULL,'public.out2');
+DROP TABLE IF EXISTS pg_temp.out2, pg_temp.out2_summary;
+SELECT pagerank('v2',NULL,'e2',NULL,'pg_temp.out2');

--- a/src/ports/postgres/modules/graph/test/sssp.sql_in
+++ b/src/ports/postgres/modules/graph/test/sssp.sql_in
@@ -161,9 +161,9 @@ ALTER TABLE vertex RENAME COLUMN dest TO id;
 CREATE TABLE v2 AS SELECT id::bigint FROM vertex;
 CREATE TABLE e2 AS SELECT src::bigint, dest::bigint, weight FROM "EDGE";
 
-DROP TABLE IF EXISTS public.out2, public.out2_summary, public.out2_path;
-SELECT graph_sssp('v2',NULL,'e2',NULL,0,'public.out2');
-SELECT graph_sssp_get_path('public.out2',5,'public.out2_path');
+DROP TABLE IF EXISTS pg_temp.out2, pg_temp.out2_summary, pg_temp.out2_path;
+SELECT graph_sssp('v2',NULL,'e2',NULL,0,'pg_temp.out2');
+SELECT graph_sssp_get_path('pg_temp.out2',5,'pg_temp.out2_path');
 
 -- Test for infinite paths
 DROP TABLE IF EXISTS out, out_summary, out_path;

--- a/src/ports/postgres/modules/graph/test/sssp.sql_in
+++ b/src/ports/postgres/modules/graph/test/sssp.sql_in
@@ -164,3 +164,14 @@ CREATE TABLE e2 AS SELECT src::bigint, dest::bigint, weight FROM "EDGE";
 DROP TABLE IF EXISTS public.out2, public.out2_summary, public.out2_path;
 SELECT graph_sssp('v2',NULL,'e2',NULL,0,'public.out2');
 SELECT graph_sssp_get_path('public.out2',5,'public.out2_path');
+
+-- Test for infinite paths
+DROP TABLE IF EXISTS out, out_summary, out_path;
+DELETE FROM "EDGE" WHERE dest = 7;
+
+SELECT graph_sssp('vertex',NULL,'"EDGE"',NULL,0,'out');
+
+SELECT assert(count(*) = 0, 'Null parent in the out table') FROM
+(SELECT * FROM out WHERE parent IS NULL)q1;
+
+SELECT graph_sssp_get_path('out',5,'out_path');

--- a/src/ports/postgres/modules/graph/test/wcc.sql_in
+++ b/src/ports/postgres/modules/graph/test/wcc.sql_in
@@ -179,5 +179,5 @@ ALTER TABLE vertex RENAME COLUMN dest TO id;
 CREATE TABLE v2 AS SELECT id::bigint FROM vertex;
 CREATE TABLE e2 AS SELECT src_node::bigint, dest_node::bigint FROM "EDGE";
 
-DROP TABLE IF EXISTS public.out2, public.out2_summary;
-SELECT weakly_connected_components('v2',NULL,'e2','src=src_node,dest=dest_node','public.out2');
+DROP TABLE IF EXISTS pg_temp.out2, pg_temp.out2_summary;
+SELECT weakly_connected_components('v2',NULL,'e2','src=src_node,dest=dest_node','pg_temp.out2');

--- a/src/ports/postgres/modules/utilities/validate_args.py_in
+++ b/src/ports/postgres/modules/utilities/validate_args.py_in
@@ -209,10 +209,20 @@ def rename_table(schema_madlib, orig_name, new_name):
             # set schema only if a change in schema is required
             before_schema_string = "{0}.{1}".format(orig_table_schema,
                                                     new_table_name)
-            plpy.execute("""ALTER TABLE {new_table}
-                            SET SCHEMA {schema_name}""".
-                         format(new_table=before_schema_string,
-                                schema_name=new_table_schema))
+
+            if 'pg_temp' in new_table_schema:
+                # We cannot alter table schemas from/to temp schemas
+                # If it looks like a temp schema, we stay safe and just use
+                # create/drop
+                plpy.execute("""CREATE TABLE {new_name} AS
+                                SELECT * FROM {new_table_name}""".
+                             format(**locals()))
+                drop_tables([new_table_name])
+            else:
+                plpy.execute("""ALTER TABLE {new_table}
+                                SET SCHEMA {schema_name}""".
+                             format(new_table=before_schema_string,
+                                    schema_name=new_table_schema))
         return new_name
     else:
         return orig_table_schema + "." + new_table_name


### PR DESCRIPTION
JIRA: MADLIB-1415

SSSP, APSP and BFS output tables had entries for unconnected vertices,
denoted by a NULL parent column. This commit filters these rows to
clean up the output tables.

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [ ] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

