### PR TITLE
C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,11 @@ if(CMAKE_COMPILER_IS_GNUCXX)
         set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
     endif(APPLE)
 elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
-    set(CMAKE_CXX_FLAGS "-stdlib=libstdc++")
+if (CXX11)
+    set(CMAKE_CXX_FLAGS "-stdlib=libc++ -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=1")
+else (CXX11)
+    set(CMAKE_CXX_FLAGS "-stdlib=libstdc++ -D_GLIBCXX_USE_CXX11_ABI=0")
+endif(CXX11)
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
 # force a `m4_' prefix to all builtins

--- a/ReadMe_Build.txt
+++ b/ReadMe_Build.txt
@@ -179,6 +179,14 @@ root directory) for more options, after having run `cmake` the first time.
     flag is set to 'True', we will create an RPM instead. Note that
     package alien must be installed for this to work.
 
+- `CXX11` (default: *empty*)
+
+    Compile with C++11 compatibility.  This may be required for building
+    on newer platforms which don't come with support for pre-2011 C++
+    standards.  For example, MacOSX >= 10.13 (XCode >= 10.x).  This option
+    is also required for Boost >= 1.65 to work, as recent versions of
+    Boost have also dropped support for older C++ standards.
+
 Debugging
 =========
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,31 +106,22 @@ set(MAD_MODULE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/modules)
 
 # -- Third-party dependencies: Find or download Boost --------------------------
 
+# set(Boost_INCLUDE_DIRS "/usr/local/opt/boost/include")
 find_package(Boost 1.47)
 if(Boost_FOUND)
     # We use BOOST_ASSERT_MSG, which only exists in Boost 1.47 and later.
-    # Unfortunately, the FindBoost module seems to be broken with respect to
-    # version checking, so we will set Boost_FOUND to FALSE if the version is
-    # too old.
-    if(Boost_VERSION LESS 104600)
-        message(STATUS "No sufficiently recent version (>= 1.47) of Boost was found. Will download.")
+    if(Boost_MACRO_VERSION LESS 104700)
         set(Boost_FOUND FALSE)
-    endif(Boost_VERSION LESS 104600)
-
-    # BOOST 1.65.0 removed the TR1 library which is required by MADlib till
-    # C++11 is completely supported. Hence, we force download of a compatible
-    # version if existing Boost is 1.65 or greater. FIXME: This should be
-    # removed when TR1 dependency is removed.
-    if(NOT Boost_VERSION LESS 106500)
-        message(STATUS
-                "Incompatible Boost version (>= 1.65) found. Will download a compatible version.")
-        set(Boost_FOUND FALSE)
-    endif(NOT Boost_VERSION LESS 106500)
+    else(Boost_MACRO_VERSION LESS 104700)
+        message(STATUS "Actual version of Boost found: ${Boost_VERSION_STRING}")
+    endif(Boost_MACRO_VERSION LESS 104700)
 endif(Boost_FOUND)
 
 if(Boost_FOUND)
+    message(STATUS "Boost include directory ${Boost_INCLUDE_DIRS}")
     include_directories(${Boost_INCLUDE_DIRS})
 else(Boost_FOUND)
