### PR TITLE
PMML: Add more namespec tests

### DIFF
--- a/src/ports/postgres/modules/pmml/test/pmml.setup.sql_in
+++ b/src/ports/postgres/modules/pmml/test/pmml.setup.sql_in
@@ -76,6 +76,8 @@ CREATE OR REPLACE FUNCTION test_pmml_output(test_table TEXT, madlib_train_table 
     #get madlib pmml output string
     if name_spec == '':
         pmml_query = "SELECT pmml('{}')".format(madlib_train_table)
+    elif 'array' in name_spec.lower():
+        pmml_query = "SELECT pmml('{}',{})".format(madlib_train_table, name_spec)
     else:
         pmml_query = "SELECT pmml('{}','{}')".format(madlib_train_table, name_spec)
     madlib_pmml_str = plpy.execute(pmml_query)[0]["pmml"]

--- a/src/ports/postgres/modules/pmml/test/pmml_glm_with_name_spec.sql_in
+++ b/src/ports/postgres/modules/pmml/test/pmml_glm_with_name_spec.sql_in
@@ -48,6 +48,9 @@ SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binom
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', '','foo1+foo2+foo3+foo4+foo5+foo6+foo7');
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', '','{bar,foo1,foo2,foo3,foo4,foo5,foo6,foo7}');
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', '','{foo1,foo2,foo3,foo4,foo5,foo6,foo7}');
+SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', '','ARRAY[''bar'', ''foo1'',''foo2'',''foo3'',''foo4'',''foo5'',''foo6'',''foo7'']');
+SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', '','ARRAY[''foo1'',''foo2'',''foo3'',''foo4'',''foo5'',''foo6'',''foo7'']');
+
 -- Even if we use explicit "1" in the formula, we will get the correct xml although it won't use the formula provided
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', '','bar ~ 1+foo1+foo2+foo3+foo4+foo5+foo6+foo7');
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', '','1+foo1+foo2+foo3+foo4+foo5+foo6+foo7');
@@ -61,6 +64,9 @@ SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binom
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_rings < 10', '', 'foo1+foo2+foo3+foo4+foo5+foo6+foo7');
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_bar', '', '{bar,foo1,foo2,foo3,foo4,foo5,foo6,foo7}');
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_rings < 10', '', '{foo1,foo2,foo3,foo4,foo5,foo6,foo7}');
+SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_bar', '','ARRAY[''bar'', ''foo1'',''foo2'',''foo3'',''foo4'',''foo5'',''foo6'',''foo7'']');
+SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_rings < 10', '','ARRAY[''foo1'',''foo2'',''foo3'',''foo4'',''foo5'',''foo6'',''foo7'']');
+
 -- Even if we use explicit "1" in the formula, we will get the correct xml although it won't use the formula provided
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_rings < 10', '', 'bar ~ 1+foo1+foo2+foo3+foo4+foo5+foo6+foo7');
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_rings < 10', '', '1+foo1+foo2+foo3+foo4+foo5+foo6+foo7');
@@ -83,6 +89,8 @@ SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binom
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', '','foo1+foo2+foo3+foo4+foo5+foo6+foo7');
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', '','{bar, foo1,foo2,foo3,foo4,foo5,foo6,foo7}');
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', '','{foo1,foo2,foo3,foo4,foo5,foo6,foo7}');
+SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', '','ARRAY[''bar'', ''foo1'',''foo2'',''foo3'',''foo4'',''foo5'',''foo6'',''foo7'']');
+SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', '','ARRAY[''foo1'',''foo2'',''foo3'',''foo4'',''foo5'',''foo6'',''foo7'']');
 
 -- Test output category
 DROP TABLE IF EXISTS glm_predict_binomial_logit_out; CREATE TABLE glm_predict_binomial_logit_out as SELECT id, glm_predict_binomial(coef, ARRAY[length, diameter, height, whole, shucked, viscera, shell], 'logit')
@@ -91,6 +99,8 @@ SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binom
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_rings < 10', '', 'foo1+foo2+foo3+foo4+foo5+foo6+foo7');
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_bar', '', '{bar, foo1,foo2,foo3,foo4,foo5,foo6,foo7}');
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_rings < 10', '', '{foo1,foo2,foo3,foo4,foo5,foo6,foo7}');
+SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_bar', '','ARRAY[''bar'', ''foo1'',''foo2'',''foo3'',''foo4'',''foo5'',''foo6'',''foo7'']');
+SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_rings < 10', '','ARRAY[''foo1'',''foo2'',''foo3'',''foo4'',''foo5'',''foo6'',''foo7'']');
 
 
 ---------------------------- with grouping -----------------------------------------
@@ -110,6 +120,8 @@ SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binom
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', 'sex','foo1+foo2+foo3+foo4+foo5+foo6+foo7');
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', 'sex','{bar, foo1,foo2,foo3,foo4,foo5,foo6,foo7}');
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', 'sex','{foo1,foo2,foo3,foo4,foo5,foo6,foo7}');
+SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', 'sex','ARRAY[''bar'', ''foo1'',''foo2'',''foo3'',''foo4'',''foo5'',''foo6'',''foo7'']');
+SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', 'sex','ARRAY[''foo1'',''foo2'',''foo3'',''foo4'',''foo5'',''foo6'',''foo7'']');
 
 -- Test output category
 DROP TABLE IF EXISTS glm_predict_binomial_logit_out; CREATE TABLE glm_predict_binomial_logit_out as SELECT id, glm_model.sex, glm_predict_binomial(coef, ARRAY[1, length, diameter, height, whole, shucked, viscera, shell], 'logit')
@@ -118,6 +130,8 @@ SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binom
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_id > 2000', 'sex', 'foo1+foo2+foo3+foo4+foo5+foo6+foo7');
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_bar', 'sex', '{bar, foo1,foo2,foo3,foo4,foo5,foo6,foo7}');
 SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_id > 2000', 'sex', '{foo1,foo2,foo3,foo4,foo5,foo6,foo7}');
+SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_id > 2000', 'sex', 'ARRAY[''foo1'',''foo2'',''foo3'',''foo4'',''foo5'',''foo6'',''foo7'']');
+SELECT test_pmml_output('abalone_test_for_pmml', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_bar', 'sex', 'ARRAY[''bar'', ''foo1'',''foo2'',''foo3'',''foo4'',''foo5'',''foo6'',''foo7'']');
 
 
 ----------------------- with grouping and incorrect feature length in name spec -------------------------
@@ -140,12 +154,14 @@ SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out'
 SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', 'sex','foo1+foo2+foo3+foo4+foo5+foo6');
 SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', 'sex','{foo1,foo2,foo3,foo4,foo5,foo6}');
 SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', 'sex','{bar,foo1,foo2,foo3,foo4,foo5,foo6,foo7,foo8}');
+SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', 'sex','ARRAY[''bar'', ''foo1'',''foo2'',''foo3'',''foo4'',''foo5'',''foo6'',''foo7'',''foo8'']');
 
 DROP TABLE IF EXISTS glm_predict_binomial_logit_out; CREATE TABLE glm_predict_binomial_logit_out as SELECT id, glm_model.sex, glm_predict_binomial(coef, ARRAY[1, length, diameter, height, whole, shucked, viscera, shell], 'logit')
 FROM glm_model, abalone WHERE abalone.sex=glm_model.sex;
 SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_id > 2000', 'sex','foo1+foo2+foo3+foo4+foo5+foo6');
 SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_id > 2000', 'sex','{foo1,foo2,foo3,foo4,foo5,foo6}');
 SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_id > 2000', 'sex','{bar,foo1,foo2,foo3,foo4,foo5,foo6,foo7,foo8}');
+SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_id > 2000', 'sex','ARRAY[''bar'', ''foo1'',''foo2'',''foo3'',''foo4'',''foo5'',''foo6'',''foo7'',''foo8'']');
 
 DROP TABLE IF EXISTS glm_model, glm_model_summary;
 SELECT glm(
@@ -163,10 +179,12 @@ SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out'
 SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', 'sex','foo1+foo2+foo3+foo4+foo5+foo6');
 SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', 'sex','{foo1,foo2,foo3,foo4,foo5,foo6}');
 SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', 'sex','{bar,foo1,foo2,foo3,foo4,foo5,foo6,foo7,foo8}');
+SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict', 'probability_true', 'sex','ARRAY[''bar'', ''foo1'',''foo2'',''foo3'',''foo4'',''foo5'',''foo6'',''foo7'',''foo8'']');
 
 DROP TABLE IF EXISTS glm_predict_binomial_logit_out; CREATE TABLE glm_predict_binomial_logit_out as SELECT id, glm_model.sex, glm_predict_binomial(coef, ARRAY[length, diameter, height, whole, shucked, viscera, shell], 'logit')
 FROM glm_model, abalone WHERE abalone.sex=glm_model.sex;
 SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_id > 2000', 'sex','foo1+foo2+foo3+foo4+foo5+foo6');
 SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_id > 2000', 'sex','{foo1,foo2,foo3,foo4,foo5,foo6}');
 SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_id > 2000', 'sex','{bar,foo1,foo2,foo3,foo4,foo5,foo6,foo7,foo8}');
+SELECT test_pmml_output('abalone', 'glm_model', 'glm_predict_binomial_logit_out', 'id', 'glm_predict_binomial', 'predicted_id > 2000', 'sex','ARRAY[''bar'', ''foo1'',''foo2'',''foo3'',''foo4'',''foo5'',''foo6'',''foo7'',''foo8'']');
 


### PR DESCRIPTION
This PR adds a bit more coverage to the pmml tests by testing the pmml function with an ARRAY namespec instead of just text/string namespec formulaes