### PR TITLE
Build System: Support Photon OS

### DIFF
--- a/cmake/LinuxUtils.cmake
+++ b/cmake/LinuxUtils.cmake
@@ -10,6 +10,18 @@ macro(rh_version OUT_VERSION)
     endif(EXISTS "/etc/redhat-release")
 endmacro(rh_version)
 
+# Get the Photon OS version
+macro(ph_version OUT_VERSION)
+    if(EXISTS "/etc/photon-release")
+        file(READ "/etc/photon-release" _PHOTON_RELEASE_CONTENT)
+        string(REGEX REPLACE "[^0-9.]*([0-9.]+)[^0-9.]*\$" "\\1" ${OUT_VERSION}
+            "${_PHOTON_RELEASE_CONTENT}"
+        )
+    else(EXISTS "/etc/photon-release")
+        set(${OUT_VERSION} "${OUT_VERSION}-NOTFOUND")
+    endif(EXISTS "/etc/photon-release")
+endmacro(ph_version)
+
 # Get the Debian version
 # DEB_OUT_VERSION will have a number if /etc/issue exists, with an entry for Debian.
 # DEB_OUT_VERSION will have 'DEB_OUT_VERSION-NOTFOUND' if /etc/issue does not exist.

--- a/deploy/CMakeLists.txt
+++ b/deploy/CMakeLists.txt
@@ -18,9 +18,18 @@ elseif(UNIX)
     if(RH_VERSION AND NOT (RH_VERSION STREQUAL "RH_VERSION-NOTFOUND"))
       set(IS_REDHAT "True")
     endif()
+    ph_version(PH_VERSION)
+    if(PH_VERSION AND NOT (PH_VERSION STREQUAL "PH_VERSION-NOTFOUND"))
+      set(IS_PHOTON "True")
+    endif()
 
     if(IS_REDHAT)
         message(STATUS "Detected RH version ${RH_VERSION}")
+        list(APPEND CPACK_GENERATOR
+            RPM
+        )
+    elseif(IS_PHOTON)
+        message(STATUS "Detected Photon version ${PH_VERSION}")
         list(APPEND CPACK_GENERATOR
             RPM
         )

--- a/deploy/RPM/CMakeLists.txt
+++ b/deploy/RPM/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 # Get information about the environment
 rh_version(RH_VERSION)
+ph_version(PH_VERSION)
 
 # -- Set RPM-specific variables ------------------------------------------------
 
@@ -17,7 +18,9 @@ set(CPACK_RPM_PACKAGE_GROUP "Development/Libraries" PARENT_SCOPE)
 set(CPACK_PACKAGING_INSTALL_PREFIX "/usr/local/madlib/Versions/${MADLIB_VERSION_STRING}" PARENT_SCOPE)
 
 set(_PACKAGE_REQUIRES "m4 >= 1.4")
-if(RH_VERSION AND RH_VERSION VERSION_LESS "6.0")
+if(PH_VERSION)
+    set(CPACK_RPM_PACKAGE_REQUIRES "python >= 2.6, ${_PACKAGE_REQUIRES}" PARENT_SCOPE)
+elseif(RH_VERSION AND RH_VERSION VERSION_LESS "6.0")
     # on RH/CentOS 5, there is no Python 2.6 or higher in the default
     # repositories.
     set(CPACK_RPM_PACKAGE_REQUIRES "python, ${_PACKAGE_REQUIRES}" PARENT_SCOPE)


### PR DESCRIPTION
Build System: Support Photon OS

JIRA: MADLIB-1510
Previously the building system only support Centos and Debian OS.
In order to run MADlib on Photon OS, we need the support to build it
with cmake on Photon OS.

Co-authored-by: Jianwen Dong <djianwen@vmware.com>
Co-authored-by: Gaurab Dey <gaurabd@vmware.com>

- [x] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

