### PR TITLE
Fix some C++11 issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,32 @@ if(NOT CMAKE_BUILD_TYPE)
       FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 
+# The C++11 standard overlaps a lot with older versions of Boost.
+# So before deciding what standard to use for the whole project, we
+#  first detect Boost to see what version is on the system.
+#
+# C++11 is required for recent versions of Boost but will cause problems
+# for older versions of Boost.  Therefore, we detect it here intstead of
+# in src/CMakeLists.txt where the other 3rd party libraries are detected.
+#
+find_package(Boost)
+if(Boost_FOUND)
+    # We use BOOST_ASSERT_MSG, which only exists in Boost 1.47 and later.
+    if(Boost_VERSION_MACRO LESS 104700)
+        message(STATUS "Found Boost ${Boost_VERSION_STRING}, but too old for MADlib")
+        set(Boost_FOUND FALSE)
+    elseif(CXX11 AND (Boost_VERSION_MACRO LESS 106500))
+        message(STATUS "Found Boost ${Boost_VERSION_STRING}, but too old for C++11")
+        set(Boost_FOUND FALSE)
+    else()
+        message(STATUS "Found Boost ${Boost_VERSION_STRING}")
+        if(106500 LESS Boost_VERSION_MACRO)
+            message(STATUS "Auto-enabling -DCXX11, because Boost >= v1.65 requires C++11")
+            set(CXX11 TRUE)
+        endif(106500 LESS Boost_VERSION_MACRO)
+    endif()
+endif(Boost_FOUND)
+
 if(CMAKE_COMPILER_IS_GNUCC)
     # Let's store the gcc version in a variable
     execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
@@ -70,9 +96,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
     # http://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_02_01_01
     # We specify that we are POSIX.1-2001 compliant and XSI-conforming. We only
     # need to specify _XOPEN_SOURCE as _POSIX_C_SOURCE will be set implicitly.
-    set(CMAKE_C_FLAGS "-std=c99 -D_GLIBCXX_USE_CXX11_ABI=0 -pedantic -Wall -Wextra -Wno-clobbered -D_XOPEN_SOURCE=600"
-        CACHE STRING
-        "Flags used by the compiler during all build types." FORCE)
+    set(CMAKE_C_FLAGS "-pedantic -Wall -Wextra -Wno-clobbered -D_XOPEN_SOURCE=600")
     if((CMAKE_C_COMPILER_VERSION VERSION_EQUAL 5.0) OR (CMAKE_C_COMPILER_VERSION VERSION_GREATER 5.0))
         # Versions 5+ fail with the "Release" build type i.e. when optimization
         # level is -O3 or greater.
@@ -86,7 +110,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
 elseif(CMAKE_C_COMPILER_ID STREQUAL "SunPro")
     set(CMAKE_C_FLAGS "-xc99=%all")
 endif()
-
+ 
 if(CMAKE_COMPILER_IS_GNUCXX)
     # Let's store the gcc version in a variable
     execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
@@ -100,15 +124,29 @@ if(CMAKE_COMPILER_IS_GNUCXX)
         set(SSE_DISABLE_OPTIONS "-mno-sse2")
     endif()
 
