### PR TITLE
Prevent an "integer out of range" exception in linear regression train

### DIFF
--- a/src/ports/postgres/modules/regress/linear.py_in
+++ b/src/ports/postgres/modules/regress/linear.py_in
@@ -180,7 +180,7 @@ def linregr_train(schema_madlib, source_table, out_table,
                     , '{out_table}'::varchar              as out_table
                     , $__madlib__${dependent_varname}$__madlib__$::varchar      as dependent_varname
                     , $__madlib__${independent_varname}$__madlib__$::varchar    as independent_varname
-                    , {num_rows_processed}::integer       as num_rows_processed
+                    , {num_rows_processed}::BIGINT       as num_rows_processed
                     , {num_rows_skipped}::integer         as num_missing_rows_skipped
                     , {grouping_col}::text                as grouping_col
             """.format(out_table=out_table, source_table=source_table,


### PR DESCRIPTION
### Module name: Linear-Regression

### JIRA: MADlib-1460

### Description:

Linear regression training results in 2 output tables (**neither are optional**): 

The **primary** output table, that includes the computed coefficients.
A **summary** output table, that contains a single line.

#### Scenario

Running the linear regression training in postgresql on an input table which has **more than 2^31 records** within it (even if a grouping column is specified), fails due to an "**integer out of range**" exception.

#### Source

**The summary table** has a column that stores **the total number of records** involved in the computation. The column's data type is a **singed integer**. However, the total number of records is computed as a **BIGINT**. Therefore, when the total number of records in the input table is beyond the range of a signed integer (i.e., 2^31), an "integer out of range" exception is thrown.

### Solution

A simple solution is to change the data type of the column from a **signed integer** into a **BIGINT**. 

### Test

We have executed the linear regression training function with and without the suggested modification on an input table having between 2^31-2^32 records. Without the modification, an integer out of range exception was thrown. After modifying the code as suggested, it worked perfectly. 
