### PR TITLE
Docker: update baseos to Ubuntu 22.04

### DIFF
--- a/tool/docker/base/Dockerfile_postgres_15_Jenkins
+++ b/tool/docker/base/Dockerfile_postgres_15_Jenkins
@@ -16,19 +16,31 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM gcr.io/data-gpdb-public-images/gpdb7-ubuntu20.04-test
+FROM ubuntu:22.04
+
+# Argument for configuring the timezone
+ARG TIMEZONE_VAR="Europe/London"
+ENV TZ=${TIMEZONE_VAR}
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Set the LOCALE
+ENV LANG=en_US.UTF-8
+RUN apt-get update && apt-get install -y locales && \
+                        locale-gen en_US.UTF-8 && \
+                        update-locale LANG=en_US.UTF-8 && \
+                        apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ### Get postgres specific add-ons
-RUN apt-get update && apt-get install -y  wget \
+RUN apt-get update && apt-get install -y wget \
                         build-essential \
                         openssl \
                         libssl-dev \
+                        lsb-release \
                         libboost-all-dev \
                         m4 \
                         rpm \
                         python3-pip \
                         python3-dev \
-                        build-essential \
                         cmake \
                         libspatialindex-dev \
                         vim \
@@ -41,11 +53,11 @@ RUN apt-get update && apt-get install -y  wget \
                         iputils-ping \
                         iproute2 \
                         net-tools \
-                        libspatialindex-dev \
-                        ca-certificates
+                        ca-certificates && \
+                        apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN add-apt-repository -y ppa:deadsnakes/ppa
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 RUN apt-get update && apt-get install -y \
@@ -53,7 +65,8 @@ RUN apt-get update && apt-get install -y \
                         postgresql-plpython3-15 \
                         postgresql-15 \
                         postgresql-client-15 \
-                        libpq-dev
+                        libpq-dev && \
+                        apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install dill rtree xgboost mock pandas numpy scikit-learn pyxb-x
 


### PR DESCRIPTION
This PR is used to update the base Docker image for better reusability.

Main changes:
- Update the base os image to official Ubuntu 22.04, the old one `gcr.io/data-gpdb-public-images/gpdb7-ubuntu20.04-test` is not available anymore.
- Update the base os from Ubuntu 20.04 to 22.04 since Ubuntu 20.04 has ended life. This change will allow us to install the newer PostgreSQL, or else you will encounter the error as follows:

  ``` E: The repository 'http://apt.postgresql.org/pub/repos/apt focal-pgdg Release' does not have a Release file. ```

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [ ] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