-    # We need the 1998 standard plus amendments (ISO/IEC 14882:2003) plus TR1
-    # Unfortunately, we only get this with gnu++98
-    # Special notes:
-    # - long long is not part of the C++ 1998/2003 standard, but it is such a
-    # common (and useful) extension that we do not want to hear warnings about
-    # it.
-    set(CMAKE_CXX_FLAGS "-std=gnu++98 -D_GLIBCXX_USE_CXX11_ABI=0 -fdiagnostics-show-option -Wall -Wextra -pedantic -Wconversion -Wno-long-long -Wno-clobbered ${SSE_DISABLE_OPTIONS} -fstrict-aliasing"
-        CACHE STRING
-        "Flags used by the compiler during all build types." FORCE)
+    set(CMAKE_CXX_FLAGS "-fdiagnostics-show-option -Wall -Wextra -pedantic -Wconversion -Wno-long-long -Wno-clobbered ${SSE_DISABLE_OPTIONS} -fstrict-aliasing"
+    )
+    if (CXX11)
+        set(CMAKE_CXX_FLAGS "-std=gnu++11 ${CMAKE_CXX_FLAGS}"
+            CACHE STRING
+            "Flags used by the compiler during all build types." FORCE)
+        set(CMAKE_C_FLAGS "-std=gnu11 ${CMAKE_C_FLAGS}"
+            CACHE STRING
+            "Flags used by the compiler during all build types." FORCE)
+    else(CXX11)
+        # We need the 1998 standard plus amendments (ISO/IEC 14882:2003) plus TR1
+        # Unfortunately, we only get this with gnu++98
+        # Special notes:
+        # - long long is not part of the C++ 1998/2003 standard, but it is such a
+        # common (and useful) extension that we do not want to hear warnings about
+        # it.
+        set(CMAKE_CXX_FLAGS "-std=gnu++98 ${CMAKE_CXX_FLAGS}"
+            CACHE STRING
+            "Flags used by the compiler during all build types." FORCE)
+        set(CMAKE_C_FLAGS "-std=gnu99 ${CMAKE_C_FLAGS}"
+            CACHE STRING
+            "Flags used by the compiler during all build types." FORCE)
+    endif(CXX11)
 
     if((CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 5.0) OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0))
         # Versions 5+ fail with the "Release" build type i.e. when optimization
@@ -122,12 +160,24 @@ if(CMAKE_COMPILER_IS_GNUCXX)
         set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
     endif(APPLE)
 elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
-if (CXX11)
-    set(CMAKE_CXX_FLAGS "-stdlib=libc++ -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=1")
-else (CXX11)
-    set(CMAKE_CXX_FLAGS "-stdlib=libstdc++ -D_GLIBCXX_USE_CXX11_ABI=0")
-endif(CXX11)
+    if(CXX11)
+        set(CMAKE_CXX_FLAGS "-stdlib=libc++ -std=c++11"
+            CACHE STRING
+            "Flags used by the compiler during all build types." FORCE)
+    else(CXX11)
+        set(CMAKE_CXX_FLAGS "-stdlib=libstdc++"
+            CACHE STRING
+            "Flags used by the compiler during all build types." FORCE)
+    endif(CXX11)
 endif(CMAKE_COMPILER_IS_GNUCXX)
