### PR TITLE
utilities/debug.py_in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ auto
 eproject.cfg
 *.project.vim
 .vscode
+.idea

--- a/src/ports/postgres/dbconnector/FunctionHandle_impl.hpp
+++ b/src/ports/postgres/dbconnector/FunctionHandle_impl.hpp
@@ -159,7 +159,7 @@ FunctionHandle::invoke(AnyType &args) {
         funcPtrCallInfo.args[i].value = args[i].getAsDatum(&funcPtrCallInfo,
             mFuncInfo->getArgumentType(i));
         funcPtrCallInfo.args[i].isnull = args[i].isNull();
-        elog(WARNING, "funcPtrCallInfo.args[i].value %d funcPtrCallInfo.args[i].isnull %d", funcPtrCallInfo.args[i].value, funcPtrCallInfo.args[i].isnull);
+        elog(WARNING, "funcPtrCallInfo.args[i].value %lu funcPtrCallInfo.args[i].isnull %d", funcPtrCallInfo.args[i].value, funcPtrCallInfo.args[i].isnull);
     }
 #else
     for (uint16_t i = 0; i < funcPtrCallInfo.nargs; ++i) {

--- a/src/ports/postgres/modules/utilities/debug.py_in
+++ b/src/ports/postgres/modules/utilities/debug.py_in
@@ -58,12 +58,53 @@ def print_mst_keys(table, label, force=False):
         dist_key = r[dist_key_col]
         plpy_orig.info("|_MST_KEYS_{label}|{mst_key}|{seg_id}|{dist_key}|{table}".format(**locals()))
 
+class prep_entry:
+    def __init__(self, sql, args, kwargs):
+        self.sql = sql
+        self.args = args
+        self.kwargs = kwargs
+
+def plpy_prepare(*args, **kwargs):
+    """ debug.plpy.prepare(sql, ..., force=False)
+
+        If you want debug.plpy.execute() to be able
+        to display the query and/or plan for a
+        prepared query, you must call this function
+        (as debug.plpy.prepare() ) in place of
+        regular plpy.prepare().  Otherwise the execute
+        wrapper will not have access to the query string,
+        so you will only get timing info (no plan).
+    """ 
+    force = False
+    if 'force' in kwargs:
+        force = kwargs['force']
+        del kwargs['force']
+
+    plpy = plpy_orig # override global plpy,
+                     # to avoid infinite recursion
+
+    if not (plpy_execute_enabled or force):
+        return plpy.prepare(*args, **kwargs)
+
+    if len(args) < 1:
+        raise TypeError('debug.plpy.execute() takes at least 1 parameter, 0 passed')
+    elif type(sql) != str:
+        raise TypeError('debug.plpy.prepare() takes a str as its 1st parameter')
+
+    sql = args[0]
+    plpy.info(sql)
+
+    plan = plpy_orig.prepare(*args, **kwargs)
+    prep = prep_entry(sql, args[1:], kwargs)
+    plpy_wrapper.prepared_queries[plan] = prep
+    return plan
+
 plpy_execute_enabled = False
 def plpy_execute(*args, **kwargs):
-    """ debug.plpy.execute(sql, ..., force=False)
+    """ debug.plpy.execute(q, ..., force=False)
 
-        Replace plpy.execute(sql, ...) with
-        debug.plpy.execute(sql, ...) to debug
+        Replace plpy.execute(q, ...) with
+        debug.plpy.execute(q, ...) to debug
         a query.  Shows the query itself, the
         EXPLAIN of it, and how long the query
         takes to execute.
@@ -81,17 +122,32 @@ def plpy_execute(*args, **kwargs):
         return plpy.execute(*args, **kwargs)
 
     if len(args) > 0:
-        sql = args[0]
+        q = args[0]
     else:
         raise TypeError('debug.plpy.execute() takes at least 1 parameter, 0 passed')
 
-    if type(sql) == str: # can't print if a PLyPlan object
-        plpy.info(sql)
+    prep = None
+    if type(q) == str:
+        plpy.info(q)
+        sql = q
+    elif repr(type(q)) == "<type 'PLyPlan'>":
+        if q in plpy_wrapper.prepared_queries:
+            prep = plpy_wrapper.prepared_queries[q]
+            sql = prep.sql
+        else:
+            sql = q
+    else:
+        raise TypeError(
+            "First arg of debug.plpy.execute() must be str or <type 'PLyPlan'>, got {}".format(type(q))
+        )
 
-        # Print EXPLAIN of sql command
-        res = plpy.execute("EXPLAIN " + sql, *args[1:], **kwargs)
-        for r in res:
-            plpy.info(r['QUERY PLAN'])
+    # Print EXPLAIN of sql command
+    explain_query = "EXPLAIN" + sql
+    if prep:
+        explain_query = plpy.prepare(explain_query, *prep.args, **prep.kwargs)
+    res = plpy.execute(explain_query, *args[1:], **kwargs)
+    for r in res:
+        plpy.info(r['QUERY PLAN'])
 
     # Run actual sql command, with timing
     start = time.time()
@@ -139,7 +195,12 @@ def plpy_debug(*args, **kwargs):
     else:
         plpy_orig.debug(*args, **kwargs)
 
-class plpy:
+class plpy_wrapper:
+    prepare = staticmethod(plpy_prepare)
     execute = staticmethod(plpy_execute)
     info = staticmethod(plpy_info)
     debug = staticmethod(plpy_debug)
+
+    prepared_queries = dict()
+
+plpy = plpy_wrapper

--- a/src/ports/postgres/modules/utilities/debug.py_in
+++ b/src/ports/postgres/modules/utilities/debug.py_in
@@ -71,8 +71,8 @@ def plpy_execute(*args, **kwargs):
 
     force = False
     if 'force' in kwargs:
+        force = kwargs['force']
         del kwargs['force']
-        force = force['force']
 
     plpy = plpy_orig # override global plpy,
                      # to avoid infinite recursion
@@ -114,8 +114,8 @@ def plpy_info(*args, **kwargs):
 
     force = False
     if 'force' in kwargs:
-        del kwargs['force']
         force = kwargs['force']
+        del kwargs['force']
 
     if plpy_info_enabled or force:
         plpy_orig.info(*args, **kwargs)
@@ -131,8 +131,8 @@ def plpy_debug(*args, **kwargs):
 
     force = False
     if 'force' in kwargs:
-        del kwargs['force']
         force = kwargs['force']
+        del kwargs['force']
 
     if plpy_debug_enabled or force:
         plpy_orig.info(*args, **kwargs)

--- a/src/ports/postgres/modules/utilities/debug.py_in
+++ b/src/ports/postgres/modules/utilities/debug.py_in
@@ -1,0 +1,145 @@
+import plpy as plpy_orig
+import time
+from deep_learning.madlib_keras_model_selection import ModelSelectionSchema
+from deep_learning.madlib_keras_helper import DISTRIBUTION_KEY_COLNAME
+
+mst_key_col = ModelSelectionSchema.MST_KEY
+dist_key_col = DISTRIBUTION_KEY_COLNAME
+
+start_times = dict()
+timings_enabled = False
+
+def start_timing(msg, force=False):
+    if timings_enabled or force:
+        start_times[msg] = time.time()
+        plpy_orig.info("|_{}_time_HDR|Elapsed (s)|Current|Current (s)|Start|Start (s)|".format(msg))
+
+def print_timing(msg, force=False):
+    if timings_enabled or force:
+        try:
+            start_time = start_times[msg]
+        except:
+            raise Exception(
+                "print_timing({msg}) called with no start_timing({msg})!".format(msg=msg)
+            )
+        current_time = time.time() 
+        plpy_orig.info(
+            '|_{0}_time|{1}|{2}|{3}|{4}|{5}'.format(
+                msg,
+                current_time - start_time,
+                time.ctime(current_time),
+                current_time,
+                time.ctime(start_time),
+                start_time
+            )
+        )
+
+mst_keys_enabled = False
+def print_mst_keys(table, label, force=False):
+    if not (mst_keys_enabled or force):
+        return
+
+    res = plpy_orig.execute("""
+        SELECT gp_segment_id AS seg_id,
+               {mst_key_col},
+               {dist_key_col}
+        FROM {table} ORDER BY {dist_key_col}
+    """.format(dist_key_col=dist_key_col,
+               table=table,
+               mst_key_col=mst_key_col))
+
+    plpy_orig.info("|_MST_KEYS_{label}_HDR|mst_key|seg_id|dist_key|table".format(**locals()))
+    if not res:
+        plpy_orig.error("{table} is empty!  Aborting".format(table=table))
+
+    for r in res:
+        seg_id = r['seg_id']
+        mst_key = r['mst_key']
+        dist_key = r[dist_key_col]
+        plpy_orig.info("|_MST_KEYS_{label}|{mst_key}|{seg_id}|{dist_key}|{table}".format(**locals()))
+
+plpy_execute_enabled = False
+def plpy_execute(*args, **kwargs):
+    """ debug.plpy.execute(sql, ..., force=False)
+
+        Replace plpy.execute(sql, ...) with
+        debug.plpy.execute(sql, ...) to debug
+        a query.  Shows the query itself, the
+        EXPLAIN of it, and how long the query
+        takes to execute.
+    """
+
+    force = False
+    if 'force' in kwargs:
+        del kwargs['force']
+        force = force['force']
+
+    plpy = plpy_orig # override global plpy,
+                     # to avoid infinite recursion
+
+    if not (plpy_execute_enabled or force):
+        return plpy.execute(*args, **kwargs)
+
+    if len(args) > 0:
+        sql = args[0]
+    else:
+        raise TypeError('debug.plpy.execute() takes at least 1 parameter, 0 passed')
+
+    if type(sql) == str: # can't print if a PLyPlan object
+        plpy.info(sql)
+
+        # Print EXPLAIN of sql command
+        res = plpy.execute("EXPLAIN " + sql, *args[1:], **kwargs)
+        for r in res:
+            plpy.info(r['QUERY PLAN'])
+
+    # Run actual sql command, with timing
+    start = time.time()
+    res = plpy.execute(*args, **kwargs)
+
+    # Print how long execution of query took
+    plpy.info("Query took {0}s".format(time.time() - start))
+    if res:
+        plpy.info("Query returned {} row(s)".format(len(res)))
+    else:
+        plpy.info("Query returned 0 rows")
+    return res
+
+plpy_info_enabled = False
+def plpy_info(*args, **kwargs):
+    """ plpy_info(..., force=False)
+
+      plpy.info() if enabled, otherwise do nothing   
+    """
+
+    force = False
+    if 'force' in kwargs:
+        del kwargs['force']
+        force = kwargs['force']
+
+    if plpy_info_enabled or force:
+        plpy_orig.info(*args, **kwargs)
+
+plpy_debug_enabled = False
+def plpy_debug(*args, **kwargs):
+    """ debug.plpy.debug(..., force=False)
+
+        Behaves like plpy.debug() if disabled (printing only
+        if DEBUG level is set high enough), but becomes a
+        plpy.info() if enabled.
+    """
+
+    force = False
+    if 'force' in kwargs:
+        del kwargs['force']
+        force = kwargs['force']
+
+    if plpy_debug_enabled or force:
+        plpy_orig.info(*args, **kwargs)
+    else:
+        plpy_orig.debug(*args, **kwargs)
+
+class plpy:
+    execute = staticmethod(plpy_execute)
+    info = staticmethod(plpy_info)
+    debug = staticmethod(plpy_debug)

--- a/src/ports/postgres/modules/utilities/utilities.py_in
+++ b/src/ports/postgres/modules/utilities/utilities.py_in
@@ -21,29 +21,8 @@ from validate_args import unquote_ident
 from validate_args import drop_tables
 import plpy
 
-
 m4_changequote(`<!', `!>')
 
-def plpy_execute_debug(sql, *args, **kwargs):
-    """ Replace plpy.execute(sql, ...) with
-        plpy_execute_debug(sql, ...) to debug
-        a query.  Shows the query itself, the
-        EXPLAIN of it, and how long the query
-        takes to execute.
-    """
-    plpy.info(sql)  # Print sql command
-
-    # Print EXPLAIN of sql command
-    res = plpy.execute("EXPLAIN " + sql, *args)
-    for r in res:
-        plpy.info(r['QUERY PLAN'])
-
-    # Run actual sql command, with timing
-    start = time.time()
-    plpy.execute(sql, *args)
-
-    # Print how long execution of query took
-    plpy.info("Query took {0}s".format(time.time() - start))
 
 def has_function_properties():
     """ __HAS_FUNCTION_PROPERTIES__ variable defined during configure """


### PR DESCRIPTION
There are no functional changes in this PR, this is just for making MADlib development and performance profiling easier.

1. Adds a new collection of utility functions (`utilities/debug.py_in`), to aid with the debugging process.

The main purpose of this new debug module is to make it easy to
    turn on or off certain kinds of debug messages, without needing to make lots of temporary changes to the code.
    There is a frequent debugging pattern which has kept repeating when it comes to performance issues:
       - We find a bug, for example something is running slowly or filling up the disk or memory.  But we don't know where in a long sequence of SQL queriers it's happening.
       - We add lots of different extra lines of code to print out timing information after each query is sent, as well as what the queries look like after all python formatting params have been filled in, what their EXPLAIN plans look like, and sometimes other things... like which models are on which segments after each hop (for the case of `madlib_keras_fit_mutliple`).
       - We check these changes in on a temporary branch, and spend a while investigating, eventually getting a good picture of where the performance bottleneck is.  As we go along, often the types of information getting printed get more complicated and spread out through the code, and these commits get all mixed up with simultaneously commits we're making to actually fix the bug.
        - After a series of tweaks to different stages of the UDF implementation, the performance profiling looks good again, and we declare the bug fixed.
        - Then we sift through a complicated mess of commits, stripping out any debugging changes so they don't get merged in to the production code.
        - Soon after, we find another bug, and now we've got to start putting some debugging statements back in, little by little.  Eventually the whole cycle repeats, and we've done and undone a lot of work many times at this point.

To improve the situation, we can build any of the profiling and debugging statements right into the production code, in a way where it can be easily enabled or disabled simply by changing a single line of code.  (In the future, we could even make it a compiler option.)

Hopefully this will speed up the process of tracking down performance bottlenecks and reduce the amount of redundant work repeated.

    debug.start_timing(msg)`
          Starts a timer.  msg is any name or short description of the timer which can be grepped for later.  Multiple timers can be running simultaneously, and they won't interfere with each other as long as they are each named differently.  This will print a header with column names that can be matched up later with the actual timings as they get printed.

    debug.print_timing(msg, force=False)` :
           Used to print timing information for different stages of a python UDF (for example, madlib_keras_fit_multiple()).  This will print (or not print) how many seconds have elapsed since this particular timer (associate with msg param) was started. If enabled, it will print a nicely formatted banner with information in different columns that can be easily extracted from logs with the grep and cut commands.  For example, we could use it to break down the current run_training() function into _hop_time_, _uda_time_, _truncate_time_, _copy_time_, and _delete_time_.  I'm not including this example yet because it's on a branch with a major refactor and these particular stages no longer line up.  (Refactor will be raised as a separate PR and call these functions with names appropriate for the new stages.)

      Enable all timing messages in a source file (just after debug module has been imported):
         debug.timings_enabled = True

      Enable a single call to debug.print_timings()
         by passing force=True.  Will print even if
         debug.timings_enabled is False

    debug.print_mst_keys(force=False) :
        If enabled, prints a map between mst_keys and seg_id's as the mst_keys
        hop around from segment to segment... to verify correct
        MOP behavior.

    debug.plpy.execute(query, ..., force=False)

        If enabled, prints query, EXPLAIN ANALYZE, and timing of a query
        while executing it.  Otherwise, just runs the query with plpy.execute(query, ...)

    debug.plpy.info(msg,..., force=False):
       Calls plpy.info(msg, ...) if enabled.
       Otherwise, does nothing.

    debug.plpy.debug(msg, ..., force=False):
        Behaves like plpy.debug(msg, ...) if disabled (printing only
        if DEBUG level is set high enough), but becomes a
        plpy.info() if enabled.

2. One minor fix to silence a warning message that started showing up for me recently (I think when I upgraded from pg9 to pg12).
