### PR TITLE
DL: Remove AOcontrol from load_top_k_accuracy fn

### DIFF
--- a/src/ports/postgres/modules/deep_learning/madlib_keras_custom_function.py_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_custom_function.py_in
@@ -22,6 +22,7 @@ from utilities.control import MinWarning
 from utilities.utilities import _assert
 from utilities.utilities import get_col_name_type_sql_string
 from utilities.utilities import current_user
+from utilities.utilities import is_platform_pg
 from utilities.utilities import is_superuser
 from utilities.utilities import get_schema
 from utilities.validate_args import columns_missing_from_table
@@ -78,9 +79,12 @@ def load_custom_function(schema_madlib, object_table, object, name, description=
         if not table_exists(object_table):
             col_defs = get_col_name_type_sql_string(CustomFunctionSchema.col_names,
                                                     CustomFunctionSchema.col_types)
+            with_query = "" if is_platform_pg() else """
+            with(appendonly=false)"""
 
             sql = """CREATE TABLE {object_table}
                                   ({col_defs}, PRIMARY KEY({fn_name}))
+                                  {with_query}
                 """.format(fn_name=CustomFunctionSchema.FN_NAME,**locals())
 
             plpy.execute(sql, 0)

--- a/src/ports/postgres/modules/deep_learning/madlib_keras_custom_function.sql_in
+++ b/src/ports/postgres/modules/deep_learning/madlib_keras_custom_function.sql_in
@@ -362,8 +362,7 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.load_custom_function(
     description             TEXT
 ) RETURNS VOID AS $$
     PythonFunctionBodyOnly(`deep_learning', `madlib_keras_custom_function')
-    with AOControl(False):
-        madlib_keras_custom_function.load_custom_function(**globals())
+    madlib_keras_custom_function.load_custom_function(**globals())
 $$ LANGUAGE plpythonu VOLATILE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 
@@ -435,8 +434,7 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.load_top_k_accuracy_function(
     k                       INTEGER
 ) RETURNS VOID AS $$
     PythonFunctionBodyOnly(`deep_learning', `madlib_keras_custom_function')
-    with AOControl(False):
-        madlib_keras_custom_function.load_top_k_accuracy_function(**globals())
+    madlib_keras_custom_function.load_top_k_accuracy_function(**globals())
 $$ LANGUAGE plpythonu VOLATILE
 m4_ifdef(`__HAS_FUNCTION_PROPERTIES__', `MODIFIES SQL DATA', `');
 


### PR DESCRIPTION
On running back to back queries for load_top_k_accuracy_function in the
same psql session on GPDB6, if any query fails in between, the very
next query hangs. This commit fixes that issue by moving the with
AOControl clause to where we create the table, rather than updating it
at the function entry level.
Removed top level AOControl from `load_custom_function` too as that is what we internally call from load_top_k_accuracy_function.

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [ ] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

