### PR TITLE
Fix compilation failures for gpdb7.

### DIFF
--- a/src/ports/postgres/dbconnector/dbconnector.hpp
+++ b/src/ports/postgres/dbconnector/dbconnector.hpp
@@ -74,6 +74,31 @@ extern "C" {
 #undef dngettext
 #endif
 
+#ifdef vsnprintf
+#undef vsnprintf
+#endif
+#ifdef snprintf
+#undef snprintf
+#endif
+#ifdef vsprintf
+#undef vsprintf
+#endif
+#ifdef sprintf
+#undef sprintf
+#endif
+#ifdef vfprintf
+#undef vfprintf
+#endif
+#ifdef fprintf
+#undef fprintf
+#endif
+#ifdef vprintf
+#undef vprintf
+#endif
+#ifdef printf
+#undef printf
+#endif
+
 // Note: If errors occur in the following include files, it could indicate that
 // new macros have been added to PostgreSQL header files.
 #include <boost/mpl/if.hpp>
@@ -93,6 +118,7 @@ extern "C" {
 #include <stdexcept>
 #include <vector>
 #include <fstream>
+#include <array>
 
 #include <dbal/dbal_proto.hpp>
 #include <utils/Reference.hpp>


### PR DESCRIPTION
This patch fixes 2 compilation errors:

1. Incomplete type: forget to include the header file `<array>`

```
/home/v/workspace/madlib/src/ports/greenplum/dbconnector/../../postgres/dbconnector/Allocator_impl.hpp:78:50: error: 'std::array<long unsigned int, 1> numElements' has incomplete type
   78 |         std::array<std::size_t, BOOST_PP_INC(n)> numElements = {{ \
      |                                                  ^~~~~~~~~~~
```

2. `snprintf` gets expanded to `pg_snprintf` in PostgreSQL/Greenplum.

```
In file included from /home/v/.local/gpdb7/include/postgresql/server/c.h:1330,
                 from /home/v/.local/gpdb7/include/postgresql/server/postgres.h:46,
                 from /home/v/workspace/madlib/src/ports/greenplum/dbconnector/dbconnector.hpp:16:
/usr/include/boost/assert/source_location.hpp: In member function 'std::string boost::source_location::to_string() const':
/usr/include/boost/assert/source_location.hpp:97:9: error: 'pg_snprintf' is not a member of 'std'; did you mean 'vsnprintf'?
   97 |         BOOST_ASSERT_SNPRINTF( buffer, ":%lu", ln );
      |         ^~~~~~~~~~~~~~~~~~~~~
/usr/include/boost/assert/source_location.hpp:104:13: error: 'pg_snprintf' is not a member of 'std'; did you mean 'vsnprintf'?
  104 |             BOOST_ASSERT_SNPRINTF( buffer, ":%lu", co );
      |             ^~~~~~~~~~~~~~~~~~~~~
```

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->


