### PR TITLE
Add PostgreSQL 16/17/18 support

### DIFF
--- a/methods/array_ops/src/pg_gp/array_ops.c
+++ b/methods/array_ops/src/pg_gp/array_ops.c
@@ -13,6 +13,9 @@
 #else
 #include "utils/int8.h"
 #endif
+#if PG_VERSION_NUM >= 160000
+#include <varatt.h>
+#endif
 #include "utils/datum.h"
 #include "utils/lsyscache.h"
 #include "utils/typcache.h"

--- a/methods/kmeans/src/pg_gp/kmeans.c
+++ b/methods/kmeans/src/pg_gp/kmeans.c
@@ -5,6 +5,9 @@
 #else
 #include <utils/builtins.h>
 #endif
+#if PG_VERSION_NUM >= 160000
+#include <varatt.h>
+#endif
 #include <utils/memutils.h>
 #include <math.h>
 #include "../../../svec/src/pg_gp/sparse_vector.h"

--- a/methods/sketch/src/pg_gp/countmin.c
+++ b/methods/sketch/src/pg_gp/countmin.c
@@ -35,6 +35,9 @@
 #include <nodes/execnodes.h>
 #include <fmgr.h>
 #include <catalog/pg_type.h>
+#if PG_VERSION_NUM >= 160000
+#include <varatt.h>
+#endif
 #include <ctype.h>
 #include "sketch_support.h"
 #include "countmin.h"

--- a/methods/sketch/src/pg_gp/fm.c
+++ b/methods/sketch/src/pg_gp/fm.c
@@ -38,6 +38,9 @@
 #else
 #include <libpq/md5.h>
 #endif
+#if PG_VERSION_NUM >= 160000
+#include <varatt.h>
+#endif
 #include <nodes/execnodes.h>
 #include <fmgr.h>
 #include <ctype.h>
@@ -592,7 +595,7 @@ bytea *fmsketch_sortasort_insert(bytea *transblob, Datum dat, size_t len)
     sortasort *s_in =
         (sortasort *)(transval->storage);
     bytea *    newblob;
-    bool       success = false;
+    int        success = 0;
     size_t     new_storage_sz;
     size_t     newsize;
 

--- a/methods/sketch/src/pg_gp/mfvsketch.c
+++ b/methods/sketch/src/pg_gp/mfvsketch.c
@@ -33,6 +33,9 @@
 #include <utils/elog.h>
 #include <utils/builtins.h>
 #include <utils/lsyscache.h>
+#if PG_VERSION_NUM >= 160000
+#include <varatt.h>
+#endif
 #include <utils/numeric.h>
 #include <utils/typcache.h>
 #include <utils/datum.h>

--- a/methods/sketch/src/pg_gp/sketch_support.c
+++ b/methods/sketch/src/pg_gp/sketch_support.c
@@ -47,6 +47,9 @@
 #else
 #include <libpq/md5.h>
 #endif
+#if PG_VERSION_NUM >= 160000
+#include <varatt.h>
+#endif
 #include <utils/lsyscache.h>
 #include "sketch_support.h"
 

--- a/methods/svec/src/pg_gp/sparse_vector.c
+++ b/methods/svec/src/pg_gp/sparse_vector.c
@@ -25,6 +25,9 @@
 #include "utils/fmgroids.h"
 #include "lib/stringinfo.h"
 #include "utils/memutils.h"
