### PR TITLE
Strengthen security checks on compile params

### DIFF
--- a/src/ports/postgres/modules/deep_learning/madlib_keras_custom_function.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_custom_function.py_in
@@ -168,12 +168,25 @@ def delete_custom_function(schema_madlib, object_table, id=None, name=None, **kw
         sql = "DROP TABLE {0}".format(object_table)
         plpy.execute(sql, 0)
 
+dangerous_builtins = set(('serialize', 'deserialize', 'get'))
+
 def update_builtin_metrics(builtin_metrics):
     builtin_metrics.append('accuracy')
     builtin_metrics.append('acc')
     builtin_metrics.append('crossentropy')
     builtin_metrics.append('ce')
+
+    builtin_metrics = [ b for b in builtin_metrics \
+                        if not b.startswith('_') and \
+                         b not in dangerous_builtins ]
+
     return builtin_metrics
+
+def update_builtin_losses(builtin_losses):
+    builtin_losses = [ b for b in builtin_losses \
+                        if not b.startswith('_') and \
+                         b not in dangerous_builtins ]
+    return builtin_losses
 
 @MinWarning("error")
 def load_top_k_accuracy_function(schema_madlib, object_table, k, **kwargs):

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_fit_multiple_model.py_in
@@ -353,7 +353,7 @@ class FitMultipleModel(object):
         DEBUG.print_timing('eval_model_total')
 
     def populate_object_map(self):
-        builtin_losses = dir(losses)
+        builtin_losses = update_builtin_losses(dir(losses))
         builtin_metrics = update_builtin_metrics(dir(metrics))
 
         # Track distinct custom functions in compile_params

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_validator.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_validator.py_in
@@ -49,6 +49,8 @@ from utilities.validate_args import input_tbl_valid
 from utilities.validate_args import output_tbl_valid
 from madlib_keras_wrapper import parse_and_validate_fit_params
 from madlib_keras_wrapper import parse_and_validate_compile_params
+from madlib_keras_custom_function import update_builtin_metrics
+from madlib_keras_custom_function import update_builtin_losses
 import tensorflow.keras.losses as losses
 import tensorflow.keras.metrics as metrics
 
@@ -541,18 +543,18 @@ class MstLoaderInputValidator():
                     """.format(fit_params, str(e)))
         if not self.compile_params_list:
             plpy.error( "compile_params_list cannot be NULL")
-        custom_fn_name = []
-        ## Initialize builtin loss/metrics functions
-        builtin_losses = dir(losses)
-        builtin_metrics = dir(metrics)
-        # Default metrics, since it is not part of the builtin metrics list
-        builtin_metrics.append('accuracy')
+        custom_fn_names = []
+
+        # Initialize builtin loss/metrics functions
+        builtin_losses = update_builtin_losses(dir(losses))
+        builtin_metrics = update_builtin_metrics(dir(metrics))
+
         if self.object_table is not None:
 
             res = plpy.execute("SELECT {0} from {1}".format(CustomFunctionSchema.FN_NAME,
                                                             self.object_table))
             for r in res:
-                custom_fn_name.append(r[CustomFunctionSchema.FN_NAME])
+                custom_fn_names.append(r[CustomFunctionSchema.FN_NAME])
         for compile_params in self.compile_params_list:
             try:
                 _, _, res = parse_and_validate_compile_params(compile_params)
@@ -563,11 +565,11 @@ class MstLoaderInputValidator():
                 if self.object_table is not None:
                     error_suffix = "is not defined in object table '{0}'!".format(self.object_table)
 
-                _assert(res['loss'] in custom_fn_name or res['loss'] in builtin_losses,
+                _assert(res['loss'] in custom_fn_names or res['loss'] in builtin_losses,
                         "custom function '{0}' used in compile params "\
                         "{1}".format(res['loss'], error_suffix))
                 if 'metrics' in res:
-                    _assert((len(set(res['metrics']).intersection(custom_fn_name)) > 0
+                    _assert((len(set(res['metrics']).intersection(custom_fn_names)) > 0
                             or len(set(res['metrics']).intersection(builtin_metrics)) > 0),
                             "custom function '{0}' used in compile params " \
                             "{1}".format(res['metrics'], error_suffix))

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_wrapper.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_wrapper.py_in
@@ -28,6 +28,7 @@ import madlib_keras_serializer
 import madlib_keras_gpu_info
 from madlib_keras_custom_function import CustomFunctionSchema
 from madlib_keras_custom_function import update_builtin_metrics
+from madlib_keras_custom_function import update_builtin_losses
 
 from utilities.utilities import _assert
 from utilities.utilities import is_platform_pg
@@ -217,14 +218,14 @@ def parse_and_validate_compile_params(str_of_args, additional_params=[]):
                                                   literal_eval_compile_params,
                                                   accepted_compile_params)
     if len(additional_params) == 0:
-        # optimizer is not a required parameter for keras compile
+        # optimizer is a required parameter for keras compile
         _assert('optimizer' in compile_dict, "optimizer is a required parameter for compile")
         opt_name, opt_args = parse_optimizer(compile_dict)
     else:
         opt_name, opt_args = None, None
 
     _assert('loss' in compile_dict, "loss is a required parameter for compile")
-    unsupported_loss_list = ['sparse_categorical_crossentropy']
+    unsupported_loss_list = ['sparse_categorical_crossentropy', 'serialize', 'deserialize', 'get' ]
     _assert(compile_dict['loss'] not in unsupported_loss_list,
             "Loss function {0} is not supported.".format(compile_dict['loss']))
     validate_compile_param_types(compile_dict)
@@ -240,7 +241,10 @@ def _validate_metrics(compile_dict):
     if 'metrics' in compile_dict and compile_dict['metrics']:
         unsupported_metrics_list = ['sparse_categorical_accuracy',
                                     'sparse_categorical_crossentropy',
-                                    'sparse_top_k_categorical_accuracy']
+                                    'sparse_top_k_categorical_accuracy',
+                                    'serialize'
+                                    'deserialize'
+                                    'get']
         _assert(len(compile_dict['metrics']) == 1,
                 "Only one metric at a time is supported.")
         _assert(compile_dict['metrics'][0] not in unsupported_metrics_list,
@@ -440,16 +444,23 @@ def get_custom_functions_list(compile_params):
 
     """
     compile_dict = convert_string_of_args_to_dict(compile_params)
-    builtin_losses = dir(losses)
+    builtin_losses = update_builtin_losses(dir(losses))
     builtin_metrics = update_builtin_metrics(dir(metrics))
 
     custom_fn_list = []
+
     local_loss = compile_dict['loss'].lower() if 'loss' in compile_dict else None
-    local_metric = compile_dict['metrics'].lower()[2:-2] if 'metrics' in compile_dict else None
+    try:
+        metrics_list = ast.literal_eval(compile_dict['metrics']) \
+                                        if 'metrics' in compile_dict else []
+    except ValueError:
+        plpy.error(("Invalid input value for parameter {0}, "
+                    "please refer to the documentation").format(compile_dict['metrics']))
+    local_metric = metrics_list[0].lower() if (len(metrics_list) > 0) else None
+
     if local_loss and (local_loss not in [a.lower() for a in builtin_losses]):
         custom_fn_list.append(local_loss)
     if local_metric and (local_metric not in [a.lower() for a in builtin_metrics]):
-        if 'top_k_categorical_accuracy' not in local_metric:
-            custom_fn_list.append(local_metric)
+        custom_fn_list.append(local_metric)
 
     return custom_fn_list


### PR DESCRIPTION
Here are a few improvements to how we process compile params, so that the code is more robust from a security perspective. 

   I haven't found a specific security exploit for these issues, but I wouldn't be surprised if someone with enough time and dedication could find a way to gain admin access via them... especially if there were a minor update to either MADlib's deep learning library or keras which doesn't take into account these potential issues.  (And at the very least, this fixes some odd error messages and crashes that can happen when strange parameters are passed.)

Changes:

1.  Exclude `deserialize`, `serialize`, `get`, and anything starting with `_` from the list of builtin losses and metrics we support.

We were unintentionally allowing users to pass `keras.losses.deserialize`, `keras.losses._sys`, `keras.losses.get`, `keras.losses.__builtins__`, `keras.losses._sys`, etc. as loss functions to keras, and the same for `keras.metrics.*` for metric functions.  Most of what's in `keras.losses.*` are loss functions or classes deriving from `keras.losses.Loss`, and most of what's in `keras.metrics` are metric functions or classes deriving from `keras.metrics.Metric`, but there are also these extra classes intended for other purposes (not intended for use directly as metrics or losses).

The `deserialize()` function is particularly dangerous, in part because it accepts exactly 2 arguments which means, even if you just pass something as simple as `loss=deserialize`, it will be called by keras itself during evaluation as `deserialize(y_true, y_pred)`.  And in part because the purpose of the `deserialize()` utility function is to take a string from the user and turn it into an instance of a callable class, which will then be called by keras.  In other words, it's a way of allowing users to pass in their own custom metric class, but in a way such that MADlib only sees it as a `str` to pass along (rather than an arbitrary callable python object, which we do not allow ordinary users to pass through to keras).

The danger is significantly mitigated by the fact that we don't allow any characters after the function name to be passed, even as a string.  For example, if the user were allowed to pass `loss=deserialize(..., ...)` then it would be fairly easy to gain admin access.  But we only allow `loss=deserialize` which makes it far more difficult if not impossible to exploit.  Nevertheless, this PR completely disables the use of such functions for losses or metrics, in case there is some way to trick keras into passing malicious arguments for y_true and y_pred.

2.  Another potentially risky behavior was the input validator allowing the user to pass as a metric any string which contains the substring `top_k_categorical_accuracy`.  This provides a loophole that circumvents the intention to only allow metric names which are either a builtin keras metric or something in the custom functions object table.  For example, if the user passes `metrics=[lambda x,y : os.system("echo allow all >> ${MASTER_DATA_DIRECTORY}/pg_hba.conf")] /* top_k_categorical_accuracy */, losses=...` for compile params, that will be considered a valid input by the input validator and passed along.  Once again, this doesn't appear to be an immediate security threat, as later we run a `literal_eval()` on it, which will error out.  But it's safest if we catch things like this up front during input validation.

From what I can tell, explicitly whitelisting %top_k_categorical_acurracy% for a metric is unnecessary, since it is already a builtin keras function, and we don't allow any arguments to be passed to it anyway, it must be an exact match to a builtin or a custom function.

3.  We were comparing the metrics parameter value substring `metrics[2:-2]` to the builtin and custom function names, which implicitly assumes that the first 2 characters are [' or [" and the last two are '] or "].

Handling this more carefully using a literal eval to extract the string inside the first element of the list prevents sneaky inputs like `metrics=[*__builtins__ ]`.  (We already validate elsewhere that the full metrics parameter value is of type `list`.)