### PR TITLE
Kmeans: Fix auto kmeans tests

### DIFF
--- a/src/ports/postgres/modules/kmeans/test/kmeans.sql_in
+++ b/src/ports/postgres/modules/kmeans/test/kmeans.sql_in
@@ -87,7 +87,7 @@ COPY km_sample (pid, points) FROM stdin DELIMITER '|';
 
 -- Test kmeanspp_auto
 DROP TABLE IF EXISTS autokm_out,autokm_out_summary;
-SELECT * FROM kmeanspp_auto('kmeans_2d', 'autokm_out', 'array[x,y]', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
+SELECT * FROM kmeanspp_auto('kmeans_2d', 'autokm_out', 'position', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
                        'MADLIB_SCHEMA.avg', 20, 0.001, 0.1, 'elbow');
 
 SELECT assert(
@@ -96,7 +96,7 @@ SELECT assert(
 FROM autokm_out_summary;
 
 DROP TABLE IF EXISTS autokm_out,autokm_out_summary;
-SELECT * FROM kmeanspp_auto('kmeans_2d', 'autokm_out', 'array[x,y]', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
+SELECT * FROM kmeanspp_auto('kmeans_2d', 'autokm_out', 'position', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
                        'MADLIB_SCHEMA.avg', 20, 0.001, 0.1, 'silhouette');
 
 SELECT assert(
@@ -105,7 +105,7 @@ SELECT assert(
 FROM autokm_out_summary;
 
 DROP TABLE IF EXISTS autokm_out,autokm_out_summary;
-SELECT * FROM kmeanspp_auto('kmeans_2d', 'autokm_out', 'array[x,y]', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
+SELECT * FROM kmeanspp_auto('kmeans_2d', 'autokm_out', 'position', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
                        'MADLIB_SCHEMA.avg', 20, 0.001, 0.1, 'both');
 
 SELECT assert(
@@ -114,7 +114,7 @@ SELECT assert(
 FROM autokm_out_summary;
 
 DROP TABLE IF EXISTS autokm_out,autokm_out_summary;
-SELECT * FROM kmeanspp_auto('kmeans_2d', 'autokm_out', 'array[x,y]', ARRAY[2,3,4,5,6,7,8]);
+SELECT * FROM kmeanspp_auto('kmeans_2d', 'autokm_out', 'position', ARRAY[2,3,4,5,6,7,8]);
 
 SELECT assert(
         silhouette > 0 AND objective_fn > 0,
@@ -123,7 +123,7 @@ FROM autokm_out_summary;
 
 -- Test kmeans_random_auto
 DROP TABLE IF EXISTS autokm_out,autokm_out_summary;
-SELECT * FROM kmeans_random_auto('kmeans_2d', 'autokm_out', 'array[x,y]', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
+SELECT * FROM kmeans_random_auto('kmeans_2d', 'autokm_out', 'position', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
                        'MADLIB_SCHEMA.avg', 20, 0.001, 'elbow');
 
 SELECT assert(
@@ -132,7 +132,7 @@ SELECT assert(
 FROM autokm_out_summary;
 
 DROP TABLE IF EXISTS autokm_out,autokm_out_summary;
-SELECT * FROM kmeans_random_auto('kmeans_2d', 'autokm_out', 'array[x,y]', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
+SELECT * FROM kmeans_random_auto('kmeans_2d', 'autokm_out', 'position', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
                        'MADLIB_SCHEMA.avg', 20, 0.001, 'El');
 
 SELECT assert(
@@ -141,7 +141,7 @@ SELECT assert(
 FROM autokm_out_summary;
 
 DROP TABLE IF EXISTS autokm_out,autokm_out_summary;
-SELECT * FROM kmeans_random_auto('kmeans_2d', 'autokm_out', 'array[x,y]', ARRAY[5,6,7,8]);
+SELECT * FROM kmeans_random_auto('kmeans_2d', 'autokm_out', 'position', ARRAY[5,6,7,8]);
 
 SELECT assert(
         silhouette > 0 AND objective_fn > 0,
@@ -154,7 +154,7 @@ FROM (SELECT * FROM autokm_out WHERE k = any(ARRAY[5,6,7,8]))q;
 
 -- Unordered k list test
 DROP TABLE IF EXISTS autokm_out,autokm_out_summary;
-SELECT * FROM kmeans_random_auto('kmeans_2d', 'autokm_out', 'array[x,y]', ARRAY[12,3,5,6,8], 'MADLIB_SCHEMA.squared_dist_norm2',
+SELECT * FROM kmeans_random_auto('kmeans_2d', 'autokm_out', 'position', ARRAY[12,3,5,6,8], 'MADLIB_SCHEMA.squared_dist_norm2',
                        'MADLIB_SCHEMA.avg', 20, 0.001, 'silhouette');
 
 -- Silhouette Tests
@@ -200,7 +200,7 @@ SELECT assert(
 FROM autokm_out_summary;
 
 DROP TABLE IF EXISTS autokm_out,autokm_out_summary;
-SELECT * FROM kmeans_random_auto('kmeans_2d', 'autokm_out', 'array[x,y]', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
+SELECT * FROM kmeans_random_auto('kmeans_2d', 'autokm_out', 'position', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
                        'MADLIB_SCHEMA.avg', 20, 0.001, 'silhouetTe');
 
 SELECT assert(
@@ -209,7 +209,7 @@ SELECT assert(
 FROM autokm_out_summary;
 
 DROP TABLE IF EXISTS autokm_out,autokm_out_summary;
-SELECT * FROM kmeans_random_auto('kmeans_2d', 'autokm_out', 'array[x,y]', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
+SELECT * FROM kmeans_random_auto('kmeans_2d', 'autokm_out', 'position', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
                        'MADLIB_SCHEMA.avg', 20, 0.001, 'siL');
 
 SELECT assert(
@@ -218,7 +218,7 @@ SELECT assert(
 FROM autokm_out_summary;
 
 DROP TABLE IF EXISTS autokm_out,autokm_out_summary;
-SELECT * FROM kmeans_random_auto('kmeans_2d', 'autokm_out', 'array[x,y]', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
+SELECT * FROM kmeans_random_auto('kmeans_2d', 'autokm_out', 'position', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
                        'MADLIB_SCHEMA.avg', 20, 0.001, 'both');
 
 SELECT assert(
@@ -228,7 +228,7 @@ SELECT assert(
 FROM autokm_out_summary;
 
 DROP TABLE IF EXISTS autokm_out,autokm_out_summary;
-SELECT * FROM kmeans_random_auto('kmeans_2d', 'autokm_out', 'array[x,y]', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
+SELECT * FROM kmeans_random_auto('kmeans_2d', 'autokm_out', 'position', ARRAY[2,3,4,5,6,7,8], 'MADLIB_SCHEMA.squared_dist_norm2',
                        'MADLIB_SCHEMA.avg', 20, 0.001, 'b');
 
 SELECT assert(


### PR DESCRIPTION
The auto kmeans dev check tests were using the incorrect column
for expr_point which caused some flaky tests.

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [ ] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

