### PR TITLE
Fix flaky keras_evaluate relative-error test

### DIFF
--- a/src/ports/postgres/modules/deep_learning/test/madlib_keras_evaluate.sql_in
+++ b/src/ports/postgres/modules/deep_learning/test/madlib_keras_evaluate.sql_in
@@ -110,9 +110,15 @@ SELECT madlib_keras_fit_multiple_model(
 
 DROP TABLE IF EXISTS evaluate_out;
 SELECT madlib_keras_evaluate('cifar_10_multiple_model', 'cifar_10_sample_batched', 'evaluate_out', FALSE, 2);
-SELECT assert(relative_error(e.metric,i.training_metrics_final) < 0.00001 AND
-        relative_error(e.loss,i.training_loss_final)  < 0.00001 AND
-        e.metrics_type = '{accuracy}', 'Evaluate output validation failed.')
+SELECT assert(
+    (
+        (e.metric < 0.00001 AND i.training_metric_final < 0.00001) OR
+         relative_error(e.metric,i.training_metrics_final) < 0.00001
+    ) AND (
+        (e.loss < 0.00001 AND i.training_loss_final < 0.00001) OR
+         relative_error(e.loss,i.training_loss_final)  < 0.00001)
+    ) AND
+         e.metrics_type = '{accuracy}', 'Evaluate output validation failed.')
 FROM evaluate_out e, cifar_10_multiple_model_info i WHERE i.mst_key = 2;
 
 


### PR DESCRIPTION
This was getting divide-by-zero errors whenever the final training
loss or metric from the previous iteration was exactly 0

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [ ] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

