### PR TITLE
Update copyright year in NOTICE to 2025

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache MADlib
-Copyright 2016-2024 The Apache Software Foundation.
+Copyright 2016-2025 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
CI is failing check which validates the NOTICE file year.