### PR TITLE
Fix CMake warning by reordering commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@
 # MADlib CMake Build Script
 # ------------------------------------------------------------------------------
 
+# FindPostgreSQL.cmake needs at least 2.8.3. We are on the safe side and require
+# the minimum version tested, which is 2.8.4.
+cmake_minimum_required(VERSION 2.8.4 FATAL_ERROR)
+
 # -- Initializations that need to run even before project()
 
 # For Solaris, we want to use the Sun compiler
@@ -12,10 +16,6 @@ set(CMAKE_GENERATOR_CXX sunCC g++)
 # -- CMake setup ---------------------------------------------------------------
 
 project(MADlib)
-
-# FindPostgreSQL.cmake needs at least 2.8.3. We are on the safe side and require
-# the minimum version tested, which is 2.8.4.
-cmake_minimum_required(VERSION 2.8.4 FATAL_ERROR)
 
 include(ExternalProject)
 include(CheckCXXCompilerFlag)


### PR DESCRIPTION
Moved cmake_minimum_required() before project() in CMakeLists.txt to resolve the CMake dev warning. This follows CMake best practices where cmake_minimum_required() should be called before project().

Reference: Warn when running `cmake ..`:
```
[gpadmin@cdw build]$ cmake ..
CMake Warning (dev) at CMakeLists.txt:14 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [ ] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

