### PR TITLE
Revert "Allocator: Remove 16-byte alignment in GPDB 6"

### DIFF
--- a/src/ports/greenplum/dbconnector/dbconnector.hpp
+++ b/src/ports/greenplum/dbconnector/dbconnector.hpp
@@ -32,23 +32,6 @@ extern "C" {
 
 #include "Compatibility.hpp"
 
-#if GP_VERSION_NUM >= 60000
-    // MADlib aligns the pointers returned by palloc() to 16-byte boundaries
-    // (see Allocator_impl.hpp). This is done to allow Eigen vectorization  (see
-    // http://eigen.tuxfamily.org/index.php?title=FAQ#Vectorization for more
-    // info).  This vectorization has to be explicitly disabled if pointers are
-    // not 16-byte aligned. Further, the pointer realignment invalidates a
-    // header that palloc creates just prior to the pointer address.  Greenplum
-    // after commit f62bd1c fails due to this invalid header.  Hence, the
-    // pointer realignment and Eigen vectorization is disabled below for
-    // Greenplum 6 and above.
-
-    // See http://eigen.tuxfamily.org/dox/group__TopicUnalignedArrayAssert.html
-    // for steps to disable vectorization
-    #define EIGEN_DONT_VECTORIZE
-    #define EIGEN_DISABLE_UNALIGNED_ARRAY_ASSERT
-#endif
-
 #include "../../postgres/dbconnector/dbconnector.hpp"
 
 #endif // defined(MADLIB_GREENPLUM_DBCONNECTOR_HPP)

--- a/src/ports/postgres/dbconnector/Allocator_impl.hpp
+++ b/src/ports/postgres/dbconnector/Allocator_impl.hpp
@@ -211,7 +211,7 @@ template <dbal::ZeroMemory ZM>
 inline
 void *
 Allocator::internalPalloc(size_t inSize) const {
-#if MAXIMUM_ALIGNOF >= 16  || defined EIGEN_DONT_VECTORIZE
+#if MAXIMUM_ALIGNOF >= 16
     return (ZM == dbal::DoZero) ? palloc0(inSize) : palloc(inSize);
 #else
     if (inSize > std::numeric_limits<size_t>::max() - 16)
@@ -221,7 +221,7 @@ Allocator::internalPalloc(size_t inSize) const {
     const size_t size = inSize + 16;
     void *raw = (ZM == dbal::DoZero) ? palloc0(size) : palloc(size);
     return makeAligned(raw);
-#endif  // MAXIMUM_ALIGNOF >= 16
+#endif
 }
 
 /**
@@ -243,7 +243,7 @@ template <dbal::ZeroMemory ZM>
 inline
 void *
 Allocator::internalRePalloc(void *inPtr, size_t inSize) const {
-#if MAXIMUM_ALIGNOF >= 16 || defined EIGEN_DONT_VECTORIZE
+#if MAXIMUM_ALIGNOF >= 16
     return repalloc(inPtr, inSize);
 #else
     if (inSize > std::numeric_limits<size_t>::max() - 16) {
@@ -262,7 +262,7 @@ Allocator::internalRePalloc(void *inPtr, size_t inSize) const {
     }
 
     return makeAligned(raw);
-#endif // MAXIMUM_ALIGNOF >= 16
+#endif
 }
 
 /**
@@ -298,7 +298,7 @@ Allocator::makeAligned(void *inPtr) const {
 inline
 void *
 Allocator::unaligned(void *inPtr) const {
-#if MAXIMUM_ALIGNOF >= 16 || defined EIGEN_DONT_VECTORIZE
+#if MAXIMUM_ALIGNOF >= 16
     return inPtr;
 #else
     return (*(reinterpret_cast<void**>(inPtr) - 1));


### PR DESCRIPTION
This reverts commit d62e5516bc6741beee18678da1b9b3e6cc95cdcf.

GPDB6 updated the finalize_windowaggregate function to use
MemoryContextContainsGenericAllocation instead of MemoryContextContains
during the PG9.3 merge. This change removes the issue the aforementioned
commit intended to fix.

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [ ] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

