### PR TITLE
DL: Set plan_cache_mode to choose generic plan when passing weights for GPDB6

### DIFF
--- a/src/ports/postgres/modules/convex/mlp_igd.py_in
+++ b/src/ports/postgres/modules/convex/mlp_igd.py_in
@@ -1051,8 +1051,8 @@ def mlp_predict(schema_madlib, model_table, data_table, id_col_name,
         else:
             intermediate_col = unique_string()
             if classes:
-                score_format = create_cols_from_array_sql_string(
-                    classes, intermediate_col, 'prob', 'double precision', False, 'MLP') 
+                score_format, _ = create_cols_from_array_sql_string(
+                    classes, intermediate_col, 'prob', 'double precision', False, 'MLP')
             else:
                 # Case when the training step did not have to one-hot encode
                 # the dependent var.

--- a/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
@@ -313,11 +313,15 @@ def fit(schema_madlib, source_table, model, model_arch_table,
                  [compile_params, fit_params, name,
                   description, metrics_elapsed_time, class_values])
 
-    create_output_table = plpy.prepare("""
-        CREATE TABLE {0} AS SELECT
-        $1 as model_weights,
-        $2 as {1}""".format(model, ModelArchSchema.MODEL_ARCH), ["bytea", "json"])
-    plpy.execute(create_output_table, [serialized_weights, model_arch])
+    plpy.execute("""
+        CREATE TABLE {0}
+        (model_weights bytea,
+        {1} json)""".format(model, ModelArchSchema.MODEL_ARCH))
+    insert_output_table = plpy.prepare("""
+        INSERT INTO {0} SELECT model_weights, {1}
+        FROM (VALUES($1, $2))t(model_weights, {1})
+        """.format(model, ModelArchSchema.MODEL_ARCH), ["bytea", "json"])
+    plpy.execute(insert_output_table, [serialized_weights, model_arch])
 
     #TODO add a unit test for this in a future PR
     reset_cuda_env(original_cuda_env)

--- a/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras.py_in
@@ -168,8 +168,6 @@ def fit(schema_madlib, source_table, model, model_arch_table,
         FROM {source_table}
         """.format(**locals()), ["bytea", "boolean"])
 
-    prepare_generic_plan(run_training_iteration, [DUMMY_WEIGHTS, False])
-
     # Define the state for the model and loss/metric storage lists
     training_loss, training_metrics, metrics_elapsed_time = [], [], []
     metrics_iters = []
@@ -315,20 +313,11 @@ def fit(schema_madlib, source_table, model, model_arch_table,
                  [compile_params, fit_params, name,
                   description, metrics_elapsed_time, class_values])
 
-    plpy.execute("""
-        CREATE TABLE {0}
-        (model_weights bytea,
-        {1} json)""".format(model, ModelArchSchema.MODEL_ARCH))
-    insert_output_table = plpy.prepare("""
-        INSERT INTO {0} SELECT model_weights, {1}
-        FROM (VALUES($1, $2))t(model_weights, {1})
-        """.format(model, ModelArchSchema.MODEL_ARCH), ["bytea", "json"])
-    ## prepare generic plan for GPDB6 insert query
-    if is_platform_gp6():
-        for i in range(1, 6):
-            plpy.execute(insert_output_table, [DUMMY_WEIGHTS, DUMMY_JSON])
-            plpy.execute("TRUNCATE TABLE {0}".format(model))
-    plpy.execute(insert_output_table, [serialized_weights, model_arch])
+    create_output_table = plpy.prepare("""
+        CREATE TABLE {0} AS SELECT
+        $1 as model_weights,
+        $2 as {1}""".format(model, ModelArchSchema.MODEL_ARCH), ["bytea", "json"])
+    plpy.execute(create_output_table, [serialized_weights, model_arch])
 
     #TODO add a unit test for this in a future PR
     reset_cuda_env(original_cuda_env)
@@ -486,7 +475,7 @@ def fit_transition(state, dependent_var, independent_var, dependent_var_shape,
         b. keras session is cleared at the end of the final iteration,
         i.e, last row of last iteration.
     """
-    if not independent_var or not dependent_var or prev_serialized_weights==DUMMY_WEIGHTS:
+    if not independent_var or not dependent_var:
         return state
     SD = kwargs['SD']
     device_name = get_device_name_and_set_cuda_env(accessible_gpus_for_seg[current_seg_id], current_seg_id)
@@ -689,8 +678,11 @@ def get_loss_metric_from_keras_eval(schema_madlib, table, compile_params,
         MINIBATCH_OUTPUT_DEPENDENT_COLNAME_DL, "_shape")
     ind_shape_col = add_postfix(
         MINIBATCH_OUTPUT_INDEPENDENT_COLNAME_DL, "_shape")
+    """
+    This function will call the internal keras evaluate function to get the loss
+    and accuracy of each tuple which then gets averaged to get the final result.
+    """
     use_gpus = use_gpus if use_gpus else False
-
     evaluate_query = plpy.prepare("""
         select ({schema_madlib}.internal_keras_evaluate(
                                             {mb_dep_var_col},
@@ -707,12 +699,11 @@ def get_loss_metric_from_keras_eval(schema_madlib, table, compile_params,
                                             ARRAY{images_per_seg},
                                             {use_gpus}::BOOLEAN,
                                             ARRAY{accessible_gpus_for_seg},
-                                            $2
+                                            {is_final_iteration}
                                             )) as loss_metric
         from {table}
-        """.format(**locals()),["bytea", "boolean"])
-    prepare_generic_plan(evaluate_query, [DUMMY_WEIGHTS, False])
-    res = plpy.execute(evaluate_query, [serialized_weights, is_final_iteration])
+        """.format(**locals()), ["bytea"])
+    res = plpy.execute(evaluate_query, [serialized_weights])
     loss_metric = res[0]['loss_metric']
     return loss_metric
 
@@ -724,8 +715,6 @@ def internal_keras_eval_transition(state, dependent_var, independent_var,
                                    segments_per_host, images_per_seg,
                                    use_gpus, accessible_gpus_for_seg,
                                    is_final_iteration, **kwargs):
-    if serialized_weights == DUMMY_WEIGHTS:
-        return None
     SD = kwargs['SD']
     device_name = get_device_name_and_set_cuda_env(accessible_gpus_for_seg[current_seg_id], current_seg_id)
     agg_loss, agg_metric, agg_image_count = state
@@ -805,10 +794,6 @@ def internal_keras_eval_merge(state1, state2, **kwargs):
     return merged_state
 
 def internal_keras_eval_final(state, **kwargs):
-    # Return if called early
-    if not state or state == [0,0,0]:
-        return state
-
     loss, metric, image_count = state
 
     if image_count == 0:

--- a/src/ports/postgres/modules/deep_learning/madlib_keras.sql_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras.sql_in
@@ -1643,8 +1643,10 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.madlib_keras_fit(
     description             VARCHAR
 ) RETURNS VOID AS $$
     PythonFunctionBodyOnly(`deep_learning', `madlib_keras')
+    from utilities.control import SetGUC
     with AOControl(False):
-        madlib_keras.fit(**globals())
+        with SetGUC("plan_cache_mode", "force_generic_plan"):
+            madlib_keras.fit(**globals())
 $$ LANGUAGE plpythonu VOLATILE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -1836,16 +1838,18 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.madlib_keras_predict(
     mst_key                 INTEGER
 ) RETURNS VOID AS $$
     PythonFunctionBodyOnly(`deep_learning', `madlib_keras_predict')
+    from utilities.control import SetGUC
     with AOControl(False):
-        madlib_keras_predict.Predict(schema_madlib,
-               model_table,
-               test_table,
-               id_col,
-               independent_varname,
-               output_table,
-               pred_type,
-               use_gpus,
-               mst_key)
+        with SetGUC("plan_cache_mode", "force_generic_plan"):
+            madlib_keras_predict.Predict(schema_madlib,
+                   model_table,
+                   test_table,
+                   id_col,
+                   independent_varname,
+                   output_table,
+                   pred_type,
+                   use_gpus,
+                   mst_key)
 $$ LANGUAGE plpythonu VOLATILE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -1917,8 +1921,10 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.madlib_keras_predict_byom(
     normalizing_const       DOUBLE PRECISION
 ) RETURNS VOID AS $$
     PythonFunctionBodyOnly(`deep_learning', `madlib_keras_predict')
+    from utilities.control import SetGUC
     with AOControl(False):
-        madlib_keras_predict.PredictBYOM(**globals())
+        with SetGUC("plan_cache_mode", "force_generic_plan"):
+            madlib_keras_predict.PredictBYOM(**globals())
 $$ LANGUAGE plpythonu VOLATILE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -1986,7 +1992,11 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.madlib_keras_evaluate(
     use_gpus                BOOLEAN,
     mst_key                 INTEGER
 ) RETURNS VOID AS $$
-    PythonFunction(`deep_learning', `madlib_keras', `evaluate')
+    PythonFunctionBodyOnly(`deep_learning', `madlib_keras')
+    from utilities.control import SetGUC
+    with AOControl(False):
+        with SetGUC("plan_cache_mode", "force_generic_plan"):
+            madlib_keras.evaluate(**globals())
 $$ LANGUAGE plpythonu VOLATILE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.py_in
@@ -221,7 +221,8 @@ class FitMultipleModel():
                 self.mst_key_col, mst[self.mst_key_col])
             model_arch, _ = get_model_arch_weights(self.model_arch_table, mst[self.model_id_col])
             _, metric, loss = compute_loss_and_metrics(
-                self.schema_madlib, table, "$madlib${0}$madlib$".format(mst[self.compile_params_col]),
+                self.schema_madlib, table, "$madlib${0}$madlib$".format(
+                    mst[self.compile_params_col]),
                 model_arch,
                 weights,
                 self.use_gpus,
@@ -293,23 +294,6 @@ class FitMultipleModel():
                                          {self.model_arch_col} JSON)
                                         """.format(self=self)
             plpy.execute(output_table_create_query)
-        output_table_insert_query = """
-                            INSERT INTO {self.model_output_table}(
-                                 {self.mst_key_col}, {self.model_weights_col},
-                                 {self.model_arch_col})
-                              SELECT v1,v2,v3 from (VALUES ($1, $2, $3))t(v1,v2,v3)
-                                """.format(self=self)
-        output_table_insert_query_prepared = plpy.prepare(
-             output_table_insert_query, ["int", "bytea", "json"])
-
-        ## prepare generic plan for GPDB6 insert query
-        if is_platform_gp6():
-            for i in range(1, 6):
-                plpy.execute(output_table_insert_query_prepared, [0, DUMMY_WEIGHTS, DUMMY_JSON])
-                plpy.execute("""
-                                DELETE FROM {self.model_output_table}
-                                WHERE {self.mst_key_col}=0
-                             """.format(self=self))
 
         info_table_create_query = """
                                   CREATE TABLE {self.model_info_table}
@@ -387,8 +371,17 @@ class FitMultipleModel():
             plpy.execute(info_table_insert_query)
 
             if not mst['mst_key'] in warm_start_msts:
+                output_table_insert_query = """
+                                    INSERT INTO {self.model_output_table}(
+                                        {self.mst_key_col}, {self.model_weights_col},
+                                        {self.model_arch_col})
+                                    VALUES ({mst_key}, $1, $2)
+                                       """.format(self=self,
+                                                  mst_key=mst[self.mst_key_col])
+                output_table_insert_query_prepared = plpy.prepare(
+                    output_table_insert_query, ["bytea", "json"])
                 plpy.execute(output_table_insert_query_prepared, [
-                    mst[self.mst_key_col], serialized_weights, model_arch])
+                             serialized_weights, model_arch])
 
     def create_model_summary_table(self):
         if self.warm_start:

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.py_in
@@ -388,6 +388,7 @@ class FitMultipleModel():
             plpy.execute("DROP TABLE {0}".format(self.model_summary_table))
         src_summary_dict = get_source_summary_table_dict(self.fit_validator_train)
         class_values = src_summary_dict['class_values']
+        class_values_type = src_summary_dict['class_values_type']
         dep_vartype = src_summary_dict['dep_vartype']
         dependent_varname = \
             src_summary_dict['dependent_varname_in_source_table']
@@ -397,11 +398,8 @@ class FitMultipleModel():
         self.validation_table = 'NULL' if self.validation_table is None \
             else '$MAD${0}$MAD$'.format(self.validation_table)
         if class_values is None:
-            class_values_str = 'NULL::{0}'.format(src_summary_dict['class_values_type'])
             num_classes = 'NULL'
         else:
-            class_values_str = 'ARRAY{0}::{1}'.format(class_values,
-                                                      src_summary_dict['class_values_type'])
             num_classes = len(class_values)
         name = 'NULL' if self.name is None else '$MAD${0}$MAD$'.format(self.name)
         descr = 'NULL' if self.description is None else '$MAD${0}$MAD$'.format(self.description)
@@ -410,7 +408,7 @@ class FitMultipleModel():
         dependent_vartype_colname = DEPENDENT_VARTYPE_COLNAME
         normalizing_const_colname = NORMALIZING_CONST_COLNAME
         float32_sql_type = FLOAT32_SQL_TYPE
-        update_query = """
+        create_query = plpy.prepare("""
                 CREATE TABLE {self.model_summary_table} AS
                 SELECT
                     $MAD${self.source_table}$MAD$::TEXT AS source_table,
@@ -429,12 +427,12 @@ class FitMultipleModel():
                     '{self.end_training_time}'::TIMESTAMP AS end_training_time,
                     '{self.version}'::TEXT AS madlib_version,
                     {num_classes}::INTEGER AS num_classes,
-                    {class_values_str} AS {class_values_colname},
+                    $1 AS {class_values_colname},
                     $MAD${dep_vartype}$MAD$::TEXT AS {dependent_vartype_colname},
                     {norm_const}::{float32_sql_type} AS {normalizing_const_colname},
                     ARRAY{metrics_iters}::INTEGER[] AS metrics_iters
-            """.format(**locals())
-        plpy.execute(update_query)
+            """.format(**locals()), [class_values_type])
+        plpy.execute(create_query, [class_values])
 
     def update_info_table(self, mst, is_train):
         mst_key = mst[self.mst_key_col]

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.sql_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.sql_in
@@ -1398,8 +1398,10 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.madlib_keras_fit_multiple_model(
     description             VARCHAR
 ) RETURNS VOID AS $$
     PythonFunctionBodyOnly(`deep_learning', `madlib_keras_fit_multiple_model')
+    from utilities.control import SetGUC
     with AOControl(False):
-        fit_obj = madlib_keras_fit_multiple_model.FitMultipleModel(**globals())
+        with SetGUC("plan_cache_mode", "force_generic_plan"):
+            fit_obj = madlib_keras_fit_multiple_model.FitMultipleModel(**globals())
 $$ LANGUAGE plpythonu VOLATILE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_helper.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_helper.py_in
@@ -19,7 +19,6 @@
 
 import numpy as np
 from model_arch_info import ModelArchSchema
-from utilities.utilities import __mad_version
 from utilities.utilities import add_postfix
 from utilities.utilities import unique_string
 from utilities.utilities import is_platform_pg
@@ -54,8 +53,6 @@ SMALLINT_SQL_TYPE = 'SMALLINT'
 DEFAULT_NORMALIZING_CONST = 1.0
 GP_SEGMENT_ID_COLNAME = "gp_segment_id"
 INTERNAL_GPU_CONFIG = '__internal_gpu_config__'
-DUMMY_WEIGHTS = 'DUMMY'
-DUMMY_JSON = '{"a": "DUMMY"}'
 
 #####################################################################
 
@@ -317,25 +314,3 @@ def get_accessible_gpus_for_seg(schema_madlib, segments_per_host, module_name):
                     'recommended configuration is to have 1 GPU available per segment.')
                 warning_flag = False
         return accessible_gpus_for_seg
-
-def is_platform_gp6():
-    version_wrapper = __mad_version()
-    return not is_platform_pg() and not version_wrapper.is_gp_version_less_than('6.0')
-
-def prepare_generic_plan(query_plan, query_params):
-    # For >=GPDB6, previously, when the queries called with the
-    # initial weights value passed in, the query plan for it would
-    # create custom plans with weights embedded in the plan itself.
-    # This meant that the query plan size would also include the size
-    # of these weights, bloating it up to hit the 1GB limit when dispatching
-    # the query plan to segments, leading to OOM for large weights.
-    # In GPDB, for PREPARE plans, there is a threshold of 5 attempts to create
-    # custom plans(constant folding the passed in params) for execution and then
-    # it uses a generic plan(not constant folding the passed in params) for all
-    # the subsequent executions.
-    # Therefore, to avoid GPDB6 from creating custom plans when passing in
-    # weights, the query is executed passing in DUMMY weights for 5
-    # time, prior to calling it with the actual weights.
-    if is_platform_gp6():
-        for i in range(1, 6):
-            plpy.execute(query_plan, query_params)

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_predict.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_predict.py_in
@@ -35,6 +35,7 @@ from utilities.utilities import add_postfix
 from utilities.utilities import create_cols_from_array_sql_string
 from utilities.utilities import get_segments_per_host
 from utilities.utilities import unique_string
+from utilities.validate_args import get_expr_type
 from utilities.validate_args import input_tbl_valid
 
 from madlib_keras_wrapper import *
@@ -78,7 +79,7 @@ class BasePredict():
         intermediate_col = unique_string()
         class_values = strip_trailing_nulls_from_class_values(self.class_values)
 
-        prediction_select_clause = create_cols_from_array_sql_string(
+        prediction_select_clause, create_table_columns = create_cols_from_array_sql_string(
             class_values, intermediate_col, pred_col_name,
             pred_col_type, self.is_response, self.module_name)
         gp_segment_id_col, seg_ids_test, \
@@ -94,14 +95,20 @@ class BasePredict():
             group_by_clause = "GROUP BY {self.test_table}.gp_segment_id".format(self=self)
             join_cond_on_segmentid = "{self.test_table}.gp_segment_id=min_ctid.gp_segment_id AND".format(self=self)
 
+        # Calling CREATE TABLE instead of CTAS, to ensure that the plan_cache_mode
+        # guc codepath is called when passing in the weights
+        plpy.execute("""
+            CREATE TABLE {self.output_table}
+            ({self.id_col} {self.id_col_type}, {create_table_columns})
+            """.format(self=self, create_table_columns=create_table_columns))
         # Passing huge model weights to internal_keras_predict() for each row
         # resulted in slowness of overall madlib_keras_predict().
         # To avoid this, a CASE is added to pass the model weights only for
         # the very first row(min(ctid)) that is fetched on each segment and NULL
         # for the other rows.
         predict_query = plpy.prepare("""
-            CREATE TABLE {self.output_table} AS
-            SELECT {self.id_col}, {prediction_select_clause}
+            INSERT INTO {self.output_table}
+            SELECT {self.id_col}::{self.id_col_type}, {prediction_select_clause}
             FROM (
                 SELECT {self.test_table}.{self.id_col},
                        ({self.schema_madlib}.internal_keras_predict
@@ -175,6 +182,7 @@ class Predict(BasePredict):
         self.dependent_varname = param_proc.get_dependent_varname()
 
         self.validate()
+        self.id_col_type = get_expr_type(self.id_col, self.test_table)
         BasePredict.call_internal_keras(self)
         if self.is_mult_model:
             plpy.execute("DROP VIEW IF EXISTS {}".format(self.temp_summary_view))
@@ -230,6 +238,7 @@ class PredictBYOM(BasePredict):
             self.test_table, self.id_col, self.output_table,
             self.independent_varname)
         self.validate_and_set_defaults()
+        self.id_col_type = get_expr_type(self.id_col, self.test_table)
         BasePredict.call_internal_keras(self)
 
     def validate_and_set_defaults(self):

--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_model_selection.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_model_selection.sql_in
@@ -367,4 +367,25 @@ SELECT assert(cnt = 1,
 FROM (SELECT count(*) cnt FROM iris_multiple_model_info
 WHERE compile_params = $MAD$loss='categorical_crossentropy', optimizer='Adam(lr=0.01)', metrics=['accuracy']$MAD$::text
 AND fit_params = $MAD$batch_size=32, epochs=1$MAD$::text) info;
+
+-- Test when class values have NULL values
+UPDATE iris_data_packed_summary SET class_values = ARRAY['Iris-setosa','Iris-versicolor',NULL];
+DROP TABLE if exists iris_multiple_model, iris_multiple_model_summary, iris_multiple_model_info;
+SELECT madlib_keras_fit_multiple_model(
+	'iris_data_packed',
+	'iris_multiple_model',
+	'mst_table_1row',
+	1,
+	FALSE,
+	NULL,
+	1,
+	FALSE
+);
+
+SELECT assert(
+        num_classes = 3 AND
+        class_values = '{Iris-setosa,Iris-versicolor,NULL}',
+        'Keras Fit Multiple num_clases and class values Validation failed. Actual:' || __to_char(summary))
+FROM (SELECT * FROM iris_multiple_model_summary) summary;
+
 !>)

--- a/src/ports/postgres/modules/deep_learning/test/unit_tests/test_madlib_keras.py_in
+++ b/src/ports/postgres/modules/deep_learning/test/unit_tests/test_madlib_keras.py_in
@@ -1374,27 +1374,6 @@ class MadlibKerasHelperTestCase(unittest.TestCase):
             self.subject.get_accessible_gpus_for_seg('schema_madlib', 2, 'foo')
         self.assertIn('no gpus configured on hosts', str(error.exception).lower())
 
-    def test_is_platform_gp6_input_gpdb6(self):
-
-        self.subject.is_platform_pg = Mock(return_value = False)
-
-        self.plpy_mock_execute.side_effect = [[{ 'version':'PostgreSQL 9.4.24 (Greenplum Database 6.3.0 build commit:aabd)'}]]
-        self.assertTrue(self.subject.is_platform_gp6())
-
-    def test_is_platform_gp6_input_gpdb5(self):
-
-        self.subject.is_platform_pg = Mock(return_value = False)
-
-        self.plpy_mock_execute.side_effect = [[{ 'version':'PostgreSQL 8.3.23 (Greenplum Database 5.24.0 build commit:bdca)'}]]
-        self.assertFalse(self.subject.is_platform_gp6())
-
-    def test_is_platform_gp6_input_pg(self):
-
-        self.subject.is_platform_pg = Mock(return_value = True)
-
-        self.plpy_mock_execute.side_effect = [[{ 'version':'PostgreSQL 10.7'}]]
-        self.assertFalse(self.subject.is_platform_gp6())
-
 class MadlibKerasEvaluationTestCase(unittest.TestCase):
     def setUp(self):
         self.plpy_mock = Mock(spec='error')
@@ -1724,7 +1703,7 @@ class MadlibKerasEvaluationTestCase(unittest.TestCase):
         self.assertEqual(result, None)
 
     def test_internal_keras_eval_final_image_count_zero(self):
-        input_state = [1, 1, 0]
+        input_state = [0, 0, 0]
 
         with self.assertRaises(plpy.PLPYException):
             result = self.subject.internal_keras_eval_final(input_state)

--- a/src/ports/postgres/modules/utilities/control.py_in
+++ b/src/ports/postgres/modules/utilities/control.py_in
@@ -44,6 +44,59 @@ class ContextDecorator(object):
         return wrapper
 
 
+class SetGUC(ContextDecorator):
+    """
+    @brief: A wrapper that sets/unsets GUCs and then sets it
+        back to the original value on exit
+
+    This context manager sets the specified GUC to the value passed in
+    """
+
+    def __init__(self, guc_name, new_guc_value, error_on_fail=True):
+        self.guc_name = guc_name
+        self.new_guc_value = new_guc_value
+        if not self.guc_name or not self.new_guc_value:
+            plpy.error("Both guc_name and new_guc_value need to have a non null"
+                       "value")
+        self.error_on_fail = error_on_fail
+        self.guc_exists = True
+        self.old_value = None
+
+    def __enter__(self):
+        if self.guc_exists:
+            # check if allowed to change the GUC
+            try:
+                show_query = "show {0}".format(self.guc_name)
+                self.old_value = plpy.execute(show_query)[0]
+                self.old_value = self.old_value["{0}".format(self.guc_name)]
+            except plpy.SPIError:
+                self.guc_exists = False
+                return self
+
+            if self.new_guc_value:
+                plpy.execute("set {0}={1}".format(self.guc_name, self.new_guc_value))
+            else:
+                if self.error_on_fail:
+                    plpy.error("Cannot set {0} to None. Please provide a valid value"
+                               .format(self.guc_name))
+                    plpy.error("Unable to change '{0}' value. "
+                               "Set '{0} = \'{1}\'' to proceed.".
+                               format(self.guc_name, self.guc_value))
+        return self
+
+    def __exit__(self, *args):
+        if args and args[0]:
+            # an exception was raised in code, return False so that any
+            # exception is re-raised after exit. The transaction will not
+            # commit leading to reset of any change to parameter.
+            return False
+        else:
+            if self.guc_exists and self.old_value:
+                pass
+                plpy.execute("set {0}='{1}'".
+                             format(self.guc_name, self.old_value))
+
+
 class OptimizerControl(ContextDecorator):
     """
     @brief: A wrapper that enables/disables the optimizer and

--- a/src/ports/postgres/modules/utilities/test/unit_tests/test_control.py_in
+++ b/src/ports/postgres/modules/utilities/test/unit_tests/test_control.py_in
@@ -76,6 +76,36 @@ class ControlTestCase(unittest.TestCase):
         with self.subject.AOControl(True) as C:
             self.assertFalse(C.guc_exists)
 
+class SetGUCTestCase(unittest.TestCase):
+    def setUp(self):
+        patches = {
+            'plpy': plpy
+        }
+        self.plpy_mock_execute = MagicMock()
+        plpy.execute = self.plpy_mock_execute
+
+        self.module_patcher = patch.dict('sys.modules', patches)
+        self.module_patcher.start()
+
+        import control
+        self.subject = control
+
+    def tearDown(self):
+        self.module_patcher.stop()
+
+    def test_set_guc_sets_new_value(self):
+        self.plpy_mock_execute.return_value = [{'foo': 'new_bar'}]
+        with self.subject.SetGUC("foo", "new_bar") as C:
+            self.assertTrue("new_bar", C.new_guc_value)
+        self.plpy_mock_execute.assert_called_with(
+            "set foo='new_bar'")
+
+    def test_set_guc_missing(self):
+        self.plpy_mock_execute.side_effect = plpy.SPIError(
+            'Unrecognized configuration parameter "foo"')
+        with self.subject.SetGUC("foo", "new_bar") as C:
+            self.assertFalse(C.guc_exists)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/ports/postgres/modules/utilities/test/unit_tests/test_utilities.py_in
+++ b/src/ports/postgres/modules/utilities/test/unit_tests/test_utilities.py_in
@@ -254,15 +254,17 @@ class UtilitiesTestCase(unittest.TestCase):
         self.colname = 'estimated_col'
         self.coltype = 'dummy'
         self.has_one_ele = True
-        out_sql = utils.create_cols_from_array_sql_string(
+        out_sql, out_col = utils.create_cols_from_array_sql_string(
             self.py_list, self.sql_array_col, self.colname, self.coltype,
             self.has_one_ele, "dummy_module")
         self.assertEqual(out_sql, 'sqlcol[1]+1 AS estimated_col')
+        self.assertEqual(out_col, 'estimated_col dummy')
         self.has_one_ele = False
-        out_sql = utils.create_cols_from_array_sql_string(
+        out_sql, out_col = utils.create_cols_from_array_sql_string(
             self.py_list, self.sql_array_col, self.colname, self.coltype,
             self.has_one_ele, "dummy_module")
         self.assertEqual(out_sql, 'sqlcol AS estimated_col')
+        self.assertEqual(out_col, 'estimated_col dummy[]')
 
     def test_create_cols_from_array_sql_string_one_ele(self):
         utils = self.subject
@@ -271,10 +273,11 @@ class UtilitiesTestCase(unittest.TestCase):
         self.colname = 'estimated_pred'
         self.coltype = 'TEXT'
         self.has_one_ele = True
-        out_sql = utils.create_cols_from_array_sql_string(
+        out_sql, out_col = utils.create_cols_from_array_sql_string(
             self.py_list, self.sql_array_col, self.colname, self.coltype,
             self.has_one_ele, "dummy_module")
         self.assertTrue(out_sql, "(ARRAY['cat','dog'])[sqlcol[1]+1]::TEXT AS estimated_pred")
+        self.assertTrue(out_col, "estimated_pred TEXT")
 
     def test_create_cols_from_array_sql_string_one_ele_with_NULL(self):
         utils = self.subject
@@ -283,10 +286,11 @@ class UtilitiesTestCase(unittest.TestCase):
         self.colname = 'estimated_pred'
         self.coltype = 'INTEGER'
         self.has_one_ele = True
-        out_sql = utils.create_cols_from_array_sql_string(
+        out_sql, out_col = utils.create_cols_from_array_sql_string(
             self.py_list, self.sql_array_col, self.colname, self.coltype,
             self.has_one_ele, "dummy_module")
         self.assertEqual(out_sql, "(ARRAY[ NULL,1,2 ]::INTEGER[])[sqlcol[1]+1]::INTEGER AS estimated_pred")
+        self.assertEqual(out_col, "estimated_pred INTEGER")
 
     def test_create_cols_from_array_sql_string_one_ele_with_many_NULL(self):
         utils = self.subject
@@ -307,10 +311,11 @@ class UtilitiesTestCase(unittest.TestCase):
         self.colname = 'prob'
         self.coltype = 'TEXT'
         self.has_one_ele = False
-        out_sql = utils.create_cols_from_array_sql_string(
+        out_sql, out_col = utils.create_cols_from_array_sql_string(
             self.py_list, self.sql_array_col, self.colname, self.coltype,
             self.has_one_ele, "dummy_module")
         self.assertEqual(out_sql, "CAST(sqlcol[1] AS TEXT) AS \"prob_cat\", CAST(sqlcol[2] AS TEXT) AS \"prob_dog\"")
+        self.assertEqual(out_col, "\"prob_cat\" TEXT, \"prob_dog\" TEXT")
 
     def test_create_cols_from_array_sql_string_many_ele_with_NULL(self):
         utils = self.subject
@@ -319,10 +324,11 @@ class UtilitiesTestCase(unittest.TestCase):
         self.colname = 'prob'
         self.coltype = 'TEXT'
         self.has_one_ele = False
-        out_sql = utils.create_cols_from_array_sql_string(
+        out_sql, out_col = utils.create_cols_from_array_sql_string(
             self.py_list, self.sql_array_col, self.colname, self.coltype,
             self.has_one_ele, "dummy_module")
         self.assertEqual(out_sql, "CAST(sqlcol[1] AS TEXT) AS \"prob_NULL\", CAST(sqlcol[2] AS TEXT) AS \"prob_cat\", CAST(sqlcol[3] AS TEXT) AS \"prob_dog\"")
+        self.assertEqual(out_col, "\"prob_NULL\" TEXT, \"prob_cat\" TEXT, \"prob_dog\" TEXT")
 
     def test_create_cols_from_array_sql_string_many_ele_with_many_NULL(self):
         utils = self.subject

--- a/src/ports/postgres/modules/utilities/utilities.py_in
+++ b/src/ports/postgres/modules/utilities/utilities.py_in
@@ -431,7 +431,8 @@ def create_cols_from_array_sql_string(py_list, sql_array_col, colname,
                                       coltype, has_one_ele,
                                       module_name='Input Error'):
     """
-    Create SQL string to convert array of elements into multiple columns.
+    Create SQL string to convert array of elements into multiple columns and corresponding
+    SQL string of columns for CREATE TABLE.
     @args:
         @param: py_list, python list, if None, return sql_array_col as colname.
                             The py_list can at most have one 'None' element that
@@ -454,6 +455,7 @@ def create_cols_from_array_sql_string(py_list, sql_array_col, colname,
                 coltype = TEXT
                 has_one_ele = FALSE
             Output:
+                prob_cat TEXT, prob_dog TEXT
                 CAST(sqlcol[1] AS TEXT) AS prob_cat, CAST(sqlcol[2] AS TEXT) AS prob_dog
         2) Input:
                 py_list = ['cat', 'dog']
@@ -462,22 +464,24 @@ def create_cols_from_array_sql_string(py_list, sql_array_col, colname,
                 coltype = TEXT
                 has_one_ele = TRUE
             Output:
+                estimated_pred TEXT
                 (ARRAY['cat','dog'])[sqlcol[1]+1]::TEXT AS estimated_pred
 
     @NOTE:
         If py_list is [None, 'cat', 'dog', NULL']:
         then the SQL query string returned would create the following
         column names:
-            prob_NULL, prob_cat, 'prob_dog', and 'prob_"NULL'.
+            prob_NULL, prob_cat, 'prob_dog', and 'prob_"NULL"'.
         1. Notice that for None, which represents Postgres' NULL value, the
         column name will be 'prob_NULL',
         2. and to differentiate the column name for a string 'NULL', the
-        resulting column name will be 'prob_"NULL'.
+        resulting column name will be 'prob_"NULL"'.
 
         The weird quoting in this column name is due to calling strip after
         quote_ident in the code below.
 
     @returns:
+        @param, str, that can be used in a SQL query.
         @param, str, that can be used in a SQL query.
 
     """
@@ -515,6 +519,8 @@ def create_cols_from_array_sql_string(py_list, sql_array_col, colname,
             py_list_sql_str = py_list_to_sql_string(py_list, coltype+'[]')
             select_clause = "({0})[{1}[1]+1]::{2} AS {3}".format(
                 py_list_sql_str, sql_array_col, coltype, colname)
+            create_columns = "{0} {1}".format(
+                colname, coltype)
         else:
             # Create as many columns as the length of py_list. The
             # colnames are created based on the elements in py_list,
@@ -534,12 +540,21 @@ def create_cols_from_array_sql_string(py_list, sql_array_col, colname,
                            coltype=coltype)
                 for i, suffix in enumerate(py_list)
                 ])
+            create_columns = ', '.join(
+                ['"{final_colname}" {coltype}'.
+                     format(final_colname=quote_ident("{0}_{1}".
+                                                      format(colname, str(suffix))).strip(' "'),
+                            coltype=coltype)
+                 for i, suffix in enumerate(py_list)
+                 ])
     else:
         if has_one_ele:
             select_clause = '{0}[1]+1 AS {1}'.format(sql_array_col, colname)
+            create_columns = '{0} {1}'.format(colname, coltype)
         else:
             select_clause = '{0} AS {1}'.format(sql_array_col, colname)
-    return select_clause
+            create_columns = '{0} {1}'.format(colname, coltype+'[]')
+    return select_clause, create_columns
 # ------------------------------------------------------------------------
 
 def _array_to_string(origin):


### PR DESCRIPTION
JIRA: MADLIB-1414

This PR reverts the previous commit for avoiding constant folding of weights in GPDB6 plans. Instead, there is a GUC introduced in GPDB6(`plan_cache_mode`) that allows controlling whether to choose generic plan(not constant folding the passed in params)/custom plans(constant folding the passed in params) for execution. This PR uses this GUC for choosing generic plan for GPDB6 execution.
This PR also fixes a bug in the way `class_values` were populated in fit multiple's summary table; it would fail when the class_values had `NULL` values in the array.

NOTE: For the prior versions of GPDB6, where this GUC doesn't exist, the DL queries will fail with `memory alloc` error for those versions.  

- [X] Add the module name, JIRA# to PR/commit and description.
- [X] Add tests for the change. 

