### PR TITLE
DL: Remove tests for no GPU hardware

### DIFF
--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_fit.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_fit.sql_in
@@ -110,21 +110,6 @@ SELECT assert(
         array_upper(validation_loss, 1) = 2 ,
         'Keras model output Summary Validation failed. Actual:' || __to_char(summary))
 FROM (SELECT * FROM keras_saved_out_summary) summary;
--- Fit with gpus_per_host set to 2 must error out on machines
--- that don't have GPUs. Since Jenkins builds are run on docker containers
--- that don't have GPUs, these queries must error out.
-DROP TABLE IF EXISTS keras_saved_out_gpu, keras_saved_out_gpu_summary;
-SELECT assert(trap_error($TRAP$SELECT madlib_keras_fit(
-    'cifar_10_sample_batched',
-    'keras_saved_out_gpu',
-    'model_arch',
-    1,
-    $$ optimizer=SGD(lr=0.01, decay=1e-6, nesterov=True), loss='categorical_crossentropy', metrics=['accuracy']$$::text,
-    $$ batch_size=2, epochs=1, verbose=0 $$::text,
-    3,
-    True,
-    'cifar_10_sample_val');$TRAP$) = 1,
-       'Fit with gpus_per_host=2 must error out.');
 
 -- Test for
   -- Non null name and description columns

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_predict.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_predict.sql_in
@@ -38,25 +38,6 @@ SELECT madlib_keras_fit(
     $$ batch_size=2, epochs=1, verbose=0 $$::text,
     3);
 
--- Prediction with gpus_per_host set to 2 must error out on machines
--- that don't have GPUs. Since Jenkins builds are run on docker containers
--- that don't have GPUs, these queries must error out.
-
--- IMPORTANT: The following test must be run when we have a valid
--- keras_saved_out model table. Otherwise, it will fail because of a
--- non-existent model table, while we want to trap failure due to
--- gpus_per_host=2
-DROP TABLE IF EXISTS cifar10_predict_gpu;
-SELECT assert(trap_error($TRAP$SELECT madlib_keras_predict(
-    'keras_saved_out',
-    'cifar_10_sample',
-    'id',
-    'x',
-    'cifar10_predict_gpu',
-    NULL,
-    TRUE);$TRAP$) = 1,
-    'Prediction with use_gpus=True must error out.');
-
 DROP TABLE IF EXISTS cifar10_predict;
 SELECT madlib_keras_predict(
     'keras_saved_out',


### PR DESCRIPTION
This commit removes 2 problematic tests that we decided weren't worth including in the DL dev-check tests.

One of these tests was checking to make sure that `madlib_keras_fit()` fails when you pass `use_gpus=True`. And the other does the same for `madlib_keras_predict()`.  This wasn't a problem originally because we usually run dev-check only on Jenkins or other docker images where there are no GPU's. But as we continue to improve our pre-release testing process, we'd like to have dev-check be able to pass on GPU-enabled test platforms as well. So these tests are no longer appropriate.