+
+if(CXX11)
+    add_definitions("-D_GLIBCXX_USE_CXX11_ABI=1")
+    # TODO: for recent cmake, add_compile_definitions("_GLIBCXX_USE_CXX11_ABI=1")
+else(CXX11)
+    add_definitions("-D_GLIBCXX_USE_CXX11_ABI=0")
+    # TODO: for recent cmake, add_compile_definitions("_GLIBCXX_USE_CXX11_ABI=0")
+endif(CXX11)
 
 # force a `m4_' prefix to all builtins
 if(FREEBSD)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,21 +34,25 @@ set(EIGEN_BASE_URL
 # running cmake:
 # "-DBOOST_TAR_SOURCE=/path/to/boost_x_x_x.tar.gz"
 
-set(BOOST_TAR_VERSION "1.61.0")
-set(BOOST_TAR_MD5 874805ba2e2ee415b1877ef3297bf8ad)
-
-string(REPLACE "." "_" _BOOST_TAR_VERSION_UNDERSCORES ${BOOST_TAR_VERSION})
-set(BOOST_TAR "boost_${_BOOST_TAR_VERSION_UNDERSCORES}.tar.gz")
-set(BOOST_URL "${SOURCEFORGE_BASE_URL}/boost/files/${BOOST_TAR}")
+if (CXX11)
+    set(BOOST_TAR_VERSION "1.75.0")  # If CXX11 is enabled, we can use latest version of Boost
+    set(BOOST_TAR_MD5 38813f6feb40387dfe90160debd71251)
+else(CXX11)
+    set(BOOST_TAR_VERSION "1.61.0")   # Most recent version that includes TR1 (necessary for old C++ compilers)
+    set(BOOST_TAR_MD5 874805ba2e2ee415b1877ef3297bf8ad)
+endif(CXX11)
+    string(REPLACE "." "_" _BOOST_TAR_VERSION_UNDERSCORES ${BOOST_TAR_VERSION})
+    set(BOOST_TAR "boost_${_BOOST_TAR_VERSION_UNDERSCORES}.tar.gz")
+    set(BOOST_URL "${SOURCEFORGE_BASE_URL}/boost/files/${BOOST_TAR}")
 
 if(NOT BOOST_TAR_SOURCE)
-    find_file(BOOST_TAR_SOURCE ${BOOST_TAR}
+    find_file(BOOST_TAR_SOURCE ${BOOST_TAR}  # If not user-specified, try finding in downloads dir
         PATHS ${MAD_THIRD_PARTY}/downloads)
-endif(NOT BOOST_TAR_SOURCE)
 
-if(NOT BOOST_TAR_SOURCE)
-    set(BOOST_TAR_SOURCE ${BOOST_URL})
-endif (NOT BOOST_TAR_SOURCE)
+    if (NOT BOOST_TAR_SOURCE)
+        set(BOOST_TAR_SOURCE ${BOOST_URL})   # If not found locally, download
+    endif()
+endif(NOT BOOST_TAR_SOURCE)
 
 # We always download Eigen (unless it is already present in
 # ${CMAKE_CURRENT_BINARY_DIR}/third_party/downloads). It is also possible to
@@ -104,19 +108,7 @@ set(MAD_MODULE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/modules)
 # try this at home.
 # ==============================================================================
 
-# -- Third-party dependencies: Find or download Boost --------------------------
-
-# set(Boost_INCLUDE_DIRS "/usr/local/opt/boost/include")
-find_package(Boost 1.47)
-if(Boost_FOUND)
-    # We use BOOST_ASSERT_MSG, which only exists in Boost 1.47 and later.
-    if(Boost_MACRO_VERSION LESS 104700)
-        set(Boost_FOUND FALSE)
-    else(Boost_MACRO_VERSION LESS 104700)
-        message(STATUS "Actual version of Boost found: ${Boost_VERSION_STRING}")
-    endif(Boost_MACRO_VERSION LESS 104700)
-endif(Boost_FOUND)
-
+# -- Third-party dependencies: Download the Boost if not previously detected
 if(Boost_FOUND)
     message(STATUS "Boost include directory ${Boost_INCLUDE_DIRS}")
     include_directories(${Boost_INCLUDE_DIRS})
@@ -134,7 +126,6 @@ else(Boost_FOUND)
     )
     include_directories(BEFORE SYSTEM ${MAD_THIRD_PARTY}/src/EP_boost)
 endif(Boost_FOUND)
-
 
 # -- Third-party dependencies: Download the C++ linear-algebra library Eigen ---
 ExternalProject_Add(EP_eigen

--- a/src/dbal/BoostIntegration/MathToolkit_impl.hpp
+++ b/src/dbal/BoostIntegration/MathToolkit_impl.hpp
@@ -49,22 +49,30 @@ user_domain_error(const char*, const char* inMessage, const T& inVal) {
     if (std::isnan(inVal))
         return std::numeric_limits<double>::quiet_NaN();
 
-    // The following line is taken from
-    // http://www.boost.org/doc/libs/1_49_0/libs/math/doc/sf_and_dist/html/math_toolkit/policy/pol_tutorial/user_def_err_pol.html
+#if _GLIBCXX_USE_CXX11_ABI
+    int prec = std::numeric_limits<T>::max_digits10;
+#else
+    // For older C++ standards, max_digits10 was not available so we have to convert manually
+    //  http://www.boost.org/doc/libs/1_49_0/libs/math/doc/sf_and_dist/html/math_toolkit/policy/pol_tutorial/user_def_err_pol.html
     int prec = 2 + (std::numeric_limits<T>::digits * 30103UL) / 100000UL;
+#endif // _GLIBCXX_USE_CXX11_ABI
 
-    std::string msg = (boost::format(inMessage)
+    throw std::domain_error(inMessage);
+
+     std:: string *msg = new std::string(
+        (boost::format(inMessage)
             % boost::io::group(std::setprecision(prec), inVal)
-        ).str();
-
+        ).str()
+     );
+ 
     // Some Boost error messages contain a space before the punctuation mark,
     // which we will remove.
-    std::string::iterator lastChar = msg.end() - 1;
-    std::string::iterator secondLastChar = msg.end() - 2;
+    std::string::iterator lastChar = msg->end() - 1;
+    std::string::iterator secondLastChar = msg->end() - 2;
     if (std::ispunct(*lastChar) && std::isspace(*secondLastChar))
-        msg.erase(secondLastChar, lastChar);
+        msg->erase(secondLastChar, lastChar);
 
-    throw std::domain_error(msg);
+    throw std::domain_error(*msg);
 }
 
 } // namespace policies

--- a/src/dbal/BoostIntegration/MathToolkit_impl.hpp
+++ b/src/dbal/BoostIntegration/MathToolkit_impl.hpp
@@ -57,14 +57,12 @@ user_domain_error(const char*, const char* inMessage, const T& inVal) {
     int prec = 2 + (std::numeric_limits<T>::digits * 30103UL) / 100000UL;
 #endif // _GLIBCXX_USE_CXX11_ABI
 
-    throw std::domain_error(inMessage);
-
      std:: string *msg = new std::string(
         (boost::format(inMessage)
             % boost::io::group(std::setprecision(prec), inVal)
         ).str()
      );
- 
+
     // Some Boost error messages contain a space before the punctuation mark,
     // which we will remove.
     std::string::iterator lastChar = msg->end() - 1;

--- a/src/dbal/Reference_proto.hpp
+++ b/src/dbal/Reference_proto.hpp
@@ -18,7 +18,7 @@ namespace dbal {
  * @tparam IsMutable Whether the target value is mutable. Note that \c IsMutable
  *     overrides any const-qualifier that \c T may contain.
  */
-template <typename T, bool IsMutable = boost::is_const<T>::value_type>
+template <typename T, bool IsMutable = boost::is_const<T>::value>
 class Ref {
 public:
     typedef const T val_type;

--- a/src/library.ver
+++ b/src/library.ver
@@ -36,6 +36,6 @@ VERS_1.0 {
 #	hiding those in namespace std.
 #
             std::*;
-
+            boost::*;
         };
 };

--- a/src/modules/lda/lda.cpp
+++ b/src/modules/lda/lda.cpp
@@ -210,9 +210,9 @@ AnyType lda_gibbs_sample::run(AnyType & args)
     if (!args.getUserFuncContext()) {
         ArrayHandle<int64_t> model64 = args[3].getAs<ArrayHandle<int64_t> >();
         if (model64.size() != model64_size) {
-            std::stringstream ss;
-            ss << "invalid dimension: model64.size() = " << model64.size();
-            throw std::invalid_argument(ss.str());
+            std::stringstream err_msg;
+            err_msg << "invalid dimension: model64.size() = " << model64.size();
+            throw std::invalid_argument(err_msg.str());
         }
         if (__min(model64) < 0) {
             throw std::invalid_argument("invalid topic counts in model");

--- a/src/modules/recursive_partitioning/DT_impl.hpp
+++ b/src/modules/recursive_partitioning/DT_impl.hpp
@@ -385,7 +385,7 @@ DecisionTree<Container>::impurity(const ColumnVector &stats) const {
         if (impurity_type == GINI){
             return 1 - proportions.cwiseProduct(proportions).sum();
         } else if (impurity_type == ENTROPY){
-            return proportions.unaryExpr(std::ptr_fun(computeEntropy)).sum();
+            return proportions.unaryExpr(std::function<double(const double&)>(computeEntropy)).sum();
         } else if (impurity_type == MISCLASS){
             return 1 - proportions.maxCoeff();
         } else

--- a/src/modules/recursive_partitioning/feature_encoding.cpp
+++ b/src/modules/recursive_partitioning/feature_encoding.cpp
@@ -164,7 +164,7 @@ dst_compute_entropy_final::run(AnyType &args){
     ColumnVector probs = state.cast<double>() / sum_of_dep_counts;
     // usage of unaryExpr with functor:
     // http://eigen.tuxfamily.org/dox/classEigen_1_1MatrixBase.html#a23fc4bf97168dee2516f85edcfd4cfe7
-    return -(probs.unaryExpr(std::ptr_fun(p_log2_p))).sum();
+    return -(probs.unaryExpr(std::function<double(const double&)>(p_log2_p))).sum();
 }
 // ------------------------------------------------------------
 

--- a/src/modules/sample/WeightedSample_impl.hpp
+++ b/src/modules/sample/WeightedSample_impl.hpp
@@ -7,17 +7,7 @@
 #ifndef MADLIB_MODULES_SAMPLE_WEIGHTED_SAMPLE_IMPL_HPP
 #define MADLIB_MODULES_SAMPLE_WEIGHTED_SAMPLE_IMPL_HPP
 
-#if _GLIBCXX_USE_CXX11_ABI
-#include <random>
-#else
-#include <boost/tr1/random.hpp>
-
-// Import TR1 names (currently used from boost). This can go away once we make
-// the switch to C++11.
-namespace std {
-    using tr1::bernoulli_distribution;
-}
-#endif // _GNUCXX_USE_CXX11_ABI
+#include <boost/random/bernoulli_distribution.hpp>
 
 namespace madlib {
 
@@ -113,7 +103,7 @@ WeightedSampleAccumulator<Container, T>::operator<<(
     // weight
     if (weight > 0.) {
         weight_sum += weight;
-        std::bernoulli_distribution success(weight / weight_sum);
+        boost::bernoulli_distribution<double> success(weight / weight_sum);
         // Note that a NativeRandomNumberGenerator object is stateless, so it
         // is not a problem to instantiate an object for each RN generation...
         NativeRandomNumberGenerator generator;

--- a/src/modules/stats/wilcoxon_signed_rank_test.cpp
+++ b/src/modules/stats/wilcoxon_signed_rank_test.cpp
@@ -68,9 +68,13 @@ wsr_test_transition::run(AnyType &args) {
         ? args[2].getAs<double>()
         : -1;
 
-    if (!std::isfinite(precision))
-        throw std::invalid_argument((boost::format(
-            "Precision must be finite, but got %1%.") % precision).str());
+
+    if (!std::isfinite(precision)) {
+        std::stringstream ss;
+        ss << "Precision must be finite, but got " << precision;
+        std::string *msg = new std::string(ss.str());
+        throw std::invalid_argument( *msg );
+    }
     else if (precision < 0)
         precision = value * std::numeric_limits<double>::epsilon();
 

--- a/src/ports/postgres/dbconnector/NativeRandomNumberGenerator_proto.hpp
+++ b/src/ports/postgres/dbconnector/NativeRandomNumberGenerator_proto.hpp
@@ -22,12 +22,11 @@ namespace postgres {
  */
 class NativeRandomNumberGenerator {
 public:
+    typedef double result_type;
 
 #if _GLIBCXX_USE_CXX11_ABI
-    typedef long long result_type;
 #define CONST_EXPR constexpr
 #else
-    typedef double result_type;
 #define CONST_EXPR
 #endif
 

--- a/src/ports/postgres/dbconnector/NewDelete.cpp
+++ b/src/ports/postgres/dbconnector/NewDelete.cpp
@@ -26,6 +26,11 @@
 // the search paths, which might point to a port-specific dbconnector.hpp
 #include <dbconnector/dbconnector.hpp>
 
+#ifdef _LIBCPP_COMPILER_CLANG
+#define _GLIBCXX_THROW(a) throw(a)
+#define _GLIBCXX_USE_NOEXCEPT noexcept
+#endif
+
 /**
  * @brief operator new for PostgreSQL. Throw on fail.
  *
@@ -34,7 +39,7 @@
  * that size.
  */
 void*
-operator new(std::size_t size) throw (std::bad_alloc) {
+operator new(std::size_t size) _GLIBCXX_THROW (std::bad_alloc) {
     return madlib::defaultAllocator().allocate<
         madlib::dbal::FunctionContext,
         madlib::dbal::DoNotZero,
@@ -42,7 +47,7 @@ operator new(std::size_t size) throw (std::bad_alloc) {
 }
 
 void*
-operator new[](std::size_t size) throw (std::bad_alloc) {
+operator new[](std::size_t size) _GLIBCXX_THROW (std::bad_alloc) {
     return madlib::defaultAllocator().allocate<
         madlib::dbal::FunctionContext,
         madlib::dbal::DoNotZero,
@@ -58,12 +63,12 @@ operator new[](std::size_t size) throw (std::bad_alloc) {
  * <tt>operator new(std::size_t)</tt>.
  */
 void
-operator delete(void *ptr) throw() {
+operator delete(void *ptr) _GLIBCXX_USE_NOEXCEPT {
     madlib::defaultAllocator().free<madlib::dbal::FunctionContext>(ptr);
 }
 
 void
-operator delete[](void *ptr) throw() {
+operator delete[](void *ptr) _GLIBCXX_USE_NOEXCEPT {
     madlib::defaultAllocator().free<madlib::dbal::FunctionContext>(ptr);
 }
 
@@ -75,7 +80,7 @@ operator delete[](void *ptr) throw() {
  * indication, instead of a bad_alloc exception.
  */
 void*
-operator new(std::size_t size, const std::nothrow_t&) throw() {
+operator new(std::size_t size, const std::nothrow_t&) _GLIBCXX_USE_NOEXCEPT {
     return madlib::defaultAllocator().allocate<
         madlib::dbal::FunctionContext,
         madlib::dbal::DoNotZero,
@@ -83,7 +88,7 @@ operator new(std::size_t size, const std::nothrow_t&) throw() {
 }
 
 void*
-operator new[](std::size_t size, const std::nothrow_t&) throw() {
+operator new[](std::size_t size, const std::nothrow_t&) _GLIBCXX_USE_NOEXCEPT {
     return madlib::defaultAllocator().allocate<
         madlib::dbal::FunctionContext,
         madlib::dbal::DoNotZero,
@@ -97,11 +102,11 @@ operator new[](std::size_t size, const std::nothrow_t&) throw() {
  * <tt>operator new(std::size_t, const std::nothrow_t&)</tt>.
  */
 void
-operator delete(void *ptr, const std::nothrow_t&) throw() {
+operator delete(void *ptr, const std::nothrow_t&) _GLIBCXX_USE_NOEXCEPT {
     madlib::defaultAllocator().free<madlib::dbal::FunctionContext>(ptr);
 }
 
 void
-operator delete[](void *ptr, const std::nothrow_t&) throw() {
+operator delete[](void *ptr, const std::nothrow_t&) _GLIBCXX_USE_NOEXCEPT {
     madlib::defaultAllocator().free<madlib::dbal::FunctionContext>(ptr);
 }


### PR DESCRIPTION
This is an assortment of bug fixes and improvements for our optional C++11 support.

It's mostly only relevant for those who were compiling by passing the -DCXX11 option manually.
Previously, that was the only way to compile with C++11, and it only affected clang (not gcc).
But in addition to fixing some bugs and warnings, this PR also improves the logic in the CMake
configuration files.  Previously if you had too recent a version of boost ( > v1.64) and the -DCXX11
option was not passed, it would just fail.  With the new behavior, it will auto-enable CXX11 support
if the version of Boost requires it.  It could still fail, if the compiler doesn't support C++11, but this
is no worse than the previous behavior.  If the option is passed manually and the detected Boost is
too old, it will still fail as before... but with a hint to upgrade Boost before trying again.
Also, if boost is not detected, the version it automatically downloads will now depend on whether 
-DCXX11 was passed.

This has still only been tested on OSX platform, but the option is now available for other platforms as
well (in case it works).

Critical bug fixes:

    - Use bernoulli_distribution from boost::, not stl:: or boost::TR1

    The TR1 sub namespace no longer exists in recent versions of boost.
    Previously, this was fixed by using the C++11 STL version if it's
    available, otherwise falling back on TR1.  But that didn't work
    (caused a crash) due to a slight incompatibility between the C++11 and
    the boost version.  The boost version still exists, just not under TR1--and
    we already use it elsewhere in the codebase, so this should be
    the cleanest fix.

    - Fix memory-corruption crash in std::domain_error(), by copying formatted
      string to memory allocated safely via postgres with palloc()

Non-critical fixes/improvements:

    - Convert ptr_fun() to function() to get rid of C++11 deprecation warning
     
    - src/dbal/Reference_proto.hpp:  Fix an error in the template definition
      of class Ref.  The default value for IsMutable should be the value true
      or false, not the type bool.  The only reason this wasn't generating
      compiler errors is that IsMutable happens to be passed explicitly in
      every place in the code where the template is instantiated--so the
      default was ignored.

    - Hide global boost symbols from external libraries
      We were already doing this for all STL symbols--for the same reasons,
      doing it for boost as well should make MADlib more robust when
      integrating with 3rd party libraries.