### PR TITLE
DL: [AutoML] Set plan_cache_mode when calling fit multiple model

### DIFF
--- a/src/ports/postgres/modules/deep_learning/madlib_keras_automl.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_automl.py_in
@@ -342,7 +342,8 @@ class KerasAutoML():
                 i_dict[k['mst_key']] += 1
             self.warm_start = int(i != 0)
             mcf = self.metrics_compute_frequency if self._is_valid_metrics_compute_frequency(num_iterations) else None
-            model_training = FitMultipleModel(self.schema_madlib, self.source_table, AutoMLSchema.TEMP_OUTPUT_TABLE,
+            with SetGUC("plan_cache_mode", "force_generic_plan"):
+                model_training = FitMultipleModel(self.schema_madlib, self.source_table, AutoMLSchema.TEMP_OUTPUT_TABLE,
                                               AutoMLSchema.TEMP_MST_TABLE, num_iterations, self.use_gpus,
                                               self.validation_table, mcf, self.warm_start, self.name, self.description)
             self.update_model_output_table(model_training)


### PR DESCRIPTION
JIRA: MADLIB-1447

There is a known issue when calling fit multiple model with huge model
weights(JIRA: MADLIB-1414). The fix for that issue was to set
`plan_cache_mode` guc in gpdb6 to `force_generic_plan`. For automl,
since we directly call madlib_keras_fit_multiple_model from the within
the automl function, we need to set the GUC plan_cache_mode when calling
it.

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [ ] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

