### PR TITLE
DL: Update ind/dep var shape to INTEGER instead of smallint

### DIFF
--- a/src/ports/postgres/modules/deep_learning/input_data_preprocessor.py_in
+++ b/src/ports/postgres/modules/deep_learning/input_data_preprocessor.py_in
@@ -280,7 +280,7 @@ class InputDataPreprocessorDL(object):
                 {self.schema_madlib}.agg_array_concat(ARRAY[{i}_norm::{float32}[]]) AS {i}
                 """.format(**locals()))
             shape_sql.append("""
-                ARRAY[count, {j}]::SMALLINT[] AS {i}_shape
+                ARRAY[count, {j}]::INTEGER[] AS {i}_shape
                 """.format(**locals()))
             bytea_sql.append("""
                 {self.schema_madlib}.array_to_bytea({i}) AS {i}
@@ -291,7 +291,7 @@ class InputDataPreprocessorDL(object):
                 {self.schema_madlib}.agg_array_concat(ARRAY[{i}]) AS {i}
                 """.format(**locals()))
             shape_sql.append("""
-                ARRAY[count, {j}]::SMALLINT[] AS {i}_shape
+                ARRAY[count, {j}]::INTEGER[] AS {i}_shape
                 """.format(**locals()))
             bytea_sql.append("""
                 {self.schema_madlib}.array_to_bytea({i}) AS {i}

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_helper.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_helper.py_in
@@ -132,7 +132,7 @@ def get_image_count_per_seg_for_minibatched_data_from_db(table_name, shape_col):
 
     if is_platform_pg():
         res = plpy.execute(
-            """ SELECT {0}::SMALLINT[] AS shape
+            """ SELECT {0} AS shape
                 FROM {1}
             """.format(shape_col, table_name))
         images_per_seg = [sum(r['shape'][0] for r in res)]


### PR DESCRIPTION
JIRA: MADLIB-1468

training_preprocessor_dl() function fails with the following error when the
number of images in a buffer is > range for smallint i.e. -32768 to +32767.
```
ERROR: spiexceptions.NumericValueOutOfRange: smallint out of range
```
This commit replaces smallint with INTEGER for the shape column.

Co-authored-by: Nikhil Kak <nkak@vmware.com>

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [ ] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