+#if PG_VERSION_NUM >= 160000
+#include <varatt.h>
+#endif
 #include "sparse_vector.h"
 
 /**

--- a/src/ports/postgres/16/CMakeLists.txt
+++ b/src/ports/postgres/16/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ------------------------------------------------------------------------------
+
+add_current_postgresql_version()
+add_extension_support()

--- a/src/ports/postgres/17/CMakeLists.txt
+++ b/src/ports/postgres/17/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ------------------------------------------------------------------------------
+
+add_current_postgresql_version()
+add_extension_support()

--- a/src/ports/postgres/18/CMakeLists.txt
+++ b/src/ports/postgres/18/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ------------------------------------------------------------------------------
+
+add_current_postgresql_version()
+add_extension_support()

--- a/src/ports/postgres/cmake/FindPostgreSQL_16.cmake
+++ b/src/ports/postgres/cmake/FindPostgreSQL_16.cmake
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ------------------------------------------------------------------------------
+
+set(_FIND_PACKAGE_FILE "${CMAKE_CURRENT_LIST_FILE}")
+include("${CMAKE_CURRENT_LIST_DIR}/FindPostgreSQL.cmake")

--- a/src/ports/postgres/cmake/FindPostgreSQL_17.cmake
+++ b/src/ports/postgres/cmake/FindPostgreSQL_17.cmake
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ------------------------------------------------------------------------------
+
+set(_FIND_PACKAGE_FILE "${CMAKE_CURRENT_LIST_FILE}")
+include("${CMAKE_CURRENT_LIST_DIR}/FindPostgreSQL.cmake")

--- a/src/ports/postgres/cmake/FindPostgreSQL_18.cmake
+++ b/src/ports/postgres/cmake/FindPostgreSQL_18.cmake
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ------------------------------------------------------------------------------
+
+set(_FIND_PACKAGE_FILE "${CMAKE_CURRENT_LIST_FILE}")
+include("${CMAKE_CURRENT_LIST_DIR}/FindPostgreSQL.cmake")

--- a/src/ports/postgres/dbconnector/Backend.hpp
+++ b/src/ports/postgres/dbconnector/Backend.hpp
@@ -19,9 +19,20 @@ namespace {
 MADLIB_WRAP_PG_FUNC(
     bool, type_is_array, (Oid typid), (typid))
 
+// PostgreSQL 16+ replaced pg_proc_aclcheck with object_aclcheck
+#if PG_VERSION_NUM >= 160000
+MADLIB_WRAP_PG_FUNC(
+    AclResult, object_aclcheck, (Oid classid, Oid objectid, Oid roleid, AclMode mode),
+    (classid, objectid, roleid, mode))
+
+inline AclResult madlib_pg_proc_aclcheck(Oid proc_oid, Oid roleid, AclMode mode) {
+    return madlib_object_aclcheck(ProcedureRelationId, proc_oid, roleid, mode);
+}
+#else
 MADLIB_WRAP_PG_FUNC(
     AclResult, pg_proc_aclcheck, (Oid proc_oid, Oid roleid, AclMode mode),
     (proc_oid, roleid, mode))
+#endif
 
 MADLIB_WRAP_PG_FUNC(
     void*, MemoryContextAlloc, (MemoryContext context, Size size),

--- a/src/ports/postgres/dbconnector/Compatibility.hpp
+++ b/src/ports/postgres/dbconnector/Compatibility.hpp
@@ -14,6 +14,12 @@ extern "C" {
     #if PG_VERSION_NUM >= 90300
         #include <access/htup_details.h>
     #endif
+
+    // PostgreSQL 16+ compatibility
+    #if PG_VERSION_NUM >= 160000
+        #include <varatt.h>
+        #include <catalog/pg_proc.h>
+    #endif
 }
 
 

--- a/tool/docker/base/Dockerfile_postgres_16_Jenkins
+++ b/tool/docker/base/Dockerfile_postgres_16_Jenkins
@@ -61,14 +61,14 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg m
 
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 RUN apt-get update && apt-get install -y \
-                        postgresql-server-dev-15 \
-                        postgresql-plpython3-15 \
-                        postgresql-15 \
-                        postgresql-client-15 \
+                        postgresql-server-dev-16 \
+                        postgresql-plpython3-16 \
+                        postgresql-16 \
+                        postgresql-client-16 \
                         libpq-dev && \
                         apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN python3 -m pip install dill rtree xgboost mock pandas numpy scikit-learn pyxb-x
 
 ## To build an image from this docker file, from madlib folder, run:
-# docker build -t madlib/postgres_15:jenkins -f tool/docker/base/Dockerfile_postgres_15_Jenkins .
+# docker build -t madlib/postgres_16:jenkins -f tool/docker/base/Dockerfile_postgres_16_Jenkins .

--- a/tool/docker/base/Dockerfile_postgres_17_Jenkins
+++ b/tool/docker/base/Dockerfile_postgres_17_Jenkins
@@ -61,14 +61,14 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg m
 
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 RUN apt-get update && apt-get install -y \
-                        postgresql-server-dev-15 \
-                        postgresql-plpython3-15 \
-                        postgresql-15 \
-                        postgresql-client-15 \
+                        postgresql-server-dev-17 \
+                        postgresql-plpython3-17 \
+                        postgresql-17 \
+                        postgresql-client-17 \
                         libpq-dev && \
                         apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN python3 -m pip install dill rtree xgboost mock pandas numpy scikit-learn pyxb-x
 
 ## To build an image from this docker file, from madlib folder, run:
-# docker build -t madlib/postgres_15:jenkins -f tool/docker/base/Dockerfile_postgres_15_Jenkins .
+# docker build -t madlib/postgres_17:jenkins -f tool/docker/base/Dockerfile_postgres_17_Jenkins .


### PR DESCRIPTION
Build system:
- Add CMakeLists.txt for PG 16/17/18 ports
- Add FindPostgreSQL cmake modules for PG 16/17/18

API compatibility fixes for PG 16+:
- Include varatt.h for VARSIZE/VARDATA macros (required since PG 16)
- Replace pg_proc_aclcheck() with object_aclcheck() in Backend.hpp

Bug fix:
- Fix -Wbool-compare warning in fm.c: change 'success' from bool to int since sortasort_try_insert() returns -1/0/1

Docker:
- Add Dockerfile for PostgreSQL 16 and 17 Jenkins builds
- Update Dockerfile_postgres_15_Jenkins

<!--  

Thanks for sending a pull request!  Here are some tips for you:
1. Refer to this link for contribution guidelines https://cwiki.apache.org/confluence/display/MADLIB/Contribution+Guidelines
2. Please Provide the Module Name, a JIRA Number and a short description about your changes.
-->

- [ ] Add the module name, JIRA# to PR/commit and description.
- [ ] Add tests for the change. 