+    message(STATUS "No sufficiently recent version (>= 1.47) of Boost was found. Will download.")
     ExternalProject_Add(EP_boost
         PREFIX ${MAD_THIRD_PARTY}
         DOWNLOAD_DIR ${MAD_THIRD_PARTY}/downloads

--- a/src/dbal/DynamicStruct_impl.hpp
+++ b/src/dbal/DynamicStruct_impl.hpp
@@ -425,7 +425,7 @@ DynamicStruct<Derived, Container, Mutable>::bindToStream(
     static_cast<Derived*>(this)->bind(inStream);
 
     if (mSizeIsLocked)
-        inStream.template seek(begin + size, std::ios_base::beg);
+        inStream.seek(begin + size, std::ios_base::beg);
     else
         inStream.template seek<ByteStream_type::maximumAlignment>(0,
             std::ios_base::cur);

--- a/src/modules/sample/WeightedSample_impl.hpp
+++ b/src/modules/sample/WeightedSample_impl.hpp
@@ -7,6 +7,9 @@
 #ifndef MADLIB_MODULES_SAMPLE_WEIGHTED_SAMPLE_IMPL_HPP
 #define MADLIB_MODULES_SAMPLE_WEIGHTED_SAMPLE_IMPL_HPP
 
+#if _GLIBCXX_USE_CXX11_ABI
+#include <random>
+#else
 #include <boost/tr1/random.hpp>
 
 // Import TR1 names (currently used from boost). This can go away once we make
@@ -14,6 +17,7 @@
 namespace std {
     using tr1::bernoulli_distribution;
 }
+#endif // _GNUCXX_USE_CXX11_ABI
 
 namespace madlib {
 

--- a/src/ports/postgres/dbconnector/NativeRandomNumberGenerator_impl.hpp
+++ b/src/ports/postgres/dbconnector/NativeRandomNumberGenerator_impl.hpp
@@ -41,7 +41,7 @@ NativeRandomNumberGenerator::operator()() {
  * @brief Return tight lower bound on the set of all values returned by
  *     <tt>operator()</tt>
  */
-inline
+inline CONST_EXPR
 NativeRandomNumberGenerator::result_type
 NativeRandomNumberGenerator::min() {
     return 0.0;
@@ -57,7 +57,7 @@ NativeRandomNumberGenerator::min() {
  * shall not change during the lifetime of the object."
  * http://www.boost.org/doc/libs/1_50_0/doc/html/boost_random/reference.html
  */
-inline
+inline CONST_EXPR
 NativeRandomNumberGenerator::result_type
 NativeRandomNumberGenerator::max() {
     return 1.0;

--- a/src/ports/postgres/dbconnector/NativeRandomNumberGenerator_proto.hpp
+++ b/src/ports/postgres/dbconnector/NativeRandomNumberGenerator_proto.hpp
@@ -22,13 +22,20 @@ namespace postgres {
  */
 class NativeRandomNumberGenerator {
 public:
+
+#if _GLIBCXX_USE_CXX11_ABI
+    typedef long long result_type;
+#define CONST_EXPR constexpr
+#else
     typedef double result_type;
+#define CONST_EXPR
+#endif
 
     NativeRandomNumberGenerator();
     void seed(result_type inSeed);
     result_type operator()();
-    static result_type min();
-    static result_type max();
+    static CONST_EXPR result_type min();
+    static CONST_EXPR result_type max();
 };
 
 } // namespace postgres

--- a/src/ports/postgres/dbconnector/dbconnector.hpp
+++ b/src/ports/postgres/dbconnector/dbconnector.hpp
@@ -85,9 +85,11 @@ extern "C" {
 #include <boost/type_traits/remove_cv.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/utility/enable_if.hpp>
+#if !_GLIBCXX_USE_CXX11_ABI
 #include <boost/tr1/array.hpp>
 #include <boost/tr1/functional.hpp>
 #include <boost/tr1/tuple.hpp>
+#endif // _GLIBCXX_USE_CXX11_ABI
 #include <algorithm>
 #include <complex>
 #include <limits>
@@ -99,6 +101,7 @@ extern "C" {
 #include <utils/Reference.hpp>
 #include <utils/Math.hpp>
 
+#if !_GLIBCXX_USE_CXX11_ABI
 namespace std {
     // Import names from TR1.
 
@@ -111,6 +114,7 @@ namespace std {
     using tr1::tie;
     using tr1::tuple;
 }
+#endif // _GLIBCXX_USE_CXX11_ABI
 
 #if !defined(NDEBUG) && !defined(EIGEN_NO_DEBUG)
 #define eigen_assert(x) \


### PR DESCRIPTION
    Add conditional support for C++11 compilers.

    This allows madlib to be compiled on OSX with libc++ and
    other C++11 compilers, and drops the requirement that an old
    version of Boost be used.
    (Previously we required Boost < 1.65 to compile.)

    On OSX, this gets rid of the need to use either an old version
    of MacOS (Sierra or earlier), download an old version of
    XCode (9.x or earlier), or compile with gcc (the last of which
    is unacceptable for a release version, as it means it will not
    run on MacOS without the user manually installing 3rd party
    libraries).