### PR TITLE
GLM-multinom: Use non-temp tables in GroupIterationController

### DIFF
--- a/src/ports/postgres/modules/glm/glm.py_in
+++ b/src/ports/postgres/modules/glm/glm.py_in
@@ -195,7 +195,8 @@ def __glm_compute(schema_madlib, tbl_source, tbl_output, col_dep_var, col_ind_va
             'rel_state': unique_string(),
             'col_grp_iteration': unique_string(),
             'col_grp_state': unique_string(),
-            'state_type': schema_madlib + ".bytea8"
+            'state_type': schema_madlib + ".bytea8",
+            'temporaryTables': False
             }
     args.update(optim_params)
     args.update(family_params)
@@ -350,7 +351,7 @@ def __glm_compute(schema_madlib, tbl_source, tbl_output, col_dep_var, col_ind_va
                    **args))
 
     # clean up
-    plpy.execute("""DROP TABLE IF EXISTS pg_temp.{rel_state} """.format(**args))
+    plpy.execute("""DROP TABLE IF EXISTS {rel_state} """.format(**args))
     plpy.execute("SET client_min_messages TO " + old_msg_level)
     return None
 

--- a/src/ports/postgres/modules/glm/multinom.py_in
+++ b/src/ports/postgres/modules/glm/multinom.py_in
@@ -186,7 +186,8 @@ def __multinom_compute(schema_madlib, tbl_source, tbl_output, col_dep_var,
             'ref_category': ref_category,
             'n_categories': len(category_list),
             'link': link_func,
-            'state_type': schema_madlib + ".bytea8"
+            'state_type': schema_madlib + ".bytea8",
+            'temporaryTables': False
             }
     args.update(optim_params_dict)
 
@@ -341,7 +342,7 @@ def __multinom_compute(schema_madlib, tbl_source, tbl_output, col_dep_var,
 
     # clean up
     plpy.execute("""
-        DROP TABLE IF EXISTS pg_temp.{rel_state}
+        DROP TABLE IF EXISTS {rel_state}
         """.format(**args))
     plpy.execute("SET client_min_messages TO " + old_msg_level)
 

--- a/src/ports/postgres/modules/utilities/in_mem_group_control.py_in
+++ b/src/ports/postgres/modules/utilities/in_mem_group_control.py_in
@@ -222,6 +222,7 @@ class GroupIterationController:
                           if arg_dict["grouping_col"] is None
                           else arg_dict["grouping_col"]),
         )
+        self.kwargs['temporaryTables'] = self.kwargs.get('temporaryTables', True)
         self.grp_to_n_tuples = {}
         self.failed_grp_keys = []
 
@@ -287,9 +288,10 @@ class GroupIterationController:
                          else "{grouping_col}").format(**self.kwargs)
             groupby_str = ("{col_grp_null}" if self.is_group_null
                            else "{grouping_col}").format(**self.kwargs)
+            temp = 'TEMPORARY' if self.kwargs['temporaryTables'] else ''
             plpy.execute("""
                 DROP TABLE IF EXISTS {rel_state};
-                CREATE TEMPORARY TABLE {rel_state} AS (
+                CREATE {temp} TABLE {rel_state} AS (
                     SELECT
                         array_to_string(ARRAY[{grouping_str}], ',') AS {col_grp_key},
                         0::integer                                  AS {col_grp_iteration},
@@ -303,6 +305,7 @@ class GroupIterationController:
                 );
                 """.format(group_col=group_col,
                            groupby_str=groupby_str,
+                           temp=temp,
                            **self.kwargs))
 
             ############################


### PR DESCRIPTION
There is a potential issue with pg_temp not cleaning up correctly in
the case of a failure in GLM and multinom. This commit changes the
default value to create the temp table used for state aggregation to
avoid the temporary tables.

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [ ] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

