### PR TITLE
Utilities: Reuse update plan in GroupIterationController 

### DIFF
--- a/src/ports/postgres/modules/svm/svm.py_in
+++ b/src/ports/postgres/modules/svm/svm.py_in
@@ -7,6 +7,7 @@ from collections import defaultdict
 from kernel_approximation import create_kernel, load_kernel
 
 from utilities.control import MinWarning
+from utilities.control import OptimizerControl
 from utilities.in_mem_group_control import GroupIterationController
 from utilities.utilities import _assert
 from utilities.utilities import _string_to_array
@@ -815,7 +816,8 @@ def svm(schema_madlib, source_table, model_table,
         if transformer.transformed_table:
             args.update(transformer.transformed_table)
         _cross_validate_svm(args)
-        _svm_parsed_params(use_transformer_for_output=True, **args)
+        with OptimizerControl(False):
+            _svm_parsed_params(use_transformer_for_output=True, **args)
         transformer.clear()
 # ------------------------------------------------------------------------------
 

--- a/src/ports/postgres/modules/svm/svm.py_in
+++ b/src/ports/postgres/modules/svm/svm.py_in
@@ -62,6 +62,7 @@ def _compute_svm(args):
                 it.kwargs['stepsize'] *= it.kwargs['decay_factor']
             else:
                 it.kwargs['stepsize'] = init_stepsize / (it.iteration + 1)
+            it.update_plan = None
             has_converged = it.test(
                 """
                 {iteration} >= {max_iter}

--- a/src/ports/postgres/modules/svm/test/svm.sql_in
+++ b/src/ports/postgres/modules/svm/test/svm.sql_in
@@ -108,9 +108,9 @@ SELECT svm_regression(
      NULL,
      'init_stepsize=0.01, max_iter=50, lambda=2, norm=l2, epsilon=0.01',
      false);
-SELECT svm_predict('svr_model', 'svr_train_data', 'id', 'svr_test_result');
+SELECT svm_predict('svr_model2', 'svr_train_data', 'id', 'svr_test_result');
 \x on
-SELECT * FROM svr_model;
+SELECT * FROM svr_model2;
 \x off
 SELECT
     assert(

--- a/src/ports/postgres/modules/utilities/in_mem_group_control.py_in
+++ b/src/ports/postgres/modules/utilities/in_mem_group_control.py_in
@@ -240,6 +240,7 @@ class GroupIterationController:
         self.finished_states = state_factory(self.is_state_type_bytea8)
 
         self.group_param = self._init_group_param()
+        self.update_plan = None
 
     def _init_group_param(self):
         _grp_key = ("array_to_string(ARRAY[{grouping_str}], ',')"
@@ -549,40 +550,43 @@ class GroupIterationController:
         self.iteration = self.iteration + 1
 
         group_param = self.group_param
-        run_sql = """
-            SELECT
-                {_grp_key} AS {col_grp_key},
-                {grouping_col},
-                {iteration} AS {col_grp_iteration},
-                ({newState}) AS {col_grp_state}
-            FROM (
-                SELECT *,
-                    array_to_string(ARRAY[{grouping_str}], ',') AS {col_grp_key}
-                FROM {rel_source}
-            ) AS {as_rel_source}
-            JOIN ( {select_rel_state} ) AS {rel_state}
-            {using_str}
-            JOIN ( {select_n_tuples} ) AS _rel_n_tuples
-            {using_str}
-            {groupby_str}
-            """.format(
-            newState=newState,
-            iteration=self.iteration,
-            using_str=group_param.using_str,
-            groupby_str=group_param.groupby_str,
-            _grp_key=group_param.grp_key,
-            select_rel_state=group_param.select_rel_state,
-            select_n_tuples=group_param.select_n_tuples,
-            **self.kwargs)
 
-        update_plan = plpy.prepare(run_sql,
-                                   ["text[]", group_param.grouped_state_type,
-                                    "text[]", "integer[]"])
-        res_tuples = plpy.execute(update_plan, [self.new_states.keys,
-                                                self.new_states.values,
-                                                self.grp_to_n_tuples.keys(),
-                                                self.grp_to_n_tuples.values()])
+        if self.update_plan is None:
+            run_sql = """
+                SELECT
+                    {_grp_key} AS {col_grp_key},
+                    {grouping_col},
+                    ({newState}) AS {col_grp_state}
+                FROM (
+                    SELECT *,
+                        array_to_string(ARRAY[{grouping_str}], ',') AS {col_grp_key}
+                    FROM {rel_source}
+                ) AS {as_rel_source}
+                JOIN ( {select_rel_state} ) AS {rel_state}
+                {using_str}
+                JOIN ( {select_n_tuples} ) AS _rel_n_tuples
+                {using_str}
+                {groupby_str}
+                """.format(
+                newState=newState,
+                iteration=self.iteration,
+                using_str=group_param.using_str,
+                groupby_str=group_param.groupby_str,
+                _grp_key=group_param.grp_key,
+                select_rel_state=group_param.select_rel_state,
+                select_n_tuples=group_param.select_n_tuples,
+                **self.kwargs)
 
+            self.update_plan = plpy.prepare(run_sql,
+                                       ["text[]", group_param.grouped_state_type,
+                                        "text[]", "integer[]"])
+
+        res_tuples = plpy.execute(self.update_plan,
+                                    [self.new_states.keys,
+                                     self.new_states.values,
+                                     self.grp_to_n_tuples.keys(),
+                                     self.grp_to_n_tuples.values()])
+        res_tuples[0][self.kwargs['col_grp_iteration']] = self.iteration
         col_grp_state = self.kwargs['col_grp_state']
         col_grp_key = self.kwargs['col_grp_key']
         self.old_states.sync_from(self.new_states)


### PR DESCRIPTION
The group iteration controller prepares a plan and executes it during
the update phase. For some modules, this plan does not change between
iterations. With this commit, the plan gets saved and reused as needed.

Co-authored-by: Bhuvnesh Chaudhary <bchaudhary@pivotal.io>

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [ ] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

