### PR TITLE
SSSP: Fix negative cycle check

### DIFF
--- a/src/ports/postgres/modules/graph/sssp.py_in
+++ b/src/ports/postgres/modules/graph/sssp.py_in
@@ -325,7 +325,10 @@ def graph_sssp(schema_madlib, vertex_table, vertex_id, edge_table,
                     WHERE {vertex_id} IS NOT NULL
                     """.format(**locals()))[0]['count']
 
-            for i in range(0, v_cnt + 1):
+            # The algorithm should converge in less than |V|+1 iterations.
+            # Otherwise there is a negative cycle in the graph.
+            # We check for v_cnt+2 because the first iteration is spent on the setup
+            for i in range(0, v_cnt + 2):
 
                 # Apply the updates calculated in the last iteration.
                 sql = """
@@ -400,9 +403,7 @@ def graph_sssp(schema_madlib, vertex_table, vertex_id, edge_table,
                 newupdate = tmp
 
             plpy.execute("DROP TABLE IF EXISTS {0}".format(newupdate))
-            # The algorithm should converge in less than |V| iterations.
-            # Otherwise there is a negative cycle in the graph.
-            if i == v_cnt:
+            if i == v_cnt+1:
                 if not grouping_cols:
                     plpy.execute("DROP TABLE IF EXISTS {0},{1},{2}".
                                  format(out_table, summary_table, oldupdate))

--- a/src/ports/postgres/modules/graph/test/sssp.sql_in
+++ b/src/ports/postgres/modules/graph/test/sssp.sql_in
@@ -256,3 +256,113 @@ SELECT assert(weight = 3, 'Wrong output in graph (SSSP)')
 	FROM sssp_mult_col_out WHERE id = ARRAY[6,6]::BIGINT[] AND grp1 = 0 AND grp2 = 0;
 SELECT assert(parent = ARRAY[5,5]::BIGINT[], 'Wrong parent in graph (SSSP)')
 	FROM sssp_mult_col_out WHERE id = ARRAY[6,6]::BIGINT[] AND grp1 = 0 AND grp2 = 0;
+
+-- Test where |shortest path| = |V|
+DROP TABLE IF EXISTS out, out_summary;
+CREATE TABLE v(id INT);
+INSERT INTO v VALUES
+  (ascii('s')),
+  (ascii('t')),
+  (ascii('y')),
+  (ascii('x')),
+  (ascii('z'));
+
+CREATE TABLE e(src INT, dest INT, weight float8);
+INSERT INTO e VALUES
+(ascii('t'), ascii('x'), 5),
+(ascii('t'), ascii('y'), 8),
+(ascii('t'), ascii('z'), -4),
+(ascii('x'), ascii('t'), -2),
+(ascii('y'), ascii('x'), -3),
+(ascii('y'), ascii('z'), 9),
+(ascii('z'), ascii('x'), 7),
+(ascii('z'), ascii('s'), 2),
+(ascii('s'), ascii('t'), 6),
+(ascii('s'), ascii('y'), 7);
+
+CREATE TABLE e_grp(src INT, dest INT, weight float8, grp INT);
+INSERT INTO e_grp VALUES
+(ascii('t'), ascii('x'), 5, 1),
+(ascii('t'), ascii('y'), 8, 1),
+(ascii('t'), ascii('z'), -4, 1),
+(ascii('x'), ascii('t'), -2, 1),
+(ascii('y'), ascii('x'), -3, 1),
+(ascii('y'), ascii('z'), 9, 1),
+(ascii('z'), ascii('x'), 7, 1),
+(ascii('z'), ascii('s'), 2, 1),
+(ascii('s'), ascii('t'), 6, 1),
+(ascii('s'), ascii('y'), 7, 1),
+(ascii('t'), ascii('x'), 5, 2),
+(ascii('t'), ascii('y'), 8, 2),
+(ascii('t'), ascii('z'), -4, 2),
+(ascii('x'), ascii('t'), -2, 2),
+(ascii('y'), ascii('x'), -3, 2),
+(ascii('y'), ascii('z'), 9, 2),
+(ascii('z'), ascii('x'), 7, 2),
+(ascii('z'), ascii('s'), 2, 2),
+(ascii('s'), ascii('t'), 6, 2),
+(ascii('s'), ascii('y'), 7, 2);
+
+DROP TABLE IF EXISTS out, out_summary;
+SELECT graph_sssp('v',
+'id',
+'e',
+'src=src,dest=dest,weight=weight',
+ascii('s'),
+'out');
+
+SELECT * FROM out_summary;
+
+DROP TABLE IF EXISTS out, out_summary;
+SELECT graph_sssp('v',
+'id',
+'e_grp',
+'src=src,dest=dest,weight=weight',
+ascii('s'),
+'out',
+'grp');
+
+SELECT * FROM out_summary;
+
+-- Test negative cycle
+DROP TABLE IF EXISTS vertex,"EDGE";
+
+CREATE TABLE vertex(
+                  id INTEGER
+                );
+
+CREATE TABLE "EDGE"(
+                  src INTEGER,
+                  dest INTEGER,
+                  weight DOUBLE PRECISION
+                );
+
+INSERT INTO vertex VALUES
+(0),
+(1),
+(2),
+(3),
+(4),
+(5),
+(6),
+(7)
+;
+INSERT INTO "EDGE" VALUES
+(0, 1, 1),
+(0, 2, 1),
+(0, 4, 10),
+(1, 2, 2),
+(1, 3, 10),
+(2, 3, 1),
+(2, 5, 1),
+(2, 6, 3),
+(3, 0, -999),
+(4, 0, -2),
+(5, 6, 1),
+(6, 7, 1)
+;
+
+DROP TABLE IF EXISTS out, out_summary;
+SELECT assert(trap_error($TRAP$SELECT graph_sssp('vertex',NULL,'"EDGE"',NULL,0,'out');
+$TRAP$) = 1,
+'Graph with negative cycle should error out.');


### PR DESCRIPTION
SSSP checks the iteration counter to identify negative cycles. If a shortest path has the same length as the number of vertices, then the check incorrectly identifies this as a negative cycle. This commit fixes the issue and adds a relevant test.

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [ ] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

