### PR TITLE
Avoid using optimization -O2 or higher if C++11 is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if (CXX11)
     SET(CMAKE_CXX_FLAGS_RELEASE "-O1 -DNDEBUG"
         CACHE STRING
         "Flags used by the CXX compiler during RELEASE builds." FORCE)
-    SET(CMAKE_CXX_FLAGS_DEBUG  "-O0 -g"
+    SET(CMAKE_CXX_FLAGS_DEBUG  "-Og -g"
         CACHE STRING
         "Flags used by the CXX compiler during DEBUG builds." FORCE)
     SET(CMAKE_CXX_FLAGS_MINSIZEREL "-Os -DNDEBUG"
@@ -129,7 +129,9 @@ if(CMAKE_COMPILER_IS_GNUCC)
     if((CMAKE_C_COMPILER_VERSION VERSION_EQUAL 5.0) OR (CMAKE_C_COMPILER_VERSION VERSION_GREATER 5.0))
         # Versions 5+ fail with the "Release" build type i.e. when optimization
         # level is -O3 or greater.
-        add_compile_options("-O2")
+        # For CXX11, we've already limited it to -O1 for similar reasons (causes crash)
+        SET(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG" CACHE STRING
+        "Flags used by the C compiler during RELEASE builds." FORCE)
     endif()
 
     # See comments below for C++:
@@ -175,13 +177,14 @@ if(CMAKE_COMPILER_IS_GNUCXX)
         set(CMAKE_C_FLAGS "-std=gnu99 ${CMAKE_C_FLAGS}"
             CACHE STRING
             "Flags used by the compiler during all build types." FORCE)
+        if((CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 5.0) OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0))
+            # Versions 5+ fail with the "Release" build type i.e. when optimization
+            # level is -O3 or greater.
+            SET(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG" CACHE STRING
+            "Flags used by the CXX compiler during RELEASE builds." FORCE)
+        endif()
     endif(CXX11)
 
-    if((CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 5.0) OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0))
-        # Versions 5+ fail with the "Release" build type i.e. when optimization
-        # level is -O3 or greater.
-        add_compile_options("-O2")
-    endif()
     # We want to include some header files as system header files in order to
     # disable warnings. However, on Mac OS X, a CMake variable is not set
     # correctly on Mac OS X. http://www.cmake.org/Bug/view.php?id=10837

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,10 +52,26 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
 endif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
 
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
-      "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
-      FORCE)
+    set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
+        "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
+        FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
+
+if (CXX11)
+    SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O1 -g"
+        CACHE STRING
+        "Flags used by the CXX compiler during RELWITHDEBINFO builds." FORCE)
+    SET(CMAKE_CXX_FLAGS_RELEASE "-O1 -DNDEBUG"
+        CACHE STRING
+        "Flags used by the CXX compiler during RELEASE builds." FORCE)
+    SET(CMAKE_CXX_FLAGS_DEBUG  "-O0 -g"
+        CACHE STRING
+        "Flags used by the CXX compiler during DEBUG builds." FORCE)
+    SET(CMAKE_CXX_FLAGS_MINSIZEREL "-Os -DNDEBUG"
+        CACHE STRING
+        "Flags used by the CXX compiler during MINSIZEREL builds." FORCE)
+endif(CXX11)
+
 
 # The C++11 standard overlaps a lot with older versions of Boost.
 # So before deciding what standard to use for the whole project, we
@@ -174,7 +190,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     endif(APPLE)
 elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
     if(CXX11)
-        set(CMAKE_CXX_FLAGS "-stdlib=libc++ -std=c++11"
+        SET(CMAKE_CXX_FLAGS "-stdlib=libc++ -std=c++11"
             CACHE STRING
             "Flags used by the compiler during all build types." FORCE)
     else(CXX11)

--- a/src/ports/postgres/dbconnector/NewDelete.cpp
+++ b/src/ports/postgres/dbconnector/NewDelete.cpp
@@ -26,6 +26,14 @@
 // the search paths, which might point to a port-specific dbconnector.hpp
 #include <dbconnector/dbconnector.hpp>
 
+#if _GLIBCXX_USE_CXX11_ABI
+#define THROW_BAD_ALLOC
+#define NOEXCEPT noexcept
+#else
+#define THROW_BAD_ALLOC throw (std::bad_alloc)
+#define NOEXCEPT throw()
+#endif
+
 /**
  * @brief operator new for PostgreSQL. Throw on fail.
  *
@@ -34,7 +42,7 @@
  * that size.
  */
 void*
-operator new(std::size_t size) throw (std::bad_alloc) {
+operator new(std::size_t size) THROW_BAD_ALLOC {
     return madlib::defaultAllocator().allocate<
         madlib::dbal::FunctionContext,
         madlib::dbal::DoNotZero,
@@ -42,7 +50,7 @@ operator new(std::size_t size) throw (std::bad_alloc) {
 }
 
 void*
-operator new[](std::size_t size) throw (std::bad_alloc) {
+operator new[](std::size_t size) THROW_BAD_ALLOC {
     return madlib::defaultAllocator().allocate<
         madlib::dbal::FunctionContext,
         madlib::dbal::DoNotZero,
@@ -58,12 +66,12 @@ operator new[](std::size_t size) throw (std::bad_alloc) {
  * <tt>operator new(std::size_t)</tt>.
  */
 void
-operator delete(void *ptr) throw() {
+operator delete(void *ptr) NOEXCEPT {
     madlib::defaultAllocator().free<madlib::dbal::FunctionContext>(ptr);
 }
 
 void
-operator delete[](void *ptr) throw() {
+operator delete[](void *ptr) NOEXCEPT {
     madlib::defaultAllocator().free<madlib::dbal::FunctionContext>(ptr);
 }
 
@@ -75,7 +83,7 @@ operator delete[](void *ptr) throw() {
  * indication, instead of a bad_alloc exception.
  */
 void*
-operator new(std::size_t size, const std::nothrow_t&) throw() {
+operator new(std::size_t size, const std::nothrow_t&) NOEXCEPT {
     return madlib::defaultAllocator().allocate<
         madlib::dbal::FunctionContext,
         madlib::dbal::DoNotZero,
@@ -83,7 +91,7 @@ operator new(std::size_t size, const std::nothrow_t&) throw() {
 }
 
 void*
-operator new[](std::size_t size, const std::nothrow_t&) throw() {
+operator new[](std::size_t size, const std::nothrow_t&) NOEXCEPT {
     return madlib::defaultAllocator().allocate<
         madlib::dbal::FunctionContext,
         madlib::dbal::DoNotZero,
@@ -97,11 +105,11 @@ operator new[](std::size_t size, const std::nothrow_t&) throw() {
  * <tt>operator new(std::size_t, const std::nothrow_t&)</tt>.
  */
 void
-operator delete(void *ptr, const std::nothrow_t&) throw() {
+operator delete(void *ptr, const std::nothrow_t&) NOEXCEPT {
     madlib::defaultAllocator().free<madlib::dbal::FunctionContext>(ptr);
 }
 
 void
-operator delete[](void *ptr, const std::nothrow_t&) throw() {
+operator delete[](void *ptr, const std::nothrow_t&) NOEXCEPT {
     madlib::defaultAllocator().free<madlib::dbal::FunctionContext>(ptr);
 }


### PR DESCRIPTION
There are some crashes we're seeing related to memory management when the C++11 flag is enabled.  It only happens when compiler optimizations at level O2 or higher are enabled, which makes it very difficult to debug.

Since this is not an essential feature, and currently only works on OSX anyway, in the meantime we will simply disable compiler optimization for that case.