### PR TITLE
Build: Fix module pathname for gppkg

### DIFF
--- a/deploy/gppkg/gppkg_spec.yml.in
+++ b/deploy/gppkg/gppkg_spec.yml.in
@@ -17,3 +17,6 @@ PostInstall:
            echo 'For additional options run:';
            echo '$ madpack --help';
            echo 'Release notes and additional documentation can be found at http://madlib.apache.org';"
+PostUninstall:
+- Master: "rm $GPHOME/lib/postgresql/libmadlib.so"
+- Segment: "rm $GPHOME/lib/postgresql/libmadlib.so"

--- a/deploy/gppkg/madlib.spec.in
+++ b/deploy/gppkg/madlib.spec.in
@@ -54,6 +54,8 @@ ln -nsf $RPM_INSTALL_PREFIX/madlib/Versions/$MADLIB_VERSION $RPM_INSTALL_PREFIX/
 ln -nsf $RPM_INSTALL_PREFIX/madlib/Current/bin $RPM_INSTALL_PREFIX/madlib/bin
 ln -nsf $RPM_INSTALL_PREFIX/madlib/Current/doc $RPM_INSTALL_PREFIX/madlib/doc
 
+ln -nsf $RPM_INSTALL_PREFIX/madlib/Current/ports/greenplum/@GPDB_VERSION@/lib/libmadlib.so $RPM_INSTALL_PREFIX/lib/postgresql/libmadlib.so
+
 # creating symlink for madpack (does not work at present)
 # find $RPM_INSTALL_PREFIX/bin/madpack -type f -exec mv {} $RPM_INSTALL_PREFIX/bin/old_madpack \; 2>/dev/null
 # ln -nsf $RPM_INSTALL_PREFIX/madlib/Current/bin/madpack $RPM_INSTALL_PREFIX/bin/madpack

--- a/src/madpack/changelist_1.18.0_1.19.0-dev.yaml
+++ b/src/madpack/changelist_1.18.0_1.19.0-dev.yaml
@@ -1,0 +1,50 @@
+# ------------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ------------------------------------------------------------------------------
+
+# Changelist for MADlib version rel/v1.15 to rel/v1.15.1
+
+# This file contains all changes that were introduced in a new version of
+# MADlib. This changelist is used by the upgrade script to detect what objects
+# should be upgraded (while retaining all other objects from the previous version)
+
+# New modules (actually .sql_in files) added in upgrade version
+# For these files the sql_in code is retained as is with the functions in the
+# file installed on the upgrade version. All other files (that don't have
+# updates), are cleaned up to remove object replacements
+new module:
+
+# Changes in the types (UDT) including removal and modification
+udt:
+
+# List of the UDF changes that affect the user externally. This includes change
+# in function name, return type, argument order or types, or removal of
+# the function. In each case, the original function is as good as removed and a
+# new function is created. In such cases, we should abort the upgrade if there
+# are user views dependent on this function, since the original function will
+# not be present in the upgraded version.
+udf:
+
+# Changes to aggregates (UDA) including removal and modification
+# Overloaded functions should be mentioned separately
+uda:
+
+# List of the UDC, UDO and UDOC changes.
+udc:
+udo:
+udoc:

--- a/src/madpack/madpack.py
+++ b/src/madpack/madpack.py
@@ -1232,6 +1232,13 @@ def get_madlib_function_drop_str(schema):
     for idx in range(len(madlib_functions)):
 
         func = madlib_functions[idx]
+
+        # Filter out the DEFAULT value from the function arguments
+        # DROP FUNCTION statements do not need or allow default values:
+        # DROP FUNCTION foo(bar INTEGER DEFAULT 0);
+        func['args'] = func['args'].split(',')
+        func['args'] = [i.split('DEFAULT')[0] for i in func['args']]
+        func['args'] = ', '.join(func['args'])
         # We don't drop type related functions
         no_drop = ['bytea8', 'float8arr', 'svec']
         if not any(x in func['name'] for x in no_drop):
@@ -1403,7 +1410,10 @@ def main(argv):
             maddir_conf = maddir + "/config"
 
         global maddir_lib
-        if os.path.isfile(maddir + "/ports/" + portid + "/" + dbver +
+        if portid == 'greenplum' and \
+           os.path.islink(maddir + "/../../../lib/postgresql/libmadlib.so"):
+           maddir_lib = '$libdir/libmadlib.so'
+        elif os.path.isfile(maddir + "/ports/" + portid + "/" + dbver +
                           "/lib/libmadlib.so"):
             maddir_lib = maddir + "/ports/" + portid + "/" + dbver + \
                 "/lib/libmadlib.so"


### PR DESCRIPTION
The MODULE_PATHNAME variable is set to an absolute path
during preprocessing. This creates an issue with the gpupgrade
since the database path changes and the old path becomes invalid.

This commit creates a link in the $libdir directory of the
greenplum installation and uses that link to create the MADlib
UDFs.

It fixes an issue with the upgrade scripts as well. The drop
commands are generated using the arguments but including
DEFAULT values breaks the drop function command. The commit
filters them out.

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [ ] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